### PR TITLE
Fix optTimestampParse

### DIFF
--- a/listener/upload.go
+++ b/listener/upload.go
@@ -74,7 +74,7 @@ func getOrCreateAccount(account string) (int, error) {
 }
 
 func optParseTimestamp(t *string) *time.Time {
-	if t == nil || len(*t) > 0 {
+	if t == nil || len(*t) == 0 {
 		return nil
 	}
 	v, err := time.Parse(base.Rfc3339NoTz, *t)


### PR DESCRIPTION
Contained an error, which resulted in always returning null, and because of thad not saving culling info into the database.