### PR TITLE
Handle panics + log errors explicitly

### DIFF
--- a/base/mqueue/mqueue.go
+++ b/base/mqueue/mqueue.go
@@ -109,6 +109,7 @@ func (t *readerImpl) HandleMessages(handler MessageHandler) {
 type CreateReader func(topic string) Reader
 
 func RunReader(topic string, createReader CreateReader, msgHandler MessageHandler) {
+	defer utils.LogPanicsAndExit()
 	reader := createReader(topic)
 	defer reader.Close()
 	reader.HandleMessages(msgHandler)

--- a/base/utils/awscloudwatch.go
+++ b/base/utils/awscloudwatch.go
@@ -13,6 +13,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var hook *lc.Hook
+
 // Try to init CloudWatch logging
 func trySetupCloudWatchLogging() {
 	key := os.Getenv("CW_AWS_ACCESS_KEY_ID")
@@ -42,11 +44,17 @@ func trySetupCloudWatchLogging() {
 
 	cred := credentials.NewStaticCredentials(key, secret, "")
 	awsconf := aws.NewConfig().WithRegion(region).WithCredentials(cred)
-	hook, err := lc.NewBatchingHook(group, hostname, awsconf, 10*time.Second)
+	hook, err = lc.NewBatchingHook(group, hostname, awsconf, 10*time.Second)
 	if err != nil {
 		Log("err", err.Error()).Error("unable to setup CloudWatch logging")
 		return
 	}
 	log.AddHook(hook)
 	log.Info("CloudWatch logging configured")
+}
+
+func FlushLogs() {
+	if hook != nil {
+		_ = hook.Flush()
+	}
 }

--- a/base/utils/core.go
+++ b/base/utils/core.go
@@ -5,7 +5,9 @@ import (
 	"github.com/joho/godotenv"
 	"os"
 	"path"
+	"runtime/debug"
 	"strconv"
+	"strings"
 )
 
 // load environment variable or return default value
@@ -94,4 +96,21 @@ func TestLoadEnv(files ...string) {
 	if err != nil {
 		Log().Panic("Could not load env file")
 	}
+}
+
+// Catches panics, and logs them to stderr, then performs onRecover
+func LogPanics(onRecover func()) {
+	if obj := recover(); obj != nil {
+		stack := string(debug.Stack())
+		stackLine := strings.Replace(stack, "\n", "|", -1)
+		Log("err", obj, "stack", stackLine).Error("Panicked")
+		FlushLogs()
+		onRecover()
+	}
+}
+
+func LogPanicsAndExit() {
+	LogPanics(func() {
+		os.Exit(1)
+	})
 }

--- a/base/utils/core_test.go
+++ b/base/utils/core_test.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRecoverAndLogPanics(t *testing.T) {
+	ConfigureLogging()
+
+	logHook := NewTestLogHook()
+	log.AddHook(logHook)
+
+	func() {
+		defer LogPanics(func() {
+
+		})
+
+		panic("We crashed")
+	}()
+
+	assert.Equal(t, 1, len(logHook.LogEntries))
+}

--- a/base/utils/identity_test.go
+++ b/base/utils/identity_test.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 

--- a/base/utils/rpm_test.go
+++ b/base/utils/rpm_test.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/RedHatInsights/patchman-clients/vmaas v0.0.0-20200211092138-af3af42fd699
 	github.com/antihax/optional v1.0.0
 	github.com/aws/aws-sdk-go v1.29.34
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/getkin/kin-openapi v0.3.0
 	github.com/gin-contrib/gzip v0.0.1
 	github.com/gin-gonic/gin v1.5.0
@@ -21,7 +20,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.5.1
-	github.com/redhatinsights/platform-go-middlewares v0.7.0
+	github.com/redhatinsights/platform-go-middlewares v0.7.1-0.20200306140908-92eb73ca70be
 	github.com/segmentio/kafka-go v0.3.5
 	github.com/sirupsen/logrus v1.5.0
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhatinsights/platform-go-middlewares v0.7.0 h1:1prVr6XxYHSKThfblJr3kaLecD/6s4xaQ9zZ+BKhHJM=
 github.com/redhatinsights/platform-go-middlewares v0.7.0/go.mod h1:g//UN9p5sxgIoZfRyyiRy+rAw1/GMqkZ4hWUFcEC71A=
+github.com/redhatinsights/platform-go-middlewares v0.7.1-0.20200306140908-92eb73ca70be h1:TrRdMm0dr5l/+d3C7IpT1tao3VnTdCQTOITd9tAtlvY=
+github.com/redhatinsights/platform-go-middlewares v0.7.1-0.20200306140908-92eb73ca70be/go.mod h1:g//UN9p5sxgIoZfRyyiRy+rAw1/GMqkZ4hWUFcEC71A=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=

--- a/listener/listener_test.go
+++ b/listener/listener_test.go
@@ -2,7 +2,7 @@ package listener
 
 import (
 	"app/base/mqueue"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"app/base"
 	"app/base/core"
+	"app/base/utils"
 	"app/database_admin"
 	"app/evaluator"
 	"app/listener"
@@ -16,6 +17,7 @@ func main() {
 	base.HandleSignals()
 	core.ConfigureApp()
 
+	defer utils.LogPanicsAndExit()
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "manager":

--- a/vmaas_sync/metrics.go
+++ b/vmaas_sync/metrics.go
@@ -82,6 +82,8 @@ func RunMetrics() {
 }
 
 func runAdvancedMetricsUpdating() {
+	defer utils.LogPanicsAndExit()
+
 	utils.Log().Info("started advanced metrics updating")
 	for {
 		update()

--- a/vmaas_sync/system_culling.go
+++ b/vmaas_sync/system_culling.go
@@ -8,6 +8,8 @@ import (
 )
 
 func RunSystemCulling() {
+	defer utils.LogPanicsAndExit()
+
 	ticker := time.NewTicker(time.Minute * 10)
 
 	for {


### PR DESCRIPTION
This should allow us to see fatal errors in external logging such as cloudwatch.

This is only a temporary solution, since panics happening in other goroutines will still just tear down the whole process.
