### PR TITLE
Use background context instead context with timeout

### DIFF
--- a/prototypes/go/app/listener/listener.go
+++ b/prototypes/go/app/listener/listener.go
@@ -54,13 +54,12 @@ func RunListener() {
 
 	var msg Message // struct to parse Kafka message into
 	var host structures.HostDAO // struct to store parsed msg from Kafka
-	ctx, _ := context.WithTimeout(context.Background(), time.Second * 5)
 
 	// Benchmark
 	benchmark := InitBenchmark(benchmarkMessages, storage)
 
 	for {
-		m, err := kafkaReader.ReadMessage(ctx)
+		m, err := kafkaReader.ReadMessage(context.Background())
 		if err != nil {
 			if err.Error() == "context deadline exceeded" {
 				utils.Log().Info("waiting for messages")


### PR DESCRIPTION
Using context with timeout for reading messages caused program to slow down heavily with increasing number of messages
**Before**
> {
  "timestamp": "2019-11-08T15:45:01Z",
  **"duration": 659.337115,**
  "items": 1000,
  "levelname": "info",
  "message": "batch finished",
  **"write/sec": 1.5166748196785493**
}


**After**
> {
  "timestamp": "2019-11-08T15:27:16Z",
  **"duration": 19.86282347,**
  "items": 1000,
  "levelname": "info",
  "message": "batch finished",
  **"write/sec": 50.34530974462716**
}