### PR TITLE
Fix CI deployment

### DIFF
--- a/database/schema/init_schema.sh
+++ b/database/schema/init_schema.sh
@@ -12,9 +12,9 @@ if $PG_INITIALIZED; then
   psql -d ${POSTGRESQL_DATABASE} -f ${CONTAINER_SCRIPTS_PATH}/start/create_users.sql
   # Create schema from scratch
   psql -d ${POSTGRESQL_DATABASE} -f ${CONTAINER_SCRIPTS_PATH}/start/create_schema.sql
-else
-  echo "Already initialized - Migrating the database"
-  ${CONTAINER_SCRIPTS_PATH}/migrate.sh up
+#else
+  #echo "Already initialized - Migrating the database"
+  #${CONTAINER_SCRIPTS_PATH}/migrate.sh up
 fi
 
 

--- a/openshift/deploy/database.yml
+++ b/openshift/deploy/database.yml
@@ -80,6 +80,12 @@ objects:
                       name:  patchman-engine-database-passwords
                       key: listener-database-password
 
+                - name: EVALUATOR_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name:  patchman-engine-database-passwords
+                      key: evaluator-database-password
+
                 - name: MANAGER_PASSWORD
                   valueFrom:
                     secretKeyRef:

--- a/openshift/deploy/listener.yml
+++ b/openshift/deploy/listener.yml
@@ -20,7 +20,7 @@ objects:
       labels: { app: patchman-engine }
       name: patchman-engine-listener
     spec:
-      replicas: 10
+      replicas: 1
       selector:
         app: patchman-engine
         deploymentconfig: patchman-engine-listener

--- a/openshift/secrets/patchman-database-passwords.yml
+++ b/openshift/secrets/patchman-database-passwords.yml
@@ -3,6 +3,7 @@ stringData:
   # Example secret values
   admin-database-password: "passwd"
   listener-database-password: "listener"
+  evaluator-database-password: "evaluator"
   manager-database-password: "manager"
   vmaas-sync-database-password: "vmaas_sync"
 kind: Secret


### PR DESCRIPTION
Fix missing configuration options on which CI deployment was crashing.
Limit number of listener pods (Incorrect resource limits, resolving in progress). 

This is just a simple fix for resolving current issues on CI. Actual fix which adresses listener performance & resource limits is in progress.