### PR TITLE
Make advisories sortable by type

### DIFF
--- a/manager/controllers/advisories.go
+++ b/manager/controllers/advisories.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-var AdvisoriesSortFields = []string{"name", "description", "synopsis", "summary", "solution", "public_date"}
+var AdvisoriesSortFields = []string{"type", "synopsis", "public_date"}
 
 type AdvisoriesResponse struct {
 	Data  []AdvisoryItem `json:"data"`
@@ -37,7 +37,7 @@ type AdvisoryWithApplicableSystems struct {
 // @Produce  json
 // @Param    limit          query   int     false   "Limit for paging"
 // @Param    offset         query   int     false   "Offset for paging"
-// @Param    sort           query   string  false   "Sort field"    Enums(name,description,synopsis,summary,solution,public_date)
+// @Param    sort           query   string  false   "Sort field"    Enums(id,type,synopsis,public_date)
 // @Success 200 {object} AdvisoriesResponse
 // @Router /api/patch/v1/advisories [get]
 func AdvisoriesListHandler(c *gin.Context) {
@@ -90,7 +90,7 @@ func AdvisoriesListHandler(c *gin.Context) {
 func buildQueryAdvisories(account string) *gorm.DB {
 	query := database.Db.Table("advisory_metadata am").
 		Select("am.id AS id, am.name AS name, COALESCE(systems_affected, 0) AS applicable_systems,"+
-			"synopsis,description, public_date, advisory_type_id").
+			"synopsis,description, public_date, advisory_type_id, advisory_type_id as type").
 		Joins("LEFT JOIN advisory_account_data aad ON am.id = aad.advisory_id").
 		Joins("LEFT JOIN rh_account ra ON aad.rh_account_id = ra.id").
 		Where("ra.name = ? OR ra.name IS NULL", account)

--- a/manager/controllers/advisory_systems.go
+++ b/manager/controllers/advisory_systems.go
@@ -39,7 +39,7 @@ type AdvisorySystemsMeta struct {
 // @Param    advisory_id    path    string  true    "Advisory ID"
 // @Param    limit          query   int     false   "Limit for paging"
 // @Param    offset         query   int     false   "Offset for paging"
-// @Param    sort           query   string  false   "Sort field"    Enums(last_updated, last_evaluation)
+// @Param    sort           query   string  false   "Sort field"    Enums(id,last_updated,last_evaluation)
 // @Success 200 {object} AdvisorySystemsResponse
 // @Router /api/patch/v1/advisories/{advisory_id}/systems [get]
 func AdvisorySystemsListHandler(c *gin.Context) {

--- a/manager/controllers/system_advisories.go
+++ b/manager/controllers/system_advisories.go
@@ -27,7 +27,7 @@ type SystemAdvisoriesResponse struct {
 // @Param    inventory_id   path    string  true    "Inventory ID"
 // @Param    limit          query   int     false   "Limit for paging"
 // @Param    offset         query   int     false   "Offset for paging"
-// @Param    sort           query   string  false   "Sort field"    Enums(name,description,synopsis,summary,solution,public_date)
+// @Param    sort           query   string  false   "Sort field"    Enums(id,type,synopsis,public_date)
 // @Success 200 {object} SystemAdvisoriesResponse
 // @Router /api/patch/v1/systems/{inventory_id}/advisories [get]
 func SystemAdvisoriesHandler(c *gin.Context) {
@@ -46,7 +46,7 @@ func SystemAdvisoriesHandler(c *gin.Context) {
 	}
 
 	query := database.SystemAdvisoriesQueryName(database.Db, inventoryID).
-		Select("am.*").
+		Select("am.*, advisory_type_id as type").
 		Joins("inner join rh_account ra on sp.rh_account_id = ra.id").
 		Where("ra.name = ?", account)
 

--- a/manager/controllers/systems.go
+++ b/manager/controllers/systems.go
@@ -38,7 +38,7 @@ type SystemsMeta struct {
 // @Produce  json
 // @Param    limit          query   int     false   "Limit for paging"
 // @Param    offset         query   int     false   "Offset for paging"
-// @Param    sort           query   string  false   "Sort field"    Enums(last_updated, last_evaluation)
+// @Param    sort           query   string  false   "Sort field"    Enums(id,last_updated,last_evaluation)
 // @Success 200 {object} SystemsResponse
 // @Router /api/patch/v1/systems [get]
 func SystemsListHandler(c *gin.Context) {


### PR DESCRIPTION
- Remove description, summary from sort fields
- Add type to sort keys for advisories
- Add `id` sort key to openapi doc