### PR TITLE
Improve build times by pre-downloading dependencies in module mode

### DIFF
--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -7,18 +7,18 @@ ENV GO111MODULE=on
 ADD go.mod  /go/src/app/
 ADD go.sum  /go/src/app/
 
+RUN adduser --gid 0 -d /go --no-create-home insights
+RUN chown -R insights:0 /go
+USER insights
+
 WORKDIR /go/src/app
-RUN go mod vendor
+RUN go mod download
 
 ADD /base       /go/src/app/base
 ADD /manager    /go/src/app/manager
 ADD /listener   /go/src/app/listener
 ADD /docs       /go/src/app/docs
 ADD main.go     /go/src/app/
-
-RUN adduser --gid 0 -d /go --no-create-home insights
-RUN chown -R insights:0 /go
-USER insights
 
 ADD /scripts/*.sh /go/src/app/
 

--- a/Dockerfile.rhel8
+++ b/Dockerfile.rhel8
@@ -7,18 +7,18 @@ ENV GO111MODULE=on
 ADD go.mod  /go/src/app/
 ADD go.sum  /go/src/app/
 
+RUN adduser --gid 0 -d /go --no-create-home insights
+RUN chown -R insights:0 /go
+USER insights
+
 WORKDIR /go/src/app
-RUN go mod vendor
+RUN go mod download
 
 ADD /base       /go/src/app/base
 ADD /manager    /go/src/app/manager
 ADD /listener   /go/src/app/listener
 ADD /docs       /go/src/app/docs
 ADD main.go     /go/src/app/
-
-RUN adduser --gid 0 -d /go --no-create-home insights
-RUN chown -R insights:0 /go
-USER insights
 
 ADD /scripts/*.sh /go/src/app/
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -9,7 +9,7 @@ ADD go.mod  /go/src/app/
 ADD go.sum  /go/src/app/
 
 WORKDIR /go/src/app
-RUN go mod vendor
+RUN go mod download
 
 ADD /base       /go/src/app/base
 ADD /manager    /go/src/app/manager


### PR DESCRIPTION
The `go vendor` created directory was not used by the build, forcing double downloading of dependencies.