### PR TITLE
Fix openshift templates

### DIFF
--- a/openshift/deploy/listener.yml
+++ b/openshift/deploy/listener.yml
@@ -48,7 +48,8 @@ objects:
                 - { name: LOG_LEVEL, value: debug }
                 - { name: LOG_STYLE, value: plain }
                 - { name: GIN_MODE, value: release }
-                - { name: GOMAXPROCS, value: 8 }
+                - { name: CONSUMER_COUNT, value: "8" }
+                - { name: GOMAXPROCS, value: "8" }
 
                 - { name: KAFKA_ADDRESS, value: "${KAFKA_ADDRESS}" }
                 - { name: KAFKA_GROUP, value: patchman }

--- a/openshift/deploy/manager.yml
+++ b/openshift/deploy/manager.yml
@@ -43,7 +43,7 @@ objects:
                 - { name: LOG_LEVEL, value: debug }
                 - { name: LOG_STYLE, value: plain }
                 - { name: GIN_MODE, value: release }
-                - { name: GOMAXPROCS, value: 8 }
+                - { name: GOMAXPROCS, value: "8" }
 
                 - { name: DB_TYPE, value: postgres }
                 - { name: DB_HOST, value: patchman-engine-database }

--- a/openshift/deploy/vmaas_sync.yml
+++ b/openshift/deploy/vmaas_sync.yml
@@ -45,8 +45,7 @@ objects:
                 - { name: LOG_LEVEL, value: debug }
                 - { name: LOG_STYLE, value: plain }
                 - { name: GIN_MODE, value: release }
-                - { name: CONSUMER_COUNT, value: 8 }
-                - { name: GOMAXPROCS, value: 8 }
+                - { name: GOMAXPROCS, value: "8" }
                 - { name: VMAAS_ADDRESS, value: "${VMAAS_ADDRESS}"}
                 - { name: VMAAS_WS_ADDRESS, value: "${VMAAS_WS_ADDRESS}"}
 

--- a/openshift/deploy/vmaas_sync.yml
+++ b/openshift/deploy/vmaas_sync.yml
@@ -45,6 +45,7 @@ objects:
                 - { name: LOG_LEVEL, value: debug }
                 - { name: LOG_STYLE, value: plain }
                 - { name: GIN_MODE, value: release }
+                - { name: CONSUMER_COUNT, value: 8 }
                 - { name: GOMAXPROCS, value: 8 }
                 - { name: VMAAS_ADDRESS, value: "${VMAAS_ADDRESS}"}
                 - { name: VMAAS_WS_ADDRESS, value: "${VMAAS_WS_ADDRESS}"}


### PR DESCRIPTION
- Env variables must be string
- missed default consumer count from listener