### PR TITLE
Concurrency

### DIFF
--- a/base/database/setup.go
+++ b/base/database/setup.go
@@ -45,7 +45,7 @@ func openPostgreSQL(dbConfig *PostgreSQLConfig) *gorm.DB {
 		panic(err)
 	}
 	// Nastavime limity dle configu.
-	db.DB().SetMaxIdleConns(dbConfig.MaxConnections)
+	db.DB().SetMaxOpenConns(dbConfig.MaxConnections)
 	db.DB().SetMaxIdleConns(dbConfig.MaxIdleConnections)
 	db.DB().SetConnMaxLifetime(time.Duration(dbConfig.MaxConnectionLifetime) * time.Second)
 	return db

--- a/conf/common.env
+++ b/conf/common.env
@@ -1,6 +1,7 @@
 LOG_LEVEL=debug
 LOG_STYLE=plain
 GIN_MODE=release
+GOMAXPROCS=8
 
 
 DB_TYPE=postgres

--- a/conf/listener.env
+++ b/conf/listener.env
@@ -1,5 +1,6 @@
 KAFKA_ADDRESS=platform:9092
 KAFKA_GROUP=patchman
+CONSUMER_COUNT=8
 
 UPLOAD_TOPIC=platform.upload.available
 EVENTS_TOPIC=platform.inventory.events

--- a/conf/test.env
+++ b/conf/test.env
@@ -11,6 +11,7 @@ DB_NAME=patchman
 
 INVENTORY_ADDRESS=http://platform:9001
 VMAAS_ADDRESS=http://platform:9001
+CONSUMER_COUNT=8
 
 KAFKA_ADDRESS=platform:9092
 KAFKA_GROUP=patchman

--- a/openshift/deploy/listener.yml
+++ b/openshift/deploy/listener.yml
@@ -20,7 +20,7 @@ objects:
       labels: { app: patchman-engine }
       name: patchman-engine-listener
     spec:
-      replicas: 10
+      replicas: 8
       selector:
         app: patchman-engine
         deploymentconfig: patchman-engine-listener

--- a/openshift/deploy/listener.yml
+++ b/openshift/deploy/listener.yml
@@ -48,6 +48,7 @@ objects:
                 - { name: LOG_LEVEL, value: debug }
                 - { name: LOG_STYLE, value: plain }
                 - { name: GIN_MODE, value: release }
+                - { name: GOMAXPROCS, value: 8 }
 
                 - { name: KAFKA_ADDRESS, value: "${KAFKA_ADDRESS}" }
                 - { name: KAFKA_GROUP, value: patchman }

--- a/openshift/deploy/manager.yml
+++ b/openshift/deploy/manager.yml
@@ -43,6 +43,7 @@ objects:
                 - { name: LOG_LEVEL, value: debug }
                 - { name: LOG_STYLE, value: plain }
                 - { name: GIN_MODE, value: release }
+                - { name: GOMAXPROCS, value: 8 }
 
                 - { name: DB_TYPE, value: postgres }
                 - { name: DB_HOST, value: patchman-engine-database }

--- a/openshift/deploy/vmaas_sync.yml
+++ b/openshift/deploy/vmaas_sync.yml
@@ -45,7 +45,7 @@ objects:
                 - { name: LOG_LEVEL, value: debug }
                 - { name: LOG_STYLE, value: plain }
                 - { name: GIN_MODE, value: release }
-
+                - { name: GOMAXPROCS, value: 8 }
                 - { name: VMAAS_ADDRESS, value: "${VMAAS_ADDRESS}"}
                 - { name: VMAAS_WS_ADDRESS, value: "${VMAAS_WS_ADDRESS}"}
 


### PR DESCRIPTION
Change the concurrency profile in listener
- We'll have 8 listeners
- Each listener will have 8 consumers,
- Scheduled on 8 hardware threads


This should allow us to process 64 messages at a time, and allow us to schedule goroutines on hardware threads, so the whole pipeline won't be blocked on waiting for database.