### PR TITLE
Move to v3/updates call, add more info to vmaas request

### DIFF
--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -28,12 +28,12 @@ func Configure() {
 	vmaasClient = vmaas.NewAPIClient(vmaasConfig)
 }
 
-func Evaluate(systemID int, ctx context.Context, updatesReq vmaas.UpdatesRequest) {
-	vmaasCallArgs := vmaas.AppUpdatesHandlerV2PostPostOpts{
-		UpdatesRequest: optional.NewInterface(updatesReq),
+func Evaluate(systemID int, ctx context.Context, updatesReq vmaas.UpdatesV3Request) {
+	vmaasCallArgs := vmaas.AppUpdatesHandlerV3PostPostOpts{
+		UpdatesV3Request: optional.NewInterface(updatesReq),
 	}
 
-	vmaasData, _, err := vmaasClient.UpdatesApi.AppUpdatesHandlerV2PostPost(ctx, &vmaasCallArgs)
+	vmaasData, _, err := vmaasClient.UpdatesApi.AppUpdatesHandlerV3PostPost(ctx, &vmaasCallArgs)
 	if err != nil {
 		utils.Log("err", err.Error()).Error("Unable to get updates from VMaaS")
 		return

--- a/evaluator/evaluate_test.go
+++ b/evaluator/evaluate_test.go
@@ -143,7 +143,7 @@ func TestEvaluate(t *testing.T) {
 
 	systemID := 11
 	expectedAddedAdvisories := []string{"ER1", "ER2", "ER3"}
-	Evaluate(systemID, context.Background(), vmaas.UpdatesRequest{})
+	Evaluate(systemID, context.Background(), vmaas.UpdatesV3Request{})
 	ids := database.CheckAdvisoriesInDb(t, expectedAddedAdvisories)
 
 	checkSystemAdvisoriesWhenPatched(t, systemID, ids, nil)
@@ -154,8 +154,8 @@ func TestEvaluate(t *testing.T) {
 }
 
 func getVMaaSUpdates(t *testing.T) vmaas.UpdatesV2Response {
-	vmaasCallArgs := vmaas.AppUpdatesHandlerV2PostPostOpts{}
-	vmaasData, resp, err := vmaasClient.UpdatesApi.AppUpdatesHandlerV2PostPost(context.Background(), &vmaasCallArgs)
+	vmaasCallArgs := vmaas.AppUpdatesHandlerV3PostPostOpts{}
+	vmaasData, resp, err := vmaasClient.UpdatesApi.AppUpdatesHandlerV3PostPost(context.Background(), &vmaasCallArgs)
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	return vmaasData

--- a/listener/upload_test.go
+++ b/listener/upload_test.go
@@ -31,7 +31,7 @@ func TestUpdateSystemPlatform(t *testing.T) {
 	deleteData(t)
 
 	accountId := getOrCreateTestAccount(t)
-	req := vmaas.UpdatesRequest{
+	req := vmaas.UpdatesV3Request{
 		PackageList:    []string{"package0"},
 		RepositoryList: []string{},
 		ModulesList:    []vmaas.UpdatesRequestModulesList{},

--- a/platform/vmaas.go
+++ b/platform/vmaas.go
@@ -128,8 +128,8 @@ func wshandler(w http.ResponseWriter, r *http.Request, ) {
 
 func InitVMaaS(app *gin.Engine) {
 	// Mock updates endpoint for VMaaS
-	app.GET("/api/v2/updates", updatesHandler)
-	app.POST("/api/v2/updates", updatesHandler)
+	app.GET("/api/v3/updates", updatesHandler)
+	app.POST("/api/v3/updates", updatesHandler)
 	// Mock erratas endpoint for VMaaS
 	app.POST("/api/v1/errata", erratasHandler)
 	// Mock websocket endpoint for VMaaS


### PR DESCRIPTION
VMaaS call for `/v3/updates` was implemented, this PR changes evaluation behaviour to use this endpoint, and adds modules + repos to VMaaS request