### PR TITLE
Database refactoring

### DIFF
--- a/base/models/models.go
+++ b/base/models/models.go
@@ -12,93 +12,80 @@ func (RhAccount) TableName() string {
 }
 
 type SystemPlatform struct {
-	ID               int
-	InventoryID      string
-	RhAccountID      int
-	FirstReported    time.Time
-	S3Url            string
-	VmaasJson        string
-	JsonChecksum     string
-	LastUpdated      time.Time
-	UnchangedSince   time.Time
-	LastEvaluation   *time.Time
-	OptOut           bool
-	ErrataCountCache int
-	LastUpload       *time.Time
+	ID                 int
+	InventoryID        string
+	RhAccountID        int
+	FirstReported      time.Time
+	VmaasJSON          string
+	JsonChecksum       string
+	LastUpdated        time.Time
+	UnchangedSince     time.Time
+	LastEvaluation     *time.Time
+	OptOut             bool
+	AdvisoryCountCache int
+	LastUpload         *time.Time
 }
 
 func (SystemPlatform) TableName() string {
 	return "system_platform"
 }
 
-type ErrataMetaData struct {
-	ID           int
-	Advisory     string
-	AdvisoryName string
-	Description  string
-	Synopsis     string
-	Topic        string
-	Solution     string
-	ErrataTypeId int
-	PublicDate   time.Time
-	ModifiedDate time.Time
-	Url          *string
+type AdvisoryMetadata struct {
+	ID             int
+	Name           string
+	Description    string
+	Synopsis       string
+	Topic          string
+	Solution       string
+	AdvisoryTypeId int
+	PublicDate     time.Time
+	ModifiedDate   time.Time
+	Url            *string
 }
 
-func (ErrataMetaData) TableName() string {
-	return "errata_metadata"
+func (AdvisoryMetadata) TableName() string {
+	return "advisory_metadata"
 }
 
 type SystemAdvisories struct {
 	ID            int
 	SystemID      int
-	ErrataID      int
+	AdvisoryID    int
 	FirstReported time.Time
 	WhenPatched   *time.Time
 	StatusId      *int
 	StatusText    *string
 }
 
-
 func (SystemAdvisories) TableName() string {
 	return "system_advisories"
 }
 
-
-type ErrataAccountData struct {
-	ErrataID    int
+type AdvisoryAccountData struct {
+	AdvisoryID  int
 	RhAccountID int
 }
 
-
-func (ErrataAccountData) TableName() string {
-	return "errata_account_data"
+func (AdvisoryAccountData) TableName() string {
+	return "advisory_account_data"
 }
-
 
 type Repo struct {
 	ID   int
 	Name string
 }
 
-
 func (Repo) TableName() string {
 	return "repo"
 }
 
-
 type SystemRepo struct {
-	SystemID int
-	RepoId   int
-	StatusID int
+	SystemID   int
+	RepoId     int
+	StatusID   int
 	StatusText *string
-
 }
-
 
 func (SystemRepo) TableName() string {
 	return "system_repo"
 }
-
-
-

--- a/database/schema/create_schema.sql
+++ b/database/schema/create_schema.sql
@@ -165,7 +165,7 @@ CREATE OR REPLACE FUNCTION refresh_all_cached_counts()
   RETURNS void AS
 $refresh_all_cached_counts$
   BEGIN
-    -- update adviosrt count for ordered systems
+    -- update advisories count for ordered systems
     WITH to_update_systems AS (
       SELECT sp.id
       FROM system_platform sp

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -15,8 +15,8 @@
     "paths": {
         "/api/patch/v1/advisories": {
             "get": {
-                "summary": "Show me all applicable errata for all my systems",
-                "description": "Show me all applicable errata for all my systems",
+                "summary": "Show me all applicable advisories for all my systems",
+                "description": "Show me all applicable advisories for all my systems",
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/manager/controllers/advisories.go
+++ b/manager/controllers/advisories.go
@@ -12,8 +12,8 @@ type AdvisoriesResponse struct {
 	Meta  AdvisoryMeta   `json:"meta"`
 }
 
-// @Summary Show me all applicable errata for all my systems
-// @Description Show me all applicable errata for all my systems
+// @Summary Show me all applicable advisories for all my systems
+// @Description Show me all applicable advisories for all my systems
 // @Security RhIdentity
 // @Accept   json
 // @Produce  json

--- a/manager/controllers/advisory_detail.go
+++ b/manager/controllers/advisory_detail.go
@@ -47,7 +47,7 @@ func AdvisoryDetailHandler(c *gin.Context) {
 				PublicDate: time.Now(),
 				Topic: "A new kpatch-patch-4_18_0-147_0_3 package is now available for Red Hat Enterprise Linux 8.",
 				Synopsis: "new package: kpatch-patch-4_18_0-147_0_3",
-				Solution: "Before applying this update, make sure all previously released errata relevant to your system " +
+				Solution: "Before applying this update, make sure all previously released advisories relevant to your system " +
 					"have been applied.",
 				Fixes: nil,
 				Cves: []string{},

--- a/manager/controllers/systems.go
+++ b/manager/controllers/systems.go
@@ -40,7 +40,7 @@ func SystemsListHandler(c *gin.Context) {
 		LogAndRespBadRequest(c, err, err.Error())
 		return
 	}
-	
+
 	var total int
 	err = database.Db.Model(models.SystemPlatform{}).Count(&total).Error
 	if err != nil {
@@ -65,7 +65,7 @@ func SystemsListHandler(c *gin.Context) {
 		"&data_format=json")
 	meta := buildMeta(limit, offset, total)
 	var resp = SystemsResponse{
-		Data: *data,
+		Data:  *data,
 		Links: links,
 		Meta:  *meta,
 	}
@@ -73,7 +73,7 @@ func SystemsListHandler(c *gin.Context) {
 	return
 }
 
-func buildMeta(limit, offset, total int) *SystemsMeta{
+func buildMeta(limit, offset, total int) *SystemsMeta {
 	meta := SystemsMeta{
 		DataFormat: "json",
 		Filter:     nil,
@@ -96,12 +96,12 @@ func buildData(systems *[]models.SystemPlatform) *[]SystemItem {
 			Attributes: SystemItemAttributes{
 				LastEvaluation: system.LastEvaluation,
 				LastUpload:     system.LastUpload,
-				RhsaCount:      system.ErrataCountCache,
+				RhsaCount:      0,
 				RhbaCount:      0,
 				RheaCount:      0,
 				Enabled:        !system.OptOut,
 			},
-			Id: system.InventoryID,
+			Id:   system.InventoryID,
 			Type: "system",
 		}
 	}

--- a/scripts/test_data.sql
+++ b/scripts/test_data.sql
@@ -4,27 +4,27 @@ DELETE FROM timestamp_kv;
 INSERT INTO rh_account (id, name) VALUES
 (0, '0'), (1, '1'), (2, '2'), (3, '3');
 
-INSERT INTO system_platform (id, inventory_id, rh_account_id, s3_url, vmaas_json, json_checksum, last_upload) VALUES
-(0, 'INV-0', 0, 'https://s3/1', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04'),
-(1, 'INV-1', 0, 'https://s3/2', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04'),
-(2, 'INV-2', 0, 'https://s3/3', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04');
+INSERT INTO system_platform (id, inventory_id, rh_account_id,  vmaas_json, json_checksum, last_upload) VALUES
+(0, 'INV-0', 0, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04'),
+(1, 'INV-1', 0, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04'),
+(2, 'INV-2', 0, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04');
 
-INSERT INTO system_platform (id, inventory_id, rh_account_id, s3_url, vmaas_json, json_checksum, last_evaluation, last_upload) VALUES
-(3, 'INV-3', 0, 'https://s3/4', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
-(4, 'INV-4', 0, 'https://s3/5', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
-(5, 'INV-5', 0, 'https://s3/6', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04');
+INSERT INTO system_platform (id, inventory_id, rh_account_id,  vmaas_json, json_checksum, last_evaluation, last_upload) VALUES
+(3, 'INV-3', 0,  '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
+(4, 'INV-4', 0, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
+(5, 'INV-5', 0, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04');
 
-INSERT INTO system_platform (id, inventory_id, rh_account_id, s3_url, vmaas_json, json_checksum, first_reported, last_updated, unchanged_since, last_upload) VALUES
-(6, 'INV-6', 0, 'https://s3/7', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2017-12-31 08:22:33-04', '2018-10-04 14:13:12-04', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04');
+INSERT INTO system_platform (id, inventory_id, rh_account_id,  vmaas_json, json_checksum, first_reported, last_updated, unchanged_since, last_upload) VALUES
+(6, 'INV-6', 0, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2017-12-31 08:22:33-04', '2018-10-04 14:13:12-04', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04');
 
-INSERT INTO system_platform (id, inventory_id, rh_account_id, s3_url, vmaas_json, json_checksum, last_evaluation, last_upload) VALUES
-(7, 'INV-7', 0, 'https://s3/7', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04');
+INSERT INTO system_platform (id, inventory_id, rh_account_id,  vmaas_json, json_checksum, last_evaluation, last_upload) VALUES
+(7, 'INV-7', 0, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04');
 
-INSERT INTO system_platform (id, inventory_id, rh_account_id, s3_url, vmaas_json, json_checksum, last_evaluation, last_upload) VALUES
-(8, 'INV-8', 1, 'https://s3/8', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
-(9, 'INV-9', 1, 'https://s3/9', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
-(10, 'INV-10', 1, 'https://s3/10', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
-(11, 'INV-11', 2, 'https://s3/11', '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04');
+INSERT INTO system_platform (id, inventory_id, rh_account_id,  vmaas_json, json_checksum, last_evaluation, last_upload) VALUES
+(8, 'INV-8', 1, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
+(9, 'INV-9', 1, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
+(10, 'INV-10', 1, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04'),
+(11, 'INV-11', 2, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04');
 
 -- TODO add advasories_metadata, system_advasories, adv. account metadata
 


### PR DESCRIPTION
- Rename all occurences of `errata` to `advisory`, to correspond with frontend and API nomenclature
- Change `advisory_type` names to correspond to the ones we receive from VMaaS
- Remove `s3_url` from hosts, since we don't download archives.