### PR TITLE
Advisory severity

### DIFF
--- a/base/models/models.go
+++ b/base/models/models.go
@@ -42,7 +42,7 @@ type AdvisorySeverity struct {
 }
 
 func (AdvisorySeverity) TableName() string {
-	return "advisory-severity"
+	return "advisory_severity"
 }
 
 type AdvisoryType struct {
@@ -62,10 +62,10 @@ type AdvisoryMetadata struct {
 	Summary        string
 	Solution       string
 	AdvisoryTypeID int
-	SeverityID     int
 	PublicDate     time.Time
 	ModifiedDate   time.Time
 	URL            *string
+	SeverityID     *int
 }
 
 func (AdvisoryMetadata) TableName() string {

--- a/base/models/models.go
+++ b/base/models/models.go
@@ -36,6 +36,15 @@ func (SystemPlatform) TableName() string {
 	return "system_platform"
 }
 
+type AdvisorySeverity struct {
+	ID   int
+	Name string
+}
+
+func (AdvisorySeverity) TableName() string {
+	return "advisory-severity"
+}
+
 type AdvisoryType struct {
 	ID   int
 	Name string
@@ -53,6 +62,7 @@ type AdvisoryMetadata struct {
 	Summary        string
 	Solution       string
 	AdvisoryTypeID int
+	SeverityID     int
 	PublicDate     time.Time
 	ModifiedDate   time.Time
 	URL            *string

--- a/base/mqueue/mqueue_test.go
+++ b/base/mqueue/mqueue_test.go
@@ -38,7 +38,7 @@ func TestRoundTrip(t *testing.T) {
 	msg := kafka.Message{Value: []byte("abcd")}
 	writer := WriterFromEnv("test")
 	assert.NoError(t, writer.WriteMessages(context.Background(), msg))
-	time.Sleep(5 * time.Second)
+	time.Sleep(8 * time.Second)
 	assert.NotNil(t, data)
 	assert.Equal(t, data, msg.Value)
 }

--- a/database/migrations/002_base_schema.up.sql
+++ b/database/migrations/002_base_schema.up.sql
@@ -92,6 +92,8 @@ CREATE INDEX ON advisory_metadata (advisory_type_id);
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON advisory_metadata TO evaluator;
 GRANT SELECT, INSERT, UPDATE, DELETE ON advisory_metadata TO vmaas_sync;
+-- TODO: Remove in later migration
+GRANT SELECT, INSERT, UPDATE, DELETE ON advisory_metadata TO listener;
 
 
 -- status table

--- a/database/migrations/005_adv_severity.down.sql
+++ b/database/migrations/005_adv_severity.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE advisory_metadata
+    DROP CONSTRAINT advisory_severity_id;
+
+ALTER TABLE advisory_metadata
+    DROP COLUMN severity_id;
+
+DROP TABLE advisory_severity;

--- a/database/migrations/005_adv_severity.up.sql
+++ b/database/migrations/005_adv_severity.up.sql
@@ -6,14 +6,13 @@ CREATE TABLE advisory_severity
 );
 
 INSERT INTO advisory_severity (id, name)
-VALUES (1, 'None'),
-       (2, 'Low'),
-       (3, 'Moderate'),
-       (4, 'Important'),
-       (5, 'Critical');
+VALUES (1, 'Low'),
+       (2, 'Moderate'),
+       (3, 'Important'),
+       (4, 'Critical');
 
 ALTER TABLE advisory_metadata
-    ADD COLUMN severity_id INT NOT NULL;
+    ADD COLUMN severity_id INT;
 
 ALTER TABLE advisory_metadata
     ADD CONSTRAINT advisory_severity_id

--- a/database/migrations/005_adv_severity.up.sql
+++ b/database/migrations/005_adv_severity.up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE advisory_severity
+(
+    id   INT  NOT NULL,
+    name TEXT NOT NULL UNIQUE CHECK ( not empty(name) ),
+    PRIMARY KEY (id)
+);
+
+INSERT INTO advisory_severity (id, name)
+VALUES (1, 'None'),
+       (2, 'Low'),
+       (3, 'Moderate'),
+       (4, 'Important'),
+       (5, 'Critical');
+
+ALTER TABLE advisory_metadata
+    ADD COLUMN severity_id INT NOT NULL;
+
+ALTER TABLE advisory_metadata
+    ADD CONSTRAINT advisory_severity_id
+        FOREIGN KEY (severity_id) REFERENCES advisory_severity (id);
+
+GRANT SELECT ON TABLE advisory_severity TO evaluator;
+GRANT SELECT ON TABLE advisory_severity TO listener;
+GRANT SELECT ON TABLE advisory_severity TO manager;
+GRANT SELECT ON TABLE advisory_severity TO vmaas_sync;

--- a/database/schema/create_schema.sql
+++ b/database/schema/create_schema.sql
@@ -561,11 +561,10 @@ CREATE TABLE advisory_severity
 );
 
 INSERT INTO advisory_severity (id, name)
-VALUES (1, 'None'),
-       (2, 'Low'),
-       (3, 'Moderate'),
-       (4, 'Important'),
-       (5, 'Critical');
+VALUES (1, 'Low'),
+       (2, 'Moderate'),
+       (3, 'Important'),
+       (4, 'Critical');
 
 -- advisory_metadata
 CREATE TABLE IF NOT EXISTS advisory_metadata
@@ -585,7 +584,7 @@ CREATE TABLE IF NOT EXISTS advisory_metadata
     public_date      TIMESTAMP WITH TIME ZONE NULL,
     modified_date    TIMESTAMP WITH TIME ZONE NULL,
     url              TEXT,
-    severity_id      INT                      NOT NULL,
+    severity_id      INT,
     UNIQUE (name),
     PRIMARY KEY (id),
     CONSTRAINT advisory_type_id

--- a/database/schema_test.go
+++ b/database/schema_test.go
@@ -77,4 +77,5 @@ func TestSchemaCompatiblity(t *testing.T) {
 	assert.NoError(t, err)
 
 	fmt.Print(diff)
+	assert.Equal(t, len(diff), 0)
 }

--- a/manager/controllers/advisories.go
+++ b/manager/controllers/advisories.go
@@ -23,9 +23,9 @@ type AdvisoryWithApplicableSystems struct {
 	Name              string
 	Description       string
 	Synopsis          string
-	Severity          string
 	PublicDate        time.Time
 	AdvisoryTypeID    int
+	Severity          *int
 	ApplicableSystems int
 }
 
@@ -105,10 +105,10 @@ func buildAdvisoriesData(advisories *[]AdvisoryWithApplicableSystems) *[]Advisor
 		data[i] = AdvisoryItem{
 			Attributes: AdvisoryItemAttributes{
 				Description:       advisory.Description,
-				Severity:          advisory.Severity,
 				PublicDate:        advisory.PublicDate,
 				Synopsis:          advisory.Synopsis,
 				AdvisoryType:      advisory.AdvisoryTypeID,
+				Severity:          advisory.Severity,
 				ApplicableSystems: advisory.ApplicableSystems},
 			ID:   advisory.Name,
 			Type: "advisory",

--- a/manager/controllers/advisories.go
+++ b/manager/controllers/advisories.go
@@ -23,6 +23,7 @@ type AdvisoryWithApplicableSystems struct {
 	Name              string
 	Description       string
 	Synopsis          string
+	Severity          string
 	PublicDate        time.Time
 	AdvisoryTypeID    int
 	ApplicableSystems int
@@ -104,7 +105,7 @@ func buildAdvisoriesData(advisories *[]AdvisoryWithApplicableSystems) *[]Advisor
 		data[i] = AdvisoryItem{
 			Attributes: AdvisoryItemAttributes{
 				Description:       advisory.Description,
-				Severity:          "",
+				Severity:          advisory.Severity,
 				PublicDate:        advisory.PublicDate,
 				Synopsis:          advisory.Synopsis,
 				AdvisoryType:      advisory.AdvisoryTypeID,

--- a/manager/controllers/advisory_detail.go
+++ b/manager/controllers/advisory_detail.go
@@ -22,12 +22,12 @@ type AdvisoryDetailItem struct {
 
 type AdvisoryDetailAttributes struct {
 	Description  string    `json:"description"`
-	Severity     *string   `json:"severity"`
 	ModifiedDate time.Time `json:"modified_date"`
 	PublicDate   time.Time `json:"public_date"`
 	Topic        string    `json:"topic"`
 	Synopsis     string    `json:"synopsis"`
 	Solution     string    `json:"solution"`
+	Severity     int       `json:"severity"`
 	Fixes        *string   `json:"fixes"`
 	Cves         []string  `json:"cves"`
 	References   []string  `json:"references"`
@@ -65,12 +65,12 @@ func AdvisoryDetailHandler(c *gin.Context) {
 		Data: AdvisoryDetailItem{
 			Attributes: AdvisoryDetailAttributes{
 				Description:  advisory.Description,
-				Severity:     nil,
 				ModifiedDate: advisory.ModifiedDate,
 				PublicDate:   advisory.PublicDate,
 				Topic:        advisory.Summary,
 				Synopsis:     advisory.Synopsis,
 				Solution:     advisory.Solution,
+				Severity:     advisory.SeverityID,
 				Fixes:        nil,
 				Cves:         []string{}, // TODO joins
 				References:   []string{}, // TODO joins

--- a/manager/controllers/advisory_detail.go
+++ b/manager/controllers/advisory_detail.go
@@ -27,7 +27,7 @@ type AdvisoryDetailAttributes struct {
 	Topic        string    `json:"topic"`
 	Synopsis     string    `json:"synopsis"`
 	Solution     string    `json:"solution"`
-	Severity     int       `json:"severity"`
+	Severity     *int      `json:"severity"`
 	Fixes        *string   `json:"fixes"`
 	Cves         []string  `json:"cves"`
 	References   []string  `json:"references"`

--- a/manager/controllers/advisory_detail_test.go
+++ b/manager/controllers/advisory_detail_test.go
@@ -28,6 +28,7 @@ func TestAdvisoryDetailDefault(t *testing.T) {
 	assert.Equal(t, "adv-1-sol", output.Data.Attributes.Solution)
 	assert.Equal(t, "2016-09-22 16:00:00 +0000 UTC", output.Data.Attributes.PublicDate.String())
 	assert.Equal(t, "2017-09-22 16:00:00 +0000 UTC", output.Data.Attributes.ModifiedDate.String())
+	assert.Nil(t, output.Data.Attributes.Severity)
 }
 
 func TestAdvisoryNoIdProvided(t *testing.T) {

--- a/manager/controllers/structures.go
+++ b/manager/controllers/structures.go
@@ -17,7 +17,7 @@ type AdvisoryItem struct {
 
 type AdvisoryItemAttributes struct {
 	Description       string    `json:"description"`
-	Severity          string    `json:"severity"`
+	Severity          string    `json:"severity,omitempty"`
 	PublicDate        time.Time `json:"public_date"`
 	Synopsis          string    `json:"synopsis"`
 	AdvisoryType      int       `json:"advisory_type"`

--- a/manager/controllers/structures.go
+++ b/manager/controllers/structures.go
@@ -17,10 +17,10 @@ type AdvisoryItem struct {
 
 type AdvisoryItemAttributes struct {
 	Description       string    `json:"description"`
-	Severity          string    `json:"severity,omitempty"`
 	PublicDate        time.Time `json:"public_date"`
 	Synopsis          string    `json:"synopsis"`
 	AdvisoryType      int       `json:"advisory_type"`
+	Severity          *int      `json:"severity,omitempty"`
 	ApplicableSystems int       `json:"applicable_systems"`
 }
 

--- a/manager/controllers/system_advisories.go
+++ b/manager/controllers/system_advisories.go
@@ -95,10 +95,16 @@ func SystemAdvisoriesHandler(c *gin.Context) {
 func buildSystemAdvisoriesData(models *[]models.AdvisoryMetadata) *[]AdvisoryItem {
 	data := make([]AdvisoryItem, len(*models))
 	for i, advisory := range *models {
-		item := AdvisoryItem{ID: advisory.Name, Type: "advisory", Attributes: AdvisoryItemAttributes{
-			Description: advisory.Description, Severity: "", PublicDate: advisory.PublicDate, Synopsis: advisory.Synopsis,
-			AdvisoryType: advisory.AdvisoryTypeID, ApplicableSystems: 0,
-		}}
+		item := AdvisoryItem{ID: advisory.Name, Type: "advisory",
+			Attributes: AdvisoryItemAttributes{
+				Description:  advisory.Description,
+				Severity:     advisory.SeverityID,
+				PublicDate:   advisory.PublicDate,
+				Synopsis:     advisory.Synopsis,
+				AdvisoryType: advisory.AdvisoryTypeID,
+				// TODO: Applicable systems
+				ApplicableSystems: 0,
+			}}
 		data[i] = item
 	}
 	return &data

--- a/scripts/test_data.sql
+++ b/scripts/test_data.sql
@@ -29,15 +29,15 @@ INSERT INTO system_platform (id, inventory_id, rh_account_id,  vmaas_json, json_
 (11, 'INV-11', 2, '{ "package_list": [ "kernel-2.6.32-696.20.1.el6.x86_64" ]}', '1', '2018-09-22 12:00:00-04', '2018-09-22 12:00:00-04');
 
 INSERT INTO advisory_metadata (id, name, description, synopsis, summary, solution, advisory_type_id,
-                               public_date, modified_date, url) VALUES
-(1, 'RH-1', 'adv-1-des', 'adv-1-syn', 'adv-1-sum', 'adv-1-sol', 1, '2016-09-22 12:00:00-04', '2017-09-22 12:00:00-04', 'url1'),
-(2, 'RH-2', 'adv-2-des', 'adv-2-syn', 'adv-2-sum', 'adv-2-sol', 2, '2016-09-22 12:00:00-04', '2017-09-22 12:00:00-04', 'url2'),
-(3, 'RH-3', 'adv-3-des', 'adv-3-syn', 'adv-3-sum', 'adv-3-sol', 3, '2016-09-22 12:00:00-04', '2017-09-22 12:00:00-04', 'url3'),
-(4, 'RH-4', 'adv-4-des', 'adv-4-syn', 'adv-4-sum', 'adv-4-sol', 1, '2016-09-22 12:00:00-04', '2017-09-22 12:00:00-04', 'url4'),
-(5, 'RH-5', 'adv-5-des', 'adv-5-syn', 'adv-5-sum', 'adv-5-sol', 2, '2016-09-22 12:00:00-05', '2017-09-22 12:00:00-05', 'url5'),
-(6, 'RH-6', 'adv-6-des', 'adv-6-syn', 'adv-6-sum', 'adv-6-sol', 3, '2016-09-22 12:00:00-06', '2017-09-22 12:00:00-06', 'url6'),
-(7, 'RH-7', 'adv-7-des', 'adv-7-syn', 'adv-7-sum', 'adv-7-sol', 1, '2017-09-22 12:00:00-07', '2017-09-22 12:00:00-07', 'url7'),
-(8, 'RH-8', 'adv-8-des', 'adv-8-syn', 'adv-8-sum', 'adv-8-sol', 2, '2016-09-22 12:00:00-08', '2018-09-22 12:00:00-08', 'url8');
+                               public_date, modified_date, url, severity_id) VALUES
+(1, 'RH-1', 'adv-1-des', 'adv-1-syn', 'adv-1-sum', 'adv-1-sol', 1, '2016-09-22 12:00:00-04', '2017-09-22 12:00:00-04', 'url1', NULL),
+(2, 'RH-2', 'adv-2-des', 'adv-2-syn', 'adv-2-sum', 'adv-2-sol', 2, '2016-09-22 12:00:00-04', '2017-09-22 12:00:00-04', 'url2', NULL),
+(3, 'RH-3', 'adv-3-des', 'adv-3-syn', 'adv-3-sum', 'adv-3-sol', 3, '2016-09-22 12:00:00-04', '2017-09-22 12:00:00-04', 'url3', 2),
+(4, 'RH-4', 'adv-4-des', 'adv-4-syn', 'adv-4-sum', 'adv-4-sol', 1, '2016-09-22 12:00:00-04', '2017-09-22 12:00:00-04', 'url4', NULL),
+(5, 'RH-5', 'adv-5-des', 'adv-5-syn', 'adv-5-sum', 'adv-5-sol', 2, '2016-09-22 12:00:00-05', '2017-09-22 12:00:00-05', 'url5', NULL),
+(6, 'RH-6', 'adv-6-des', 'adv-6-syn', 'adv-6-sum', 'adv-6-sol', 3, '2016-09-22 12:00:00-06', '2017-09-22 12:00:00-06', 'url6', 4),
+(7, 'RH-7', 'adv-7-des', 'adv-7-syn', 'adv-7-sum', 'adv-7-sol', 1, '2017-09-22 12:00:00-07', '2017-09-22 12:00:00-07', 'url7', NULL),
+(8, 'RH-8', 'adv-8-des', 'adv-8-syn', 'adv-8-sum', 'adv-8-sol', 2, '2016-09-22 12:00:00-08', '2018-09-22 12:00:00-08', 'url8', NULL);
 
 INSERT INTO system_advisories (system_id, advisory_id, first_reported, when_patched, status_id) VALUES
 (0, 1, '2016-09-22 12:00:00-04', NULL, 0),

--- a/vmaas_sync/advisory_sync.go
+++ b/vmaas_sync/advisory_sync.go
@@ -87,9 +87,9 @@ func parseAdvisories(data map[string]vmaas.ErrataResponseErrataList) (models.Adv
 			utils.Log().Error("An advisory without description or summary")
 			continue
 		}
-		severityID := 0
-		if v.Severity != "" {
-			severityID = severities[strings.ToLower(v.Severity)]
+		var severityID *int
+		if id, has := severities[strings.ToLower(v.Severity)]; has {
+			severityID = &id
 		}
 
 		advisory := models.AdvisoryMetadata{


### PR DESCRIPTION
Sync advisory severity from vmaas.
- After internal discussion interprets `None` as null. Provides only index in the frontend, since strings will always be translated.