### PR TITLE
Move to host-egress queue

### DIFF
--- a/base/mqueue/mqueue.go
+++ b/base/mqueue/mqueue.go
@@ -10,7 +10,7 @@ import (
 
 // By wrapping raw value we can add new methods & ensure methods of wrapped type are callable
 type Reader interface {
-	HandleEvents(handler EventHandler)
+	HandleMessages(handler MessageHandler)
 	io.Closer
 }
 
@@ -19,7 +19,7 @@ type readerImpl struct {
 }
 
 type Writer interface {
-	WriteEvents(ctx context.Context, events ...PlatformEvent) error
+	WriteMessages(ctx context.Context, msgs ...kafka.Message) error
 }
 
 type writerImpl struct {
@@ -59,9 +59,9 @@ func WriterFromEnv(topic string) Writer {
 	return writer
 }
 
-type KafkaHandler func(message kafka.Message)
+type MessageHandler func(message kafka.Message)
 
-func (t *readerImpl) HandleMessages(handler KafkaHandler) {
+func (t *readerImpl) HandleMessages(handler MessageHandler) {
 	ctx := context.Background()
 
 	for {
@@ -82,8 +82,8 @@ func (t *readerImpl) HandleMessages(handler KafkaHandler) {
 
 type CreateReader func(topic string) Reader
 
-func RunReader(topic string, createReader CreateReader, eventHandler EventHandler) {
+func RunReader(topic string, createReader CreateReader, msgHandler MessageHandler) {
 	reader := createReader(topic)
 	defer reader.Close()
-	reader.HandleEvents(eventHandler)
+	reader.HandleMessages(msgHandler)
 }

--- a/base/mqueue/testing.go
+++ b/base/mqueue/testing.go
@@ -2,8 +2,8 @@ package mqueue
 
 type mockReader struct{}
 
-func (t *mockReader) HandleEvents(_ EventHandler) {}
-func (t *mockReader) Close() error                { return nil }
+func (t *mockReader) HandleMessages(_ MessageHandler) {}
+func (t *mockReader) Close() error                    { return nil }
 
 // Count how many times reader is created.
 func CreateCountedMockReader(cnt *int) CreateReader {

--- a/conf/evaluator_common.env
+++ b/conf/evaluator_common.env
@@ -1,8 +1,5 @@
 KAFKA_ADDRESS=platform:9092
 KAFKA_GROUP=patchman
 
-# Platform is mocking the inventory
-INVENTORY_ADDRESS=http://platform:9001
-
 DB_USER=evaluator
 DB_PASSWD=evaluator

--- a/conf/listener.env
+++ b/conf/listener.env
@@ -2,13 +2,10 @@ KAFKA_ADDRESS=platform:9092
 KAFKA_GROUP=patchman
 CONSUMER_COUNT=8
 
-UPLOAD_TOPIC=platform.upload.available
+UPLOAD_TOPIC=platform.inventory.host-egress
 EVENTS_TOPIC=platform.inventory.events
 EVAL_TOPIC=patchman.evaluator.upload
 
-
-# Platform is mocking the inventory
-INVENTORY_ADDRESS=http://platform:9001
 
 DB_USER=listener
 DB_PASSWD=listener

--- a/conf/test.env
+++ b/conf/test.env
@@ -15,7 +15,7 @@ CONSUMER_COUNT=8
 
 KAFKA_ADDRESS=platform:9092
 KAFKA_GROUP=patchman
-UPLOAD_TOPIC=platform.upload.available
+UPLOAD_TOPIC=platform.inventory.host-egress
 EVENTS_TOPIC=platform.inventory.events
 EVAL_TOPIC=patchman.evaluator.upload
 EVAL_LABEL=upload

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -394,7 +394,7 @@ func run(readerBuilder mqueue.CreateReader) {
 	// We create multiple consumers, and hope that the partition rebalancing
 	// algorithm assigns each consumer a single partition
 	for i := 0; i < consumerCount; i++ {
-		go mqueue.RunReader(evalTopic, readerBuilder, evaluateHandler)
+		go mqueue.RunReader(evalTopic, readerBuilder, mqueue.MakeMessageHandler(evaluateHandler))
 	}
 }
 

--- a/listener/delete.go
+++ b/listener/delete.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+var DeleteMessageHandler = mqueue.MakeMessageHandler(deleteHandler)
+
 func deleteHandler(event mqueue.PlatformEvent) {
 	tStart := time.Now()
 	defer utils.ObserveSecondsSince(tStart, messageHandlingDuration.WithLabelValues(EventDelete))

--- a/listener/delete_test.go
+++ b/listener/delete_test.go
@@ -12,11 +12,11 @@ func TestDeleteSystem(t *testing.T) {
 	configure()
 
 	deleteData(t)
-	uploadEvent := createTestUploadEvent(t, id)
+	uploadEvent := createTestUploadEvent(id, true)
 	uploadHandler(uploadEvent)
 	assertSystemInDb(t, id, nil)
 
-	deleteEvent := createTestDeleteEvent(t)
+	deleteEvent := createTestDeleteEvent(id)
 	deleteHandler(deleteEvent)
 	assertSystemNotInDb(t)
 }

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -1,18 +1,15 @@
 package listener
 
 import (
-	"app/base"
 	"app/base/mqueue"
 	"app/base/utils"
-	"github.com/RedHatInsights/patchman-clients/inventory"
 )
 
 var (
-	uploadTopic     string
-	eventsTopic     string
-	consumerCount   int
-	evalWriter      mqueue.Writer
-	inventoryClient *inventory.APIClient
+	uploadTopic   string
+	eventsTopic   string
+	consumerCount int
+	evalWriter    mqueue.Writer
 )
 
 func configure() {
@@ -24,15 +21,6 @@ func configure() {
 	evalTopic := utils.GetenvOrFail("EVAL_TOPIC")
 
 	evalWriter = mqueue.WriterFromEnv(evalTopic)
-
-	traceAPI := utils.GetenvOrFail("LOG_LEVEL") == "trace"
-
-	inventoryAddr := utils.GetenvOrFail("INVENTORY_ADDRESS")
-
-	inventoryConfig := inventory.NewConfiguration()
-	inventoryConfig.Debug = traceAPI
-	inventoryConfig.BasePath = inventoryAddr + base.InventoryAPIPrefix
-	inventoryClient = inventory.NewAPIClient(inventoryConfig)
 }
 
 func runReaders(readerBuilder mqueue.CreateReader) {
@@ -46,8 +34,8 @@ func runReaders(readerBuilder mqueue.CreateReader) {
 	// We create multiple consumers, and hope that the partition rebalancing
 	// algorithm assigns each consumer a single partition
 	for i := 0; i < consumerCount; i++ {
-		go mqueue.RunReader(uploadTopic, readerBuilder, uploadHandler)
-		go mqueue.RunReader(eventsTopic, readerBuilder, deleteHandler)
+		go mqueue.RunReader(uploadTopic, readerBuilder, uploadMsgHandler)
+		go mqueue.RunReader(eventsTopic, readerBuilder, DeleteMessageHandler)
 	}
 }
 

--- a/listener/metrics.go
+++ b/listener/metrics.go
@@ -8,16 +8,15 @@ import (
 )
 
 const (
-	EventUpload                = "upload"
-	EventDelete                = "delete"
-	ReceivedSuccess            = "success"
-	ReceivedErrorIdentity      = "error-identity"
-	ReceivedErrorParsing       = "error-parsing"
-	ReceivedErrorProcessing    = "error-processing"
-	ReceivedErrorOtherType     = "error-other-type"
-	ReceivedErrorNoRows        = "error-no-rows"
-	ReceivedErrorInventoryCall = "error-inventory-call"
-	ReceivedWarnNoPackages     = "warn-no-packages"
+	EventUpload             = "upload"
+	EventDelete             = "delete"
+	ReceivedSuccess         = "success"
+	ReceivedErrorIdentity   = "error-identity"
+	ReceivedErrorParsing    = "error-parsing"
+	ReceivedErrorProcessing = "error-processing"
+	ReceivedErrorOtherType  = "error-other-type"
+	ReceivedErrorNoRows     = "error-no-rows"
+	ReceivedWarnNoPackages  = "warn-no-packages"
 )
 
 var (

--- a/platform/entrypoint.sh
+++ b/platform/entrypoint.sh
@@ -21,7 +21,7 @@ until ./kafka/bin/kafka-topics.sh --list --zookeeper localhost:2181 &> /dev/null
 done
 
 # create topics with multiple partitions for scaling
-for topic in "platform.upload.available" "platform.inventory.events" "patchman.evaluator.upload" \
+for topic in "platform.inventory.host-egress" "platform.inventory.events" "patchman.evaluator.upload" \
              "patchman.evaluator.recalc" "test"
 do
     ./kafka/bin/kafka-topics.sh --create --topic $topic --partitions 1 --zookeeper localhost:2181 --replication-factor 1

--- a/platform/inventory.go
+++ b/platform/inventory.go
@@ -30,35 +30,12 @@ var pkgs = []string{
 	"iproute-2.6.18-13.el5.i386",
 	"libbonobo-2.24.2-5.el6.i686"}
 
-func makeSystemProfile(id string) inventory.SystemProfileByHostOut {
-	_pkgs := pkgs
-	if id == "TEST-NO-PKGS" {
-		_pkgs = []string{}
-	}
-
+// Create system profile call result with paging
+func makeSystemProfileRes(id string) inventory.SystemProfileByHostOut {
 	profile := inventory.HostSystemProfileOut{
-		Id: id,
-		SystemProfile: inventory.SystemProfileIn{
-			Arch:              "i686",
-			InstalledPackages: _pkgs,
-			YumRepos: []inventory.YumRepo{
-				{
-					Id:       "repo1",
-					Name:     "Debug packages",
-					Baseurl:  "http://repo.com/$arch/$releasever/$product/repo",
-					Enabled:  true,
-					Gpgcheck: false,
-				},
-			},
-			DnfModules: []inventory.DnfModule{
-				{
-					Name:   "firefox",
-					Stream: "60",
-				},
-			},
-		},
+		Id:            id,
+		SystemProfile: makeSystemProfile(id),
 	}
-
 	return inventory.SystemProfileByHostOut{
 		Total:   1,
 		Count:   1,
@@ -68,8 +45,36 @@ func makeSystemProfile(id string) inventory.SystemProfileByHostOut {
 	}
 }
 
+// Create bare system profile
+func makeSystemProfile(id string) inventory.SystemProfileIn {
+	_pkgs := pkgs
+	if id == "TEST-NO-PKGS" {
+		_pkgs = []string{}
+	}
+
+	return inventory.SystemProfileIn{
+		Arch:              "i686",
+		InstalledPackages: _pkgs,
+		YumRepos: []inventory.YumRepo{
+			{
+				Id:       "repo1",
+				Name:     "Debug packages",
+				Baseurl:  "http://repo.com/$arch/$releasever/$product/repo",
+				Enabled:  true,
+				Gpgcheck: false,
+			},
+		},
+		DnfModules: []inventory.DnfModule{
+			{
+				Name:   "firefox",
+				Stream: "60",
+			},
+		},
+	}
+}
+
 func systemProfileHandler(c *gin.Context) {
-	c.JSON(http.StatusOK, makeSystemProfile(c.Param("host_id")))
+	c.JSON(http.StatusOK, makeSystemProfileRes(c.Param("host_id")))
 }
 
 func systemHandler(c *gin.Context) {

--- a/vmaas_sync/send_messages.go
+++ b/vmaas_sync/send_messages.go
@@ -44,7 +44,7 @@ func sendMessages(ctx context.Context, inventoryIDs ...string) {
 		}
 	}
 
-	err := evalWriter.WriteEvents(ctx, events...)
+	err := mqueue.WriteEvents(ctx, evalWriter, events...)
 	if err != nil {
 		utils.Log("err", err.Error()).Error("sending to re-evaluate failed")
 	}

--- a/vmaas_sync/vmaas_sync_test.go
+++ b/vmaas_sync/vmaas_sync_test.go
@@ -3,19 +3,19 @@ import (
 	"app/base/core"
 	"app/base/database"
 	"app/base/models"
-	"app/base/mqueue"
 	"app/base/utils"
 	"context"
+	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-var events []mqueue.PlatformEvent
+var msgs []kafka.Message
 
 type mockKafkaWriter struct{}
 
-func (t mockKafkaWriter) WriteEvents(_ context.Context, ev ...mqueue.PlatformEvent) error {
-	events = append(events, ev...)
+func (t mockKafkaWriter) WriteMessages(_ context.Context, ev ...kafka.Message) error {
+	msgs = append(msgs, ev...)
 	return nil
 }
 
@@ -33,5 +33,5 @@ func TestSync(t *testing.T) {
 	database.CheckAdvisoriesInDb(t, expected)
 	assert.Nil(t, database.Db.Unscoped().Where("name IN (?)", expected).Delete(&models.AdvisoryMetadata{}).Error)
 
-	assert.Equal(t, 12, len(events))
+	assert.Equal(t, 12, len(msgs))
 }


### PR DESCRIPTION
Allows us to not call inventory at all, we can get all the info we need from kafka messages.
- Changes `mqueue.go` to only deal with kafka messages
- `events.go` now deals with standard event format for delete and eval messages.
- `upload.go` Parses messages into custom event format
- Platform mock code now uses `map[string]interface{}` instead of string interpolation

Tied with https://github.com/RedHatInsights/e2e-deploy/pull/1124
