### PR TITLE
Use custom tag to denote struct queries

### DIFF
--- a/base/database/query.go
+++ b/base/database/query.go
@@ -1,0 +1,89 @@
+package database
+
+import (
+	"fmt"
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+type AttrName = string
+type AttrQuery = string
+
+// Used to store field name => sql query mapping
+type AttrMap = map[AttrName]AttrQuery
+
+var ColumnNameRe = regexp.MustCompile(`column:(<[\w]+)`)
+
+func MustGetSelect(t interface{}) string {
+	// We must get fields ordered, so we assemble them in proper order for gorm select
+	attrs, names, err := GetQueryAttrs(t)
+	if err != nil {
+		panic(err)
+	}
+	fields := make([]string, 0, len(names))
+	for _, n := range names {
+		fields = append(fields, fmt.Sprintf("%v as %v", attrs[n], n))
+	}
+	return strings.Join(fields, ",")
+}
+
+func getQueryFromTags(v reflect.Type) (AttrMap, []AttrName, error) {
+	if v.Kind() != reflect.Struct {
+		return nil, nil, errors.New("Only struct kind is supported")
+	}
+	res := AttrMap{}
+	var resNames []AttrName
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		// Parse from nested struct fields
+		if field.Type.Kind() == reflect.Struct && field.Name == field.Type.Name() {
+			nested, names, err := getQueryFromTags(field.Type)
+			if err != nil {
+				return nil, nil, err
+			}
+			resNames = append(resNames, names...)
+			for k, v := range nested {
+				res[k] = v
+			}
+		} else {
+			columnName := gorm.ToColumnName(field.Name)
+			if expr, has := field.Tag.Lookup("gorm"); has {
+				match := ColumnNameRe.FindStringSubmatch(expr)
+				if len(match) > 0 {
+					columnName = match[1]
+				}
+			}
+
+			if expr, has := field.Tag.Lookup("query"); has {
+				res[columnName] = expr
+			} else {
+				// If we dont have expr, we just use raw column name
+				res[columnName] = columnName
+			}
+			// Result HAS to contain all columns, because gorm loads by index, not by name
+			resNames = append(resNames, columnName)
+		}
+	}
+	return res, resNames, nil
+}
+
+func GetQueryAttrs(s interface{}) (AttrMap, []string, error) {
+	v := reflect.ValueOf(s)
+	if v.Kind() == reflect.Struct {
+		return getQueryFromTags(v.Type())
+	} else if v.Kind() == reflect.Ptr || v.Kind() == reflect.Slice {
+		return getQueryFromTags(v.Elem().Type())
+	}
+	return nil, nil, errors.New("Invalid type")
+}
+
+func MustGetQueryAttrs(s interface{}) AttrMap {
+	res, _, err := GetQueryAttrs(s)
+	if err != nil {
+		panic(err)
+	}
+	return res
+}

--- a/base/database/query.go
+++ b/base/database/query.go
@@ -15,7 +15,7 @@ type AttrQuery = string
 // Used to store field name => sql query mapping
 type AttrMap = map[AttrName]AttrQuery
 
-var ColumnNameRe = regexp.MustCompile(`column:(<[\w]+)`)
+var ColumnNameRe = regexp.MustCompile(`column:([\w_]+)`)
 
 func MustGetSelect(t interface{}) string {
 	// We must get fields ordered, so we assemble them in proper order for gorm select
@@ -27,7 +27,7 @@ func MustGetSelect(t interface{}) string {
 	for _, n := range names {
 		fields = append(fields, fmt.Sprintf("%v as %v", attrs[n], n))
 	}
-	return strings.Join(fields, ",")
+	return strings.Join(fields, ", ")
 }
 
 func getQueryFromTags(v reflect.Type) (AttrMap, []AttrName, error) {
@@ -75,7 +75,7 @@ func GetQueryAttrs(s interface{}) (AttrMap, []string, error) {
 	if v.Kind() == reflect.Struct {
 		return getQueryFromTags(v.Type())
 	} else if v.Kind() == reflect.Ptr || v.Kind() == reflect.Slice {
-		return getQueryFromTags(v.Elem().Type())
+		return getQueryFromTags(v.Type().Elem())
 	}
 	return nil, nil, errors.New("Invalid type")
 }

--- a/base/database/query_test.go
+++ b/base/database/query_test.go
@@ -1,0 +1,51 @@
+package database
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type Inherited struct {
+	Bare string
+}
+type queryStruct struct {
+	ID int `query:"am.id"`
+	// We have to take gorm column name into account
+	Note string `gorm:"column:note_str" query:"COALESCE(am.text_note, '')"`
+	Inherited
+}
+
+func testQueryAttrsOk(t *testing.T, v interface{}) {
+	attrs, named, err := GetQueryAttrs(v)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(named))
+	assert.Equal(t, []string{"id", "note_str", "bare"}, named)
+	assert.Equal(t, "am.id", attrs["id"])
+	assert.Equal(t, "COALESCE(am.text_note, '')", attrs["note_str"])
+	assert.Equal(t, "bare", attrs["bare"])
+}
+
+func TestGetAttrs(t *testing.T) {
+	testQueryAttrsOk(t, queryStruct{})
+	testQueryAttrsOk(t, &queryStruct{})
+	testQueryAttrsOk(t, []queryStruct{})
+
+	_, _, err := GetQueryAttrs([]string{})
+	assert.Error(t, err)
+
+	assert.NotPanics(t, func() {
+		MustGetSelect(queryStruct{})
+		MustGetQueryAttrs(queryStruct{})
+	})
+	assert.Panics(t, func() {
+		MustGetQueryAttrs([]string{})
+	})
+	assert.Panics(t, func() {
+		MustGetSelect([]string{})
+	})
+}
+
+func TestSelect(t *testing.T) {
+	sel := MustGetSelect(queryStruct{})
+	assert.Equal(t, "am.id as id, COALESCE(am.text_note, '') as note_str, bare as bare", sel)
+}

--- a/manager/controllers/advisories_test.go
+++ b/manager/controllers/advisories_test.go
@@ -29,7 +29,7 @@ func testAdvisoriesOk(t *testing.T, method, url string, check func(out Advisorie
 func TestAdvisoriesDefault(t *testing.T) {
 	testAdvisoriesOk(t, "GET", "/", func(output AdvisoriesResponse) {
 		assert.Equal(t, 8, len(output.Data))
-		assert.Equal(t, "RH-1", output.Data[0].ID)
+		assert.Equal(t, "RH-1", output.Data[0].ID, output.Data[0])
 		assert.Equal(t, "advisory", output.Data[0].Type)
 		assert.Equal(t, "2016-09-22 16:00:00 +0000 UTC", output.Data[0].Attributes.PublicDate.String())
 		assert.Equal(t, "adv-1-des", output.Data[0].Attributes.Description)

--- a/manager/controllers/filter.go
+++ b/manager/controllers/filter.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"app/base/database"
 	"fmt"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -44,7 +45,7 @@ func ParseFilterValue(field string, val string) (Filter, error) {
 }
 
 // Convert a single filter to where clauses
-func (t *Filter) ToWhere(attributes AttrMap) (string, []interface{}, error) {
+func (t *Filter) ToWhere(attributes database.AttrMap) (string, []interface{}, error) {
 	// Gorm deals with interface{} but for ease of use we only use strings
 	var values = make([]interface{}, len(t.Values))
 	for i, v := range t.Values {
@@ -98,7 +99,7 @@ func (t *Filters) ToMetaMap() map[string]FilterData {
 	return res
 }
 
-func (t *Filters) Apply(tx *gorm.DB, fields AttrMap) (*gorm.DB, error) {
+func (t *Filters) Apply(tx *gorm.DB, fields database.AttrMap) (*gorm.DB, error) {
 	for _, f := range *t {
 		query, args, err := f.ToWhere(fields)
 		if err != nil {

--- a/manager/controllers/filter_test.go
+++ b/manager/controllers/filter_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"app/base/database"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -46,7 +47,7 @@ func TestFilterToSql(t *testing.T) {
 	for i, f := range testFilters {
 		filter, err := ParseFilterValue("test", f)
 		assert.Equal(t, nil, err)
-		query, _, err := filter.ToWhere(AttrMap{"test": "test"})
+		query, _, err := filter.ToWhere(database.AttrMap{"test": "test"})
 		assert.Equal(t, nil, err)
 		assert.Equal(t, queries[i], query)
 	}
@@ -64,7 +65,7 @@ func TestFilterToSqlAdvanced(t *testing.T) {
 	for i, f := range testFilters {
 		filter, err := ParseFilterValue("test", f)
 		assert.Equal(t, nil, err)
-		query, _, err := filter.ToWhere(AttrMap{"test": "(NOT test)"})
+		query, _, err := filter.ToWhere(database.AttrMap{"test": "(NOT test)"})
 		assert.Equal(t, nil, err)
 		assert.Equal(t, queries[i], query)
 	}

--- a/manager/controllers/structures.go
+++ b/manager/controllers/structures.go
@@ -1,9 +1,5 @@
 package controllers
 
-import (
-	"time"
-)
-
 type Links struct {
 	First    string  `json:"first"`
 	Last     string  `json:"last"`
@@ -20,44 +16,4 @@ type ListMeta struct {
 	Sort       []string              `json:"sort"`
 	Filter     map[string]FilterData `json:"filter"`
 	TotalItems int                   `json:"total_items"`
-}
-
-type SystemAdvisoryItem struct {
-	Attributes SystemAdvisoryItemAttributes `json:"attributes"`
-	ID         string                       `json:"id"`
-	Type       string                       `json:"type"`
-}
-
-type SystemAdvisoryItemAttributes struct {
-	Description  string    `json:"description"`
-	PublicDate   time.Time `json:"public_date"`
-	Synopsis     string    `json:"synopsis"`
-	AdvisoryType int       `json:"advisory_type"`
-	Severity     *int      `json:"severity,omitempty"`
-}
-
-type AdvisoryItem struct {
-	Attributes AdvisoryItemAttributes `json:"attributes"`
-	ID         string                 `json:"id"`
-	Type       string                 `json:"type"`
-}
-
-type AdvisoryItemAttributes struct {
-	SystemAdvisoryItemAttributes
-	ApplicableSystems int `json:"applicable_systems"`
-}
-
-type SystemItem struct {
-	Attributes SystemItemAttributes `json:"attributes"`
-	ID         string               `json:"id"`
-	Type       string               `json:"type"`
-}
-
-type SystemItemAttributes struct {
-	LastEvaluation *time.Time `json:"last_evaluation"`
-	LastUpload     *time.Time `json:"last_upload"`
-	RhsaCount      int        `json:"rhsa_count"`
-	RhbaCount      int        `json:"rhba_count"`
-	RheaCount      int        `json:"rhea_count"`
-	Enabled        bool       `json:"enabled"`
 }


### PR DESCRIPTION
Reworks the filter & sort implementation, so that SQL column definitions are stored along with structs which will be retrieved from database

Also avoids loading whole models. Instead loads just structs which will be returned from the API.