### PR TITLE
Change max buffer size for kafka consumer

### DIFF
--- a/base/mqueue/mqueue.go
+++ b/base/mqueue/mqueue.go
@@ -35,7 +35,7 @@ func ReaderFromEnv(topic string) Reader {
 		Topic:    topic,
 		GroupID:  kafkaGroup,
 		MinBytes: 1,
-		MaxBytes: 10e6, // 1MB
+		MaxBytes: 1e6, // 1MB
 		ErrorLogger: kafka.LoggerFunc(func(fmt string, args ...interface{}) {
 			utils.Log("type", "kafka").Errorf(fmt, args)
 		}),


### PR DESCRIPTION
The issues in QA environment were probably caused by loading too many messages.

+ 8 consumers  = 8 x 10MB = 80MB in raw buffers
+ deserialized = 2 x 80MB = 160MB in just the data size.

With GOGC being 100 by default, go will allocate 100% of previous memory snapshot before forcing a GC. which will result in 320 MB peak ram. 

320MB + our base memory experienced by listener with no load = 320MB + 30MB = 350MB, just what we experienced.


With max buffer of 1MB per listener:

8 x 1MB = 8MB ...  max buffers
2x 8MB = 16MB ... buffers + deserialized
2x 16MB = 32MB .... Peak before GC

32MB + 30 MB = 80MB , we should be under 128 MB resource limit.
