### PR TITLE
Fix indexing error in advisory_sync

### DIFF
--- a/vmaas_sync/advisory_sync.go
+++ b/vmaas_sync/advisory_sync.go
@@ -109,7 +109,7 @@ func syncAdvisories() error {
 	pageIdx := 0
 	maxPageIdx := 1
 
-	for pageIdx <= maxPageIdx {
+	for pageIdx < maxPageIdx {
 
 		opts := vmaas.AppErrataHandlerPostPostOpts{
 			ErrataRequest: optional.NewInterface(vmaas.ErrataRequest{


### PR DESCRIPTION
An indexing error resulted in vmaas_sync container crashing after each sync.