### PR TITLE
Fix wrong timestamp for system culling

### DIFF
--- a/database/migrations/011_culling_timestamps.down.sql
+++ b/database/migrations/011_culling_timestamps.down.sql
@@ -1,0 +1,1 @@
+-- "no down migration"

--- a/database/migrations/011_culling_timestamps.up.sql
+++ b/database/migrations/011_culling_timestamps.up.sql
@@ -1,0 +1,26 @@
+-- mark all systems as fresh, since we had the wrong implementation for function for marking
+UPDATE system_platform
+SET stale = false;
+
+CREATE OR REPLACE FUNCTION mark_stale_systems()
+    RETURNS INTEGER
+AS
+$fun$
+DECLARE
+    marked integer;
+BEGIN
+    with updated as (UPDATE system_platform
+        SET stale = true
+        -- Systems AFTER stale_warning timestamp
+        WHERE now() > stale_warning_timestamp
+        RETURNING id
+    )
+    select count(*)
+    from updated
+    INTO marked;
+    return marked;
+END;
+$fun$ LANGUAGE plpgsql;
+
+-- Re-mark systems that have been marked as stale correctly
+SELECT * from mark_stale_systems();

--- a/database/schema/create_schema.sql
+++ b/database/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (10, false);
+VALUES (11, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -387,7 +387,8 @@ DECLARE
 BEGIN
     with updated as (UPDATE system_platform
         SET stale = true
-        WHERE stale_timestamp < now()
+        -- Systems AFTER stale_warning timestamp
+        WHERE now() > stale_warning_timestamp
         RETURNING id
     )
     select count(*)


### PR DESCRIPTION
We've used the wrong timestamp for marking systems stale.