### PR TITLE
Fix advisory counts per type in advisory/id/systems

### DIFF
--- a/manager/controllers/advisory_systems.go
+++ b/manager/controllers/advisory_systems.go
@@ -118,9 +118,12 @@ func buildAdvisorySystemsData(dbItems *[]models.SystemPlatform) *[]SystemItem {
 			ID:   model.InventoryID,
 			Type: "system",
 			Attributes: SystemItemAttributes{
-				LastUpload: model.LastUpload,
-				Enabled:    !model.OptOut,
-				RhsaCount:  model.AdvisoryCountCache,
+				LastEvaluation: model.LastEvaluation,
+				LastUpload:     model.LastUpload,
+				RhsaCount:      model.AdvisorySecCountCache,
+				RhbaCount:      model.AdvisoryBugCountCache,
+				RheaCount:      model.AdvisoryEnhCountCache,
+				Enabled:        !model.OptOut,
 			}}
 		data[i] = item
 	}

--- a/manager/controllers/advisory_systems_test.go
+++ b/manager/controllers/advisory_systems_test.go
@@ -26,7 +26,9 @@ func TestAdvisorySystemsDefault(t *testing.T) { //nolint:dupl
 	assert.Equal(t, "system", output.Data[0].Type)
 	assert.Equal(t, "2018-09-22 16:00:00 +0000 UTC", output.Data[0].Attributes.LastUpload.String())
 	assert.Equal(t, true, output.Data[0].Attributes.Enabled)
-	assert.Equal(t, 8, output.Data[0].Attributes.RhsaCount)
+	assert.Equal(t, 2, output.Data[0].Attributes.RhsaCount)
+	assert.Equal(t, 3, output.Data[0].Attributes.RhbaCount)
+	assert.Equal(t, 3, output.Data[0].Attributes.RheaCount)
 	assert.Equal(t, 0, output.Meta.Page)
 }
 
@@ -46,7 +48,9 @@ func TestAdvisorySystemsOffsetLimit(t *testing.T) { //nolint:dupl
 	assert.Equal(t, "system", output.Data[0].Type)
 	assert.Equal(t, "2018-09-22 16:00:00 +0000 UTC", output.Data[0].Attributes.LastUpload.String())
 	assert.Equal(t, true, output.Data[0].Attributes.Enabled)
-	assert.Equal(t, 1, output.Data[0].Attributes.RhsaCount)
+	assert.Equal(t, 0, output.Data[0].Attributes.RhsaCount)
+	assert.Equal(t, 1, output.Data[0].Attributes.RheaCount)
+	assert.Equal(t, 0, output.Data[0].Attributes.RhbaCount)
 	assert.Equal(t, 1, output.Meta.Page)
 }
 


### PR DESCRIPTION
Data provided in `/advisoies/:id/systems` was invalid.