### PR TITLE
Implement host deletion

### DIFF
--- a/base/database/batch.go
+++ b/base/database/batch.go
@@ -1,8 +1,8 @@
 package database
 // This file was adapted from https://github.com/bombsimon/gorm-bulk
 import (
-	"errors"
 	"fmt"
+	"github.com/pkg/errors"
 	"reflect"
 	"sort"
 	"strings"

--- a/base/utils/gin.go
+++ b/base/utils/gin.go
@@ -1,8 +1,8 @@
 package utils
 
 import (
-	"errors"
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	"strconv"
 )
 

--- a/base/utils/rpm.go
+++ b/base/utils/rpm.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 	"regexp"
 )
 

--- a/database/schema/create_schema.sql
+++ b/database/schema/create_schema.sql
@@ -598,19 +598,6 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON advisory_account_data TO evaluator;
 -- listner user needs to change this table when deleting system
 GRANT SELECT, INSERT, UPDATE, DELETE ON advisory_account_data TO listener;
 
-
-CREATE TABLE IF NOT EXISTS deleted_systems (
-  inventory_id TEXT NOT NULL, CHECK (NOT empty(inventory_id)),
-  when_deleted TIMESTAMP WITH TIME ZONE NOT NULL,
-  UNIQUE (inventory_id)
-) TABLESPACE pg_default;
-
-CREATE INDEX ON deleted_systems(when_deleted);
-
-GRANT SELECT, INSERT, UPDATE, DELETE ON deleted_systems TO listener;
-GRANT SELECT, INSERT, UPDATE, DELETE ON deleted_systems TO manager;
-
-
 -- repo
 CREATE TABLE IF NOT EXISTS repo (
   id SERIAL,

--- a/dev/scripts/platform_delete.sh
+++ b/dev/scripts/platform_delete.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -v -X POST http://localhost:9001/control/delete

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/mattn/go-isatty v0.0.11 // indirect
 	github.com/mattn/go-sqlite3 v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4 v2.3.0+incompatible // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/prometheus/client_model v0.0.0-20191202183732-d1d2010b5bee // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect

--- a/listener/common_test.go
+++ b/listener/common_test.go
@@ -1,0 +1,68 @@
+package listener
+
+import (
+	"app/base/database"
+	"app/base/models"
+	"encoding/json"
+	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+const id = "TEST-00000"
+
+func deleteData(t *testing.T) {
+	// Delete debug data from previous run
+	assert.Nil(t, database.Db.Unscoped().Where("inventory_id = ?", id).Delete(&models.SystemPlatform{}).Error)
+	assert.Nil(t, database.Db.Unscoped().Where("name = ?", id).Delete(&models.RhAccount{}).Error)
+}
+
+func assertSystemInDb(t *testing.T) {
+	var system models.SystemPlatform
+	assert.Nil(t, database.Db.Where("inventory_id = ?", id).Find(&system).Error)
+	assert.Equal(t, system.InventoryID, id)
+
+	var account models.RhAccount
+	assert.Nil(t, database.Db.Where("id = ?", system.RhAccountID).Find(&account).Error)
+	assert.Equal(t, id, account.Name)
+
+	now := time.Now().Add(-time.Minute)
+	assert.True(t, system.FirstReported.After(now), "First reported")
+	assert.True(t, system.LastUpdated.After(now), "Last updated")
+	assert.True(t, system.UnchangedSince.After(now), "Unchanged since")
+	assert.True(t, system.LastUpload.After(now), "Last upload")
+	// Last eval should be nil, system has not yet been evaluated
+	assert.Nil(t, system.LastEvaluation)
+}
+
+func assertSystemNotInDb(t *testing.T) {
+	var systemCount int
+	assert.Nil(t, database.Db.Model(models.SystemPlatform{}).
+		Where("inventory_id = ?", id).Count(&systemCount).Error)
+
+	assert.Equal(t, systemCount, 0)
+}
+
+
+func getOrCreateTestAccount(t *testing.T) int {
+	accountId, err := getOrCreateAccount(id)
+	assert.Nil(t, err)
+	return accountId
+}
+
+func createTestUploadEvent(t *testing.T) PlatformEvent {
+	msg := kafka.Message{Value: []byte(`{ "id": "TEST-00000","type": "created", "b64_identity": "eyJlbnRpdGxlbWVudHMiOnsic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1ZX19LCJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IlRFU1QtMDAwMDAiLCJ0eXBlIjoiVXNlciIsIkludGVybmFsIjpudWxsfX0="}`)}
+	var event PlatformEvent
+	err := json.Unmarshal(msg.Value, &event)
+	assert.Nil(t, err)
+	return event
+}
+
+func createTestDeleteEvent(t *testing.T) PlatformEvent {
+	msg := kafka.Message{Value: []byte(`{ "id": "TEST-00000","type": "delete"}`)}
+	var event PlatformEvent
+	err := json.Unmarshal(msg.Value, &event)
+	assert.Nil(t, err)
+	return event
+}

--- a/listener/common_test.go
+++ b/listener/common_test.go
@@ -13,7 +13,7 @@ import (
 const id = "TEST-00000"
 
 func deleteData(t *testing.T) {
-	// Delete debug data from previous run
+	// Delete test data from previous run
 	assert.Nil(t, database.Db.Unscoped().Where("inventory_id = ?", id).Delete(&models.SystemPlatform{}).Error)
 	assert.Nil(t, database.Db.Unscoped().Where("name = ?", id).Delete(&models.RhAccount{}).Error)
 }
@@ -44,7 +44,6 @@ func assertSystemNotInDb(t *testing.T) {
 	assert.Equal(t, systemCount, 0)
 }
 
-
 func getOrCreateTestAccount(t *testing.T) int {
 	accountId, err := getOrCreateAccount(id)
 	assert.Nil(t, err)
@@ -66,3 +65,20 @@ func createTestDeleteEvent(t *testing.T) PlatformEvent {
 	assert.Nil(t, err)
 	return event
 }
+
+func TestParseEvents(t *testing.T) {
+
+	msg := kafka.Message{Value: []byte(`{"id": "TEST-00000", "type": "delete"}`)}
+
+	reached := false
+
+	makeKafkaHandler(func(event PlatformEvent) {
+		assert.Equal(t, event.Id, "TEST-00000")
+		assert.Equal(t, *event.Type, "delete")
+		reached = true
+	})(msg)
+
+	assert.True(t, reached,"Event handler should have been called")
+}
+
+

--- a/listener/delete.go
+++ b/listener/delete.go
@@ -1,0 +1,22 @@
+package listener
+
+import (
+	"app/base/database"
+	"app/base/utils"
+)
+
+func deleteHandler(event PlatformEvent)  {
+	if event.Type == nil || *event.Type != "delete" {
+		return
+	}
+
+	query := database.Db.Exec("select deleted_inventory_id from delete_system(?)", event.Id)
+	err := query.Error
+
+	if err != nil {
+		utils.Log("id", event.Id, "err", err.Error()).Error("Could not delete system")
+		return
+	}
+
+	utils.Log("id", event.Id, "count", query.RowsAffected).Info("Systems deleted")
+}

--- a/listener/delete_test.go
+++ b/listener/delete_test.go
@@ -1,0 +1,22 @@
+package listener
+
+import (
+	"app/base/core"
+	"app/base/utils"
+	"testing"
+)
+
+func TestDeleteSystem(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+	configure()
+
+	deleteData(t)
+	uploadEvent := createTestUploadEvent(t)
+	uploadHandler(uploadEvent)
+	assertSystemInDb(t)
+
+	deleteEvent := createTestDeleteEvent(t)
+	deleteHandler(deleteEvent)
+	assertSystemNotInDb(t)
+}

--- a/listener/event.go
+++ b/listener/event.go
@@ -5,12 +5,11 @@ type HostInfo struct {
 }
 
 type PlatformEvent struct {
-	Id        string `json:"id"`
-	Timestamp string `json:"timestamp"`
-	Account   string `json:"account"`
+	Id string `json:"id"`
 
-	// Optional fields
 	Type        *string `json:"type"`
+	Timestamp   *string `json:"timestamp"`
+	Account     *string `json:"account"`
 	B64Identity *string `json:"b64_identity"`
 	Url         *string `json:"url"`
 

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -8,9 +8,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"github.com/RedHatInsights/patchman-clients/inventory"
 	"github.com/RedHatInsights/patchman-clients/vmaas"
+	"github.com/pkg/errors"
 	"time"
 )
 

--- a/listener/upload_test.go
+++ b/listener/upload_test.go
@@ -56,6 +56,25 @@ func TestParseUploadMessage(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, id, event.Id)
 	assert.Equal(t, "User", identity.Identity.Type)
+
+
+	ident, err :=  utils.Identity{
+		Entitlements: nil,
+		Identity:     utils.IdentityDetail{},
+	}.Encode()
+
+	event.B64Identity = &ident
+	identity, err = parseUploadMessage(&event)
+	assert.NotNil(t, err, "Should return not entitled error")
+
+	ident = "Invalid"
+	event.B64Identity = &ident
+	identity, err = parseUploadMessage(&event)
+	assert.NotNil(t, err, "Should report invalid identity")
+
+	event.B64Identity = nil
+	identity, err = parseUploadMessage(&event)
+	assert.NotNil(t, err, "Should report missing identity")
 }
 
 func TestUploadHandler(t *testing.T) {

--- a/listener/upload_test.go
+++ b/listener/upload_test.go
@@ -2,23 +2,13 @@ package listener
 
 import (
 	"app/base/core"
-	"app/base/database"
-	"app/base/models"
 	"app/base/utils"
 	"github.com/RedHatInsights/patchman-clients/vmaas"
-	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"time"
 )
 
-const id = "TEST-00000"
 
-func deleteData(t *testing.T) {
-	// Delete debug data from previous run
-	assert.Nil(t, database.Db.Unscoped().Where("inventory_id = ?", id).Delete(&models.SystemPlatform{}).Error)
-	assert.Nil(t, database.Db.Unscoped().Where("name = ?", id).Delete(&models.RhAccount{}).Error)
-}
 
 func TestGetOrCreateAccount(t *testing.T) {
 	utils.SkipWithoutDB(t)
@@ -61,8 +51,8 @@ func TestUpdateSystemPlatform(t *testing.T) {
 }
 
 func TestParseUploadMessage(t *testing.T) {
-	msg := createTestingUploadKafkaMsg()
-	event, identity, err := parseUploadMessage(msg)
+	event := createTestUploadEvent(t)
+	identity, err := parseUploadMessage(&event)
 	assert.Nil(t, err)
 	assert.Equal(t, id, event.Id)
 	assert.Equal(t, "User", identity.Identity.Type)
@@ -75,39 +65,11 @@ func TestUploadHandler(t *testing.T) {
 	deleteData(t)
 
 	getOrCreateTestAccount(t)
-	msg := createTestingUploadKafkaMsg()
-	uploadHandler(msg)
+	event := createTestUploadEvent(t)
+	uploadHandler(event)
 
 	assertSystemInDb(t)
 
 	deleteData(t)
 }
 
-func assertSystemInDb(t *testing.T) {
-	var system models.SystemPlatform
-	assert.Nil(t, database.Db.Where("inventory_id = ?", id).Find(&system).Error)
-	assert.Equal(t, system.InventoryID, id)
-
-	var account models.RhAccount
-	assert.Nil(t, database.Db.Where("id = ?", system.RhAccountID).Find(&account).Error)
-	assert.Equal(t, id, account.Name)
-
-	now := time.Now().Add(-time.Minute)
-	assert.True(t, system.FirstReported.After(now), "First reported")
-	assert.True(t, system.LastUpdated.After(now), "Last updated")
-	assert.True(t, system.UnchangedSince.After(now), "Unchanged since")
-	assert.True(t, system.LastUpload.After(now), "Last upload")
-	// Last eval should be nil, system has not yet been evaluated
-	assert.Nil(t, system.LastEvaluation)
-}
-
-func getOrCreateTestAccount(t *testing.T) int {
-	accountId, err := getOrCreateAccount(id)
-	assert.Nil(t, err)
-	return accountId
-}
-
-func createTestingUploadKafkaMsg() kafka.Message {
-	msg := kafka.Message{Value: []byte(`{ "id": "TEST-00000", "b64_identity": "eyJlbnRpdGxlbWVudHMiOnsic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1ZX19LCJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IlRFU1QtMDAwMDAiLCJ0eXBlIjoiVXNlciIsIkludGVybmFsIjpudWxsfX0="}`)}
-	return msg
-}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -64,42 +64,36 @@ func mockIdentity()string {
 	return identity
 }
 
-func MockUploadHandler(c *gin.Context) {
-	utils.Log().Info("Mocking platform upload event")
-	writer := mockKafkaWriter("platform.upload.available")
-	identity := mockIdentity();
-
-	// We need to format this message to not depend on listener.
-	// TODO: Replace with a typed solution, once we move event code to base library
-	event := fmt.Sprintf(`{ "id": "TEST-0000", "type": "created", "b64_identity": "%v"}`, identity)
+func sendMessageToTopic(topic, message string) {
+	writer := mockKafkaWriter(topic)
 
 	err := writer.WriteMessages(context.Background(), kafka.Message{
 		Key:   []byte{},
-		Value: []byte(event),
+		Value: []byte(message),
 	})
+
 	if err != nil {
 		panic(err)
 	}
 
+}
+func MockUploadHandler(c *gin.Context) {
+	utils.Log().Info("Mocking platform upload event")
+	identity := mockIdentity()
+
+	// We need to format this message to not depend on listener.
+	// TODO: Replace with a typed solution, once we move event code to base library
+	event := fmt.Sprintf(`{ "id": "TEST-0000", "type": "created", "b64_identity": "%v"}`, identity)
+	sendMessageToTopic("platform.upload.available", event)
 	c.Status(http.StatusOK)
 }
 
 func MockDeleteHandler(c *gin.Context) {
 	utils.Log().Info("Mocking platform delete event")
-	writer := mockKafkaWriter("platform.inventory.events")
+
 	identity := mockIdentity();
-
-	// We need to format this message to not depend on listener.
-	// TODO: Replace with a typed solution, once we move event code to base library
 	event := fmt.Sprintf(`{ "id": "TEST-0000", "type": "delete", "b64_identity": "%v"}`, identity)
-
-	err := writer.WriteMessages(context.Background(), kafka.Message{
-		Key:   []byte{},
-		Value: []byte(event),
-	})
-	if err != nil {
-		panic(err)
-	}
+	sendMessageToTopic("platform.inventory.events", event)
 	c.Status(http.StatusOK)
 }
 


### PR DESCRIPTION
- Removed 'deleted_systems' table is not needed, since we are querying
inventory for systems, and can detect out-of-order deletions that way.

  This table was used as a guard against accidentally reordered upload,
and delete messages. If in a rare case, a delete message was processed
before an upload message for same host, it would mean that host would
be deleted and re-created. We can detect this when processing an upload
message. If the call to get 'system_profile' returns no data, host is deleted.

- Re-organized the handlers, to make event parsing code shared.