### PR TITLE
Always handle filters as a map

### DIFF
--- a/manager/controllers/filter_test.go
+++ b/manager/controllers/filter_test.go
@@ -28,7 +28,7 @@ func TestFilterParse(t *testing.T) {
 	}
 
 	for i, f := range testFilters {
-		filter, err := ParseFilterValue("test", f)
+		filter, err := ParseFilterValue(f)
 		assert.Equal(t, nil, err)
 		assert.Equal(t, operators[i], filter.Operator)
 		assert.Equal(t, values[i], filter.Values)
@@ -45,9 +45,9 @@ func TestFilterToSql(t *testing.T) {
 	}
 
 	for i, f := range testFilters {
-		filter, err := ParseFilterValue("test", f)
+		filter, err := ParseFilterValue(f)
 		assert.Equal(t, nil, err)
-		query, _, err := filter.ToWhere(database.AttrMap{"test": "test"})
+		query, _, err := filter.ToWhere("test", database.AttrMap{"test": "test"})
 		assert.Equal(t, nil, err)
 		assert.Equal(t, queries[i], query)
 	}
@@ -63,9 +63,9 @@ func TestFilterToSqlAdvanced(t *testing.T) {
 	}
 
 	for i, f := range testFilters {
-		filter, err := ParseFilterValue("test", f)
+		filter, err := ParseFilterValue(f)
 		assert.Equal(t, nil, err)
-		query, _, err := filter.ToWhere(database.AttrMap{"test": "(NOT test)"})
+		query, _, err := filter.ToWhere("test", database.AttrMap{"test": "(NOT test)"})
 		assert.Equal(t, nil, err)
 		assert.Equal(t, queries[i], query)
 	}

--- a/manager/controllers/utils.go
+++ b/manager/controllers/utils.go
@@ -60,14 +60,12 @@ func ApplySort(c *gin.Context, tx *gorm.DB, fieldExprs database.AttrMap) (*gorm.
 func ParseFilters(c *gin.Context, allowedFields database.AttrMap,
 	defaultFilters map[string]FilterData) (Filters, error) {
 	filters := Filters{}
+
 	// Apply default filters
 	for n, v := range defaultFilters {
-		filters = append(filters, Filter{
-
-			FieldName:  n,
-			FilterData: v,
-		})
+		filters[n] = v
 	}
+
 	// Apply query filters, if there are any
 	queryFilters, has := c.GetQueryMap("filter")
 	if !has {
@@ -77,11 +75,11 @@ func ParseFilters(c *gin.Context, allowedFields database.AttrMap,
 		if _, has := allowedFields[k]; !has {
 			return nil, errors.New(fmt.Sprintf("Invalid filter field: %v", k))
 		}
-		filter, err := ParseFilterValue(k, v)
+		filter, err := ParseFilterValue(v)
 		if err != nil {
 			return nil, err
 		}
-		filters = append(filters, filter)
+		filters[k] = filter
 	}
 	return filters, nil
 }
@@ -129,7 +127,7 @@ func ListCommon(tx *gorm.DB, c *gin.Context, path string, fields database.AttrMa
 	meta := ListMeta{
 		Limit:      limit,
 		Offset:     offset,
-		Filter:     filters.ToMetaMap(),
+		Filter:     filters,
 		Sort:       sortFields,
 		TotalItems: total,
 	}


### PR DESCRIPTION
Current code which handles filters as an array has an error, which results in default filters always being applied.

This PR changes this behavior, and always handles filters as a map keyed by field name to which a filter is applied.