### PR TITLE
Sync advisories from VMaaS

### DIFF
--- a/base/base.go
+++ b/base/base.go
@@ -1,0 +1,6 @@
+package base
+
+const INVENTORY_API_PREFIX = "/api/inventory/v1"
+const VMAAS_API_PREFIX = "/api"
+// Go datetime parser does not like slightly incorrect RFC 3339 which we are using (missing Z )
+const RFC_3339_NO_TZ = "2006-01-02T15:04:05-07:00"

--- a/base/models/models.go
+++ b/base/models/models.go
@@ -12,9 +12,9 @@ func (RhAccount) TableName() string {
 }
 
 type SystemPlatform struct {
-	ID                    int
-	InventoryID           string
-	RhAccountID           int
+	ID          int
+	InventoryID string
+	RhAccountID int
 	// All times need to be stored as pointers, since they are set to 0000-00-00 00:00 by gorm if not present
 	FirstReported         *time.Time
 	VmaasJSON             string
@@ -34,12 +34,21 @@ func (SystemPlatform) TableName() string {
 	return "system_platform"
 }
 
+type AdvisoryType struct {
+	ID   int
+	Name string
+}
+
+func (AdvisoryType) TableName() string {
+	return "advisory_type"
+}
+
 type AdvisoryMetadata struct {
 	ID             int
 	Name           string
 	Description    string
 	Synopsis       string
-	Topic          string
+	Summary        string
 	Solution       string
 	AdvisoryTypeId int
 	PublicDate     time.Time
@@ -49,6 +58,16 @@ type AdvisoryMetadata struct {
 
 func (AdvisoryMetadata) TableName() string {
 	return "advisory_metadata"
+}
+
+type AdvisoryMetadataSlice []AdvisoryMetadata
+
+func (this AdvisoryMetadataSlice) ToInterfaceSlice() []interface{} {
+	res := make([]interface{}, len(this))
+	for i, v := range this {
+		res[i] = v
+	}
+	return res
 }
 
 type SystemAdvisories struct {

--- a/conf/common.env
+++ b/conf/common.env
@@ -7,3 +7,11 @@ DB_TYPE=postgres
 DB_HOST=db
 DB_NAME=patchman
 DB_PORT=5432
+
+
+# platform is mocking the vmaas
+VMAAS_ADDRESS=http://platform:9001
+VMAAS_WS_ADDRESS=ws://platform:9001/ws
+
+# If vmaas is running locally, its available here
+#VMAAS_ADDRESS=http://vmaas_webapp:8080

--- a/conf/listener.env
+++ b/conf/listener.env
@@ -6,11 +6,6 @@ EVENTS_TOPIC=platform.inventory.events
 
 # Platform is mocking the inventory
 INVENTORY_ADDRESS=http://platform:9001
-# platform is mocking the vmaas
-VMAAS_ADDRESS=http://platform:9001
-
-# If vmaas is running locally, its available here
-#VMAAS_ADDRESS=http://vmaas_webapp:8080
 
 DB_USER=listener
 DB_PASSWD=listener

--- a/conf/vmaas_sync.env
+++ b/conf/vmaas_sync.env
@@ -1,4 +1,2 @@
 DB_USER=vmaas_sync
 DB_PASSWD=vmaas_sync
-
-VMAAS_WS_ADDRESS=ws://platform:9001/ws

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"app/base"
 	"app/base/utils"
 	"app/manager/middlewares"
 	"context"
@@ -9,9 +10,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/segmentio/kafka-go"
 )
-
-const INVENTORY_API_PREFIX = "/api/inventory/v1"
-const VMAAS_API_PREFIX = "/api"
 
 var (
 	uploadReader    *kafka.Reader
@@ -50,14 +48,12 @@ func configure() {
 
 	inventoryConfig := inventory.NewConfiguration()
 	inventoryConfig.Debug = traceApi
-	inventoryConfig.BasePath = inventoryAddr + INVENTORY_API_PREFIX
-
+	inventoryConfig.BasePath = inventoryAddr + base.INVENTORY_API_PREFIX
 	inventoryClient = inventory.NewAPIClient(inventoryConfig)
 
 	vmaasConfig := vmaas.NewConfiguration()
-	vmaasConfig.BasePath = utils.GetenvOrFail("VMAAS_ADDRESS") + VMAAS_API_PREFIX
+	vmaasConfig.BasePath = utils.GetenvOrFail("VMAAS_ADDRESS") + base.VMAAS_API_PREFIX
 	vmaasConfig.Debug = traceApi
-
 	vmaasClient = vmaas.NewAPIClient(vmaasConfig)
 }
 

--- a/manager/controllers/advisory_detail.go
+++ b/manager/controllers/advisory_detail.go
@@ -67,7 +67,7 @@ func AdvisoryDetailHandler(c *gin.Context) {
 				Severity: nil,
 				ModifiedDate: advisory.ModifiedDate,
 				PublicDate: advisory.PublicDate,
-				Topic: advisory.Topic,
+				Topic: advisory.Summary,
 				Synopsis: advisory.Synopsis,
 				Solution: advisory.Solution,
 				Fixes: nil,

--- a/openshift/deploy/database.yml
+++ b/openshift/deploy/database.yml
@@ -86,6 +86,11 @@ objects:
                       name:  patchman-engine-database-passwords
                       key: manager-database-password
 
+                - name: VMAAS_SYNC_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name:  patchman-engine-database-passwords
+                      key: vmaas-sync-database-password
 
           dnsPolicy: ClusterFirst
           restartPolicy: Always

--- a/openshift/deploy/vmaas_sync.yml
+++ b/openshift/deploy/vmaas_sync.yml
@@ -9,6 +9,7 @@ parameters:
   - name: IMAGE_TAG
     displayName: Image tag
     value: latest
+  - name: VMAAS_ADDRESS
   - name: VMAAS_WS_ADDRESS
 objects:
   - apiVersion: v1
@@ -32,7 +33,7 @@ objects:
             - image: ${IMAGE_NAMESPACE}/patchman-engine-app:${IMAGE_TAG}
               imagePullPolicy: Always
               name: patchman-engine-vmaas-sync
-              command: [ ./vmaas-sync/entrypoint.sh ]
+              command: [ ./vmaas_sync/entrypoint.sh ]
               resources:
                 limits: { cpu: 500m,  memory: 512Mi }
                 requests: { cpu: 200m, memory: 512Mi }
@@ -45,6 +46,7 @@ objects:
                 - { name: LOG_STYLE, value: plain }
                 - { name: GIN_MODE, value: release }
 
+                - { name: VMAAS_ADDRESS, value: "${VMAAS_ADDRESS}"}
                 - { name: VMAAS_WS_ADDRESS, value: "${VMAAS_WS_ADDRESS}"}
 
                 - { name: DB_TYPE, value: postgres }

--- a/scripts/test_data.sql
+++ b/scripts/test_data.sql
@@ -78,5 +78,6 @@ INSERT INTO timestamp_kv (name, value) VALUES
 
 SELECT refresh_all_cached_counts();
 
+SELECT setval('advisory_metadata_id_seq', 100);
 SELECT setval('system_platform_id_seq', 100);
 SELECT setval('rh_account_id_seq', 100);

--- a/vmaas_sync/advisory_sync.go
+++ b/vmaas_sync/advisory_sync.go
@@ -1,0 +1,138 @@
+package vmaas_sync
+
+import (
+	"app/base"
+	"app/base/database"
+	"app/base/models"
+	"app/base/utils"
+	"context"
+	"github.com/RedHatInsights/patchman-clients/vmaas"
+	"github.com/antihax/optional"
+	"github.com/pkg/errors"
+	"time"
+)
+
+var (
+	vmaasClient *vmaas.APIClient
+)
+
+func configure() {
+	cfg := vmaas.NewConfiguration()
+	cfg.BasePath = utils.GetenvOrFail("VMAAS_ADDRESS") + base.VMAAS_API_PREFIX
+	cfg.Debug = true
+
+	vmaasClient = vmaas.NewAPIClient(cfg)
+}
+
+func parseAdvisories(data map[string]vmaas.ErrataResponseErrataList) (models.AdvisoryMetadataSlice, error) {
+	var advisories models.AdvisoryMetadataSlice
+
+	// We use advisory types from DB
+	var advisoryTypesArr []models.AdvisoryType
+	advisoryTypes := map[string]int{}
+
+	err := database.Db.Find(&advisoryTypesArr).Error
+	if err != nil {
+		return nil, errors.WithMessage(err, "Loading advisory types")
+	}
+
+	for _, t := range advisoryTypesArr {
+		advisoryTypes[t.Name] = t.ID
+	}
+
+	for n, v := range data {
+		// Should we skip or report invalid erratas ?
+		issued, err := time.Parse(base.RFC_3339_NO_TZ, v.Issued)
+		if err != nil {
+			utils.Log("err", err.Error()).Error("Invalid errata issued date")
+			continue
+		}
+		modified, err := time.Parse(base.RFC_3339_NO_TZ, v.Updated)
+		if err != nil {
+			utils.Log("err", err.Error()).Error("Invalid errata modified date")
+			continue
+		}
+
+		if v.Description == "" || v.Summary == "" {
+			utils.Log().Error("An advisory without description or summary")
+			continue
+		}
+
+		advisory := models.AdvisoryMetadata{
+			Name:           n,
+			AdvisoryTypeId: advisoryTypes[v.Type],
+			Description:    v.Description,
+			Synopsis:       v.Synopsis,
+			Summary:        v.Summary,
+			Solution:       v.Solution,
+			PublicDate:     issued,
+			ModifiedDate:   modified,
+			Url:            &v.Url,
+		}
+
+		advisories = append(advisories, advisory)
+	}
+	return advisories, nil
+}
+
+func storeAdvisories(data map[string]vmaas.ErrataResponseErrataList) error {
+
+	advisories, err := parseAdvisories(data)
+	if err != nil {
+		return errors.WithMessage(err, "Parsing advisories")
+	}
+	if advisories == nil || len(advisories) == 0 {
+		return nil
+	}
+
+	tx := database.OnConflictUpdate(database.Db, "name", "description", "synopsis", "summary", "solution", "public_date", "modified_date", "url")
+	errors := database.BulkInsertChunk(tx, advisories.ToInterfaceSlice(), 1000)
+
+	if errors != nil && len(errors) > 0 {
+		return errors[0]
+	}
+	return nil
+
+}
+
+func syncAdvisories() error {
+	ctx := context.Background()
+
+	if vmaasClient == nil {
+
+		panic("VMaaS client is nil")
+	}
+
+	pageIdx := 0
+	maxPageIdx := 1
+
+	for pageIdx <= maxPageIdx {
+
+		opts := vmaas.AppErrataHandlerPostPostOpts{
+			ErrataRequest: optional.NewInterface(vmaas.ErrataRequest{
+				Page:          float32(pageIdx),
+				PageSize:      1000,
+				ErrataList:    []string{".*"},
+				ModifiedSince: "",
+			}),
+		}
+
+		data, _, err := vmaasClient.ErrataApi.AppErrataHandlerPostPost(ctx, &opts)
+
+		if err != nil {
+			return errors.WithMessage(err, "Downloading erratas")
+		}
+
+		maxPageIdx = int(data.Pages)
+		pageIdx += 1
+
+		utils.Log("count", len(data.ErrataList)).Debug("Downloaded advisories")
+
+		err = storeAdvisories(data.ErrataList)
+		if err != nil {
+			return errors.WithMessage(err, "Storing advisories")
+
+		}
+	}
+	return nil
+}

--- a/vmaas_sync/advisory_sync_test.go
+++ b/vmaas_sync/advisory_sync_test.go
@@ -1,0 +1,142 @@
+package vmaas_sync
+
+import (
+	"app/base"
+	"app/base/core"
+	"app/base/database"
+	"app/base/models"
+	"app/base/utils"
+	"encoding/json"
+	"github.com/RedHatInsights/patchman-clients/vmaas"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+const testAdvisories = `
+{
+   "errata_list":{
+      "RHBA-2004:391":{
+         "synopsis":"Updated perl packages",
+         "summary":"Updated perl packages that fix a UTF-8 support bug are now available.",
+         "type":"bugfix",
+         "severity":"None",
+         "description":"Perl is a high-level programming language with roots in C, sed, awk\nand shell scripting.  Perl is good at handling processes and files,\nand is especially good at handling text.\n\nPerl-5.8.0 now includes default support for UTF-8 character encoding for\nRed Hat Enterprise Linux 3.  Some interactions between UTF-8 support and\nperl could result in corrupted data.  This update fixes an issue in regards\nto regular expression handling.\n\nAll users of perl should upgrade to these updated packages, which resolve\nthis issue.",
+         "solution":"Before applying this update, make sure that all previously-released\nerrata relevant to your system have been applied.  Use Red Hat\nNetwork to download and update your packages.  To launch the Red Hat\nUpdate Agent, use the following command:\n\n    up2date\n\nFor information on how to install packages manually, refer to the\nfollowing Web page for the System Administration or Customization\nguide specific to your system:\n\n    http://www.redhat.com/docs/manuals/enterprise/",
+         "issued":"2004-09-02T00:00:00+00:00",
+         "updated":"2004-09-02T00:00:00+00:00",
+         "cve_list":[
+
+         ],
+         "package_list":[
+
+         ],
+         "source_package_list":[
+
+         ],
+         "bugzilla_list":[
+            "112339"
+         ],
+         "reference_list":[
+
+         ],
+         "modules_list":[
+
+         ],
+         "url":"https://access.redhat.com/errata/RHBA-2004:391"
+      },
+      "RHBA-2004:403":{
+         "synopsis":"Updated rusers packages",
+         "summary":"Updated rusers packages that remove the requirement for procps are now\navailable.",
+         "type":"bugfix",
+         "severity":"None",
+         "description":"The rusers program allows users to find out who is logged into certain\nmachines on the local network. The 'rusers' command produces output\nsimilar to 'who', but for a specified list of hosts or for all machines\non the local network.\n\nPrevious versions of the rusers package, and the included rstatd\napplication, had a requirement such that the procps package and the\nlibraries therein were required for rusers to function properly. This\ncaused problems when updated versions of procps were released. These\nupdated rusers packages contain a fix that removes the procps package\ndependancy.\n\nAll users of rusers and rstatd should upgrade to these updated packages,\nwhich resolve this issue.",
+         "solution":"Before applying this update, make sure that all previously-released\nerrata relevant to your system have been applied.  Use Red Hat\nNetwork to download and update your packages.  To launch the Red Hat\nUpdate Agent, use the following command:\n\n    up2date\n\nFor information on how to install packages manually, refer to the\nfollowing Web page for the System Administration or Customization\nguide specific to your system:\n\n    http://www.redhat.com/docs/manuals/enterprise/",
+         "issued":"2004-09-02T00:00:00+00:00",
+         "updated":"2004-09-02T00:00:00+00:00",
+         "cve_list":[
+
+         ],
+         "package_list":[
+
+         ],
+         "source_package_list":[
+
+         ],
+         "bugzilla_list":[
+
+         ],
+         "reference_list":[
+
+         ],
+         "modules_list":[
+
+         ],
+         "url":"https://access.redhat.com/errata/RHBA-2004:403"
+      }
+	},
+   "page":0,
+   "page_size":10,
+   "pages":1
+}
+`
+
+func TestParseAdvisories(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+
+	data := map[string]vmaas.ErrataResponseErrataList{
+		"ER1": {
+			Updated:     "2004-09-02T00:00:00+00:00",
+			Issued:      "2004-09-02T00:00:00+00:00",
+			Description: "DESC",
+			Solution:    "SOL",
+			Summary:     "SUM",
+			Url:         "URL",
+			Synopsis:    "SYN",
+			Type:        "bugfix",
+		},
+	}
+
+	res, err := parseAdvisories(data)
+	assert.Nil(t, err)
+	assert.Equal(t, len(res), 1)
+	adv := res[0]
+
+	time, err := time.Parse(base.RFC_3339_NO_TZ, "2004-09-02T00:00:00+00:00")
+	assert.Nil(t, err)
+	assert.Equal(t, adv.PublicDate, time)
+	assert.Equal(t, adv.ModifiedDate, time)
+	assert.Equal(t, adv.Description, "DESC")
+	assert.Equal(t, adv.Solution, "SOL")
+	assert.Equal(t, adv.Summary, "SUM")
+	assert.Equal(t, *adv.Url, "URL")
+	assert.Equal(t, adv.Synopsis, "SYN")
+	assert.Equal(t, adv.AdvisoryTypeId, 2)
+
+}
+
+func TestSaveAdvisories(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+
+	var data vmaas.ErrataResponse
+
+	assert.Nil(t, json.Unmarshal([]byte(testAdvisories), &data))
+	for i, v := range data.ErrataList {
+		v.Url = "TEST"
+		data.ErrataList[i] = v
+	}
+
+	// Repeatedly storing erratas should just overwrite them
+	for i := 0; i < 2; i++ {
+		assert.Nil(t, storeAdvisories(data.ErrataList))
+		var count int
+
+		assert.Nil(t, database.Db.Model(&models.AdvisoryMetadata{}).Where("url = ?", "TEST").Count(&count).Error)
+
+		assert.Equal(t, count, len(data.ErrataList))
+	}
+
+	assert.Nil(t, database.Db.Unscoped().Where("url = ?", "TEST").Delete(&models.AdvisoryMetadata{}).Error)
+}


### PR DESCRIPTION
Implements syncing advisories from VMaaS. Contains just storing the data.

Next step will be forcing re-evaluation of systems, based on information of updated repos.

The synchronization can be caused by running `dev/scripts/platform_sync.sh` script in local development environmnet.