### PR TITLE
Set up Prometheus metrics

### DIFF
--- a/dev/scripts/metrics.sh
+++ b/dev/scripts/metrics.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -v -XGET http://localhost:8080/metrics

--- a/dev/scripts/systems_applicable.sh
+++ b/dev/scripts/systems_applicable.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl -v -XGET http://localhost:8080/api/patch/v1/advisories/$1/applicable_systems | python -m json.tool
+curl -v -XGET http://localhost:8080/api/patch/v1/advisories/$1/systems | python -m json.tool

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -6,8 +6,6 @@ import (
 	"app/manager/routes"
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
-	"github.com/zsais/go-gin-prometheus"
-
 	swaggerFiles "github.com/swaggo/files"
 	"github.com/swaggo/gin-swagger"
 
@@ -21,8 +19,7 @@ func RunManager() {
 	app := gin.New()
 
 	// middlewares
-	prometheus := ginprometheus.NewPrometheus("gin")
-	prometheus.Use(app)
+	middlewares.Prometheus().Use(app)
 	app.Use(middlewares.RequestResponseLogger())
 	app.Use(gzip.Gzip(gzip.DefaultCompression))
 	app.HandleMethodNotAllowed = true

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -6,10 +6,6 @@ import (
 	"app/manager/routes"
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
-	swaggerFiles "github.com/swaggo/files"
-	"github.com/swaggo/gin-swagger"
-
-	_ "app/docs"
 )
 
 
@@ -22,10 +18,8 @@ func RunManager() {
 	middlewares.Prometheus().Use(app)
 	app.Use(middlewares.RequestResponseLogger())
 	app.Use(gzip.Gzip(gzip.DefaultCompression))
+	middlewares.SetSwagger(app)
 	app.HandleMethodNotAllowed = true
-
-	url := ginSwagger.URL("http://localhost:8080/swagger/doc.json") // The url pointing to API definition
-	app.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
 
 	// routes
 	routes.Init(app)

--- a/manager/middlewares/prometheus.go
+++ b/manager/middlewares/prometheus.go
@@ -1,9 +1,24 @@
 package middlewares
 
-import ginprometheus "github.com/zsais/go-gin-prometheus"
+import (
+	"github.com/gin-gonic/gin"
+	ginprometheus "github.com/zsais/go-gin-prometheus"
+	"strings"
+)
 
 // Create and configure Prometheus middleware to expose metrics
 func Prometheus() *ginprometheus.Prometheus{
 	prometheus := ginprometheus.NewPrometheus("patchman_engine")
+	unifyParametrizedUrlsCounters(prometheus)
 	return prometheus
+}
+
+func unifyParametrizedUrlsCounters(p *ginprometheus.Prometheus) {
+	p.ReqCntURLLabelMappingFn = func(c *gin.Context) string {
+		url := c.Request.URL.Path
+		for _, p := range c.Params {
+			url = strings.Replace(url, "/" + p.Value, "/:" + p.Key, 1)
+		}
+		return url
+	}
 }

--- a/manager/middlewares/prometheus.go
+++ b/manager/middlewares/prometheus.go
@@ -1,0 +1,9 @@
+package middlewares
+
+import ginprometheus "github.com/zsais/go-gin-prometheus"
+
+// Create and configure Prometheus middleware to expose metrics
+func Prometheus() *ginprometheus.Prometheus{
+	prometheus := ginprometheus.NewPrometheus("patchman_engine")
+	return prometheus
+}

--- a/manager/middlewares/swagger.go
+++ b/manager/middlewares/swagger.go
@@ -1,0 +1,16 @@
+package middlewares
+
+import (
+	"github.com/gin-gonic/gin"
+
+	ginSwagger "github.com/swaggo/gin-swagger"
+
+	swaggerFiles "github.com/swaggo/files"
+
+	_ "app/docs"
+)
+
+func SetSwagger(app *gin.Engine) {
+	url := ginSwagger.URL("http://localhost:8080/swagger/doc.json") // The url pointing to API definition
+	app.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
+}


### PR DESCRIPTION
SPM-28
- added `patchman_engine` prefix to metric names
- unified parametrized endpoints counters
- Prometheus and Swagger setup moved to middlewares package