### PR TITLE
Added repo-based re-evaluation - vmaas_sync

### DIFF
--- a/base/models/models.go
+++ b/base/models/models.go
@@ -132,7 +132,7 @@ type SystemRepoSlice []SystemRepo
 
 type TimestampKV struct {
 	Name  string
-	Value *time.Time
+	Value time.Time
 }
 
 func (TimestampKV) TableName() string {

--- a/base/models/models.go
+++ b/base/models/models.go
@@ -129,3 +129,12 @@ func (SystemRepo) TableName() string {
 }
 
 type SystemRepoSlice []SystemRepo
+
+type TimestampKV struct {
+	Name  string
+	Value *time.Time
+}
+
+func (TimestampKV) TableName() string {
+	return "timestamp_kv"
+}

--- a/base/utils/core.go
+++ b/base/utils/core.go
@@ -26,6 +26,21 @@ func GetenvOrFail(envname string) string {
 	return value
 }
 
+// parse bool value from env variable
+func GetBoolEnvOrFail(envname string) bool {
+	value := os.Getenv(envname)
+	if value == "" {
+		panic(fmt.Sprintf("Set %s env variable!", envname))
+	}
+
+	parsedBool, err := strconv.ParseBool(value)
+	if err != nil {
+		panic(err)
+	}
+
+	return parsedBool
+}
+
 // load int environment variable or fail
 func GetIntEnvOrFail(envname string) int {
 	valueStr := os.Getenv(envname)

--- a/conf/test.env
+++ b/conf/test.env
@@ -20,3 +20,5 @@ EVENTS_TOPIC=platform.inventory.events
 EVAL_TOPIC=patchman.evaluator.upload
 EVAL_LABEL=upload
 PORT=8082
+
+ENABLE_REPO_BASED_RE_EVALUATION=true

--- a/conf/vmaas_sync.env
+++ b/conf/vmaas_sync.env
@@ -4,3 +4,5 @@ DB_PASSWD=vmaas_sync
 KAFKA_ADDRESS=platform:9092
 KAFKA_GROUP=patchman
 EVAL_TOPIC=patchman.evaluator.recalc
+
+ENABLE_REPO_BASED_RE_EVALUATION=true

--- a/dev/test_data.sql
+++ b/dev/test_data.sql
@@ -63,11 +63,14 @@ INSERT INTO system_advisories (system_id, advisory_id, first_reported, when_patc
 
 INSERT INTO repo (id, name) VALUES
 (1, 'repo1'),
-(2, 'repo2');
+(2, 'repo2'),
+(3, 'repo3');
 
 INSERT INTO system_repo (system_id, repo_id) VALUES
-(2, 1),
-(3, 1);
+(1, 1),
+(2, 2),
+(5, 3),
+(6, 3);
 
 INSERT INTO timestamp_kv (name, value) VALUES
 ('last_eval_repo_based', '2018-04-05T01:23:45+02:00');

--- a/dev/test_data.sql
+++ b/dev/test_data.sql
@@ -67,10 +67,8 @@ INSERT INTO repo (id, name) VALUES
 (3, 'repo3');
 
 INSERT INTO system_repo (system_id, repo_id) VALUES
-(1, 1),
-(2, 2),
-(5, 3),
-(6, 3);
+(2, 1),
+(3, 1);
 
 INSERT INTO timestamp_kv (name, value) VALUES
 ('last_eval_repo_based', '2018-04-05T01:23:45+02:00');

--- a/platform/vmaas.go
+++ b/platform/vmaas.go
@@ -107,6 +107,20 @@ func erratasHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, data)
 }
 
+func reposHandler(c *gin.Context) {
+	data := vmaas.ReposResponse{
+		Page:     0,
+		PageSize: 3,
+		Pages:    1,
+		RepositoryList: map[string][]map[string]interface{}{
+			"repo1": make([]map[string]interface{}, 0),
+			"repo2": make([]map[string]interface{}, 0),
+			"repo3": make([]map[string]interface{}, 0),
+		},
+	}
+	c.JSON(http.StatusOK, data)
+}
+
 var upgrader = websocket.Upgrader{} // use default options
 func wshandler(w http.ResponseWriter, r *http.Request) {
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -132,6 +146,8 @@ func InitVMaaS(app *gin.Engine) {
 	app.POST("/api/v3/updates", updatesHandler)
 	// Mock erratas endpoint for VMaaS
 	app.POST("/api/v1/errata", erratasHandler)
+	// Mock repos endpoint for VMaaS
+	app.POST("/api/v1/repos", reposHandler)
 	// Mock websocket endpoint for VMaaS
 	app.GET("/ws", func(context *gin.Context) {
 		wshandler(context.Writer, context.Request)

--- a/vmaas_sync/advisory_sync.go
+++ b/vmaas_sync/advisory_sync.go
@@ -4,7 +4,6 @@ import (
 	"app/base"
 	"app/base/database"
 	"app/base/models"
-	"app/base/mqueue"
 	"app/base/utils"
 	"context"
 	"github.com/RedHatInsights/patchman-clients/vmaas"
@@ -13,27 +12,6 @@ import (
 	"strings"
 	"time"
 )
-
-// Should be < 5000
-const SyncBatchSize = 1000
-
-var (
-	vmaasClient *vmaas.APIClient
-	evalWriter  mqueue.Writer
-)
-
-func configure() {
-	traceAPI := utils.GetenvOrFail("LOG_LEVEL") == "trace"
-
-	cfg := vmaas.NewConfiguration()
-	cfg.BasePath = utils.GetenvOrFail("VMAAS_ADDRESS") + base.VMaaSAPIPrefix
-	cfg.Debug = traceAPI
-
-	vmaasClient = vmaas.NewAPIClient(cfg)
-
-	evalTopic := utils.GetenvOrFail("EVAL_TOPIC")
-	evalWriter = mqueue.WriterFromEnv(evalTopic)
-}
 
 func getAdvisoryTypes() (map[string]int, error) {
 	var advisoryTypesArr []models.AdvisoryType

--- a/vmaas_sync/repo_based.go
+++ b/vmaas_sync/repo_based.go
@@ -11,7 +11,7 @@ import (
 
 const LastEvalRepoBased = "last_eval_repo_based"
 
-func getCurrentRepoBasedInventoryIDs() (*[]string, error) {
+func getCurrentRepoBasedInventoryIDs() ([]string, error) {
 	lastRepoBaseEval, err := getLastRepobasedEvalTms()
 	if err != nil {
 		return nil, err
@@ -62,22 +62,22 @@ func updateRepoBaseEvalTimestampStr(value string) error {
 	return err
 }
 
-func getRepoBasedInventoryIDs(repos *[]string) (*[]string, error) {
+func getRepoBasedInventoryIDs(repos []string) ([]string, error) {
 	var intentoryIDs []string
 	err := database.Db.Table("system_repo sr").
 		Joins("JOIN repo ON repo.id = sr.repo_id").
 		Joins("JOIN system_platform sp ON sp.id = sr.system_id").
-		Where("repo.name IN (?)", *repos).
+		Where("repo.name IN (?)", repos).
 		Order("inventory_id ASC").
 		Pluck("inventory_id", &intentoryIDs).Error
 	if err != nil {
 		return nil, err
 	}
-	return &intentoryIDs, nil
+	return intentoryIDs, nil
 }
 
 //nolint unused
-func getUpdatedRepos(modifiedSince *time.Time) (*[]string, error) {
+func getUpdatedRepos(modifiedSince *time.Time) ([]string, error) {
 	page := float32(1)
 	var reposArr []string
 	for {
@@ -109,5 +109,5 @@ func getUpdatedRepos(modifiedSince *time.Time) (*[]string, error) {
 		page++
 	}
 
-	return &reposArr, nil
+	return reposArr, nil
 }

--- a/vmaas_sync/repo_based.go
+++ b/vmaas_sync/repo_based.go
@@ -1,0 +1,23 @@
+package vmaas_sync //nolint:golint,stylecheck
+import (
+	"app/base/database"
+	"app/base/models"
+	"time"
+)
+
+const LastEvalRepoBased = "last_eval_repo_based"
+
+func getLastRepobasedEvalTms() (*time.Time, error) {
+	var timestamps []*time.Time
+	err := database.Db.Model(&models.TimestampKV{}).
+		Where("name = ?", LastEvalRepoBased).
+		Pluck("value", &timestamps).Error
+	if err != nil {
+		return nil, err
+	}
+
+	if len(timestamps) == 0 {
+		return nil, nil
+	}
+	return timestamps[0], nil
+}

--- a/vmaas_sync/repo_based.go
+++ b/vmaas_sync/repo_based.go
@@ -16,7 +16,7 @@ func getCurrentRepoBasedInventoryIDs() (*[]string, error) {
 		return nil, err
 	}
 
-	updateRepos, err := getUpdatedRepos(*lastRepoBaseEval)
+	updateRepos, err := getUpdatedRepos(lastRepoBaseEval)
 	if err != nil {
 		return nil, err
 	}
@@ -58,14 +58,17 @@ func getRepoBasedInventoryIDs(repos *[]string) (*[]string, error) {
 }
 
 //nolint unused
-func getUpdatedRepos(modifiedSince time.Time) (*[]string, error){
+func getUpdatedRepos(modifiedSince *time.Time) (*[]string, error){
 	page := float32(1)
 	var reposArr []string
 	for {
 		reposReq := vmaas.ReposRequest{
 			Page:           page,
 			RepositoryList: []string{".*"},
-			ModifiedSince:  modifiedSince.Format(time.RFC3339),
+		}
+
+		if modifiedSince != nil {
+			reposReq.ModifiedSince = modifiedSince.Format(time.RFC3339)
 		}
 
 		vmaasCallArgs := vmaas.AppReposHandlerPostPostOpts{

--- a/vmaas_sync/repo_based.go
+++ b/vmaas_sync/repo_based.go
@@ -10,6 +10,24 @@ import (
 
 const LastEvalRepoBased = "last_eval_repo_based"
 
+func getCurrentRepoBasedInventoryIDs() (*[]string, error) {
+	lastRepoBaseEval, err := getLastRepobasedEvalTms()
+	if err != nil {
+		return nil, err
+	}
+
+	updateRepos, err := getUpdatedRepos(*lastRepoBaseEval)
+	if err != nil {
+		return nil, err
+	}
+
+	inventoryIDs, err := getRepoBasedInventoryIDs(updateRepos)
+	if err != nil {
+		return nil, err
+	}
+	return inventoryIDs, nil
+}
+
 func getLastRepobasedEvalTms() (*time.Time, error) {
 	var timestamps []*time.Time
 	err := database.Db.Model(&models.TimestampKV{}).
@@ -25,12 +43,12 @@ func getLastRepobasedEvalTms() (*time.Time, error) {
 	return timestamps[0], nil
 }
 
-func getRepoBasedInventoryIDs(repos []string) (*[]string, error) {
+func getRepoBasedInventoryIDs(repos *[]string) (*[]string, error) {
 	var intentoryIDs []string
 	err := database.Db.Table("system_repo sr").
 		Joins("JOIN repo ON repo.id = sr.repo_id").
 		Joins("JOIN system_platform sp ON sp.id = sr.system_id").
-		Where("repo.name IN (?)", repos).
+		Where("repo.name IN (?)", *repos).
 		Order("inventory_id ASC").
 		Pluck("inventory_id", &intentoryIDs).Error
 	if err != nil {

--- a/vmaas_sync/repo_based.go
+++ b/vmaas_sync/repo_based.go
@@ -21,3 +21,17 @@ func getLastRepobasedEvalTms() (*time.Time, error) {
 	}
 	return timestamps[0], nil
 }
+
+func getRepoBasedInventoryIDs(repos []string) (*[]string, error) {
+	var intentoryIDs []string
+	err := database.Db.Table("system_repo sr").
+		Joins("JOIN repo ON repo.id = sr.repo_id").
+		Joins("JOIN system_platform sp ON sp.id = sr.system_id").
+		Where("repo.name IN (?)", repos).
+		Order("inventory_id ASC").
+		Pluck("inventory_id", &intentoryIDs).Error
+	if err != nil {
+		return nil, err
+	}
+	return &intentoryIDs, nil
+}

--- a/vmaas_sync/repo_based_test.go
+++ b/vmaas_sync/repo_based_test.go
@@ -1,0 +1,17 @@
+package vmaas_sync //nolint:golint,stylecheck
+
+import (
+	"app/base/core"
+	"app/base/utils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetLastRepobasedEvalTms(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+
+	ts, err := getLastRepobasedEvalTms()
+	assert.Nil(t, err)
+	assert.Equal(t, "2018-04-04 23:23:45 +0000 UTC", ts.String())
+}

--- a/vmaas_sync/repo_based_test.go
+++ b/vmaas_sync/repo_based_test.go
@@ -15,7 +15,7 @@ func TestGetCurrentRepoBasedInventoryIDs(t *testing.T) {
 
 	inventoryIDs, err := getCurrentRepoBasedInventoryIDs()
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"INV-1", "INV-2", "INV-5", "INV-6"}, *inventoryIDs)
+	assert.Equal(t, []string{"INV-1", "INV-2", "INV-5", "INV-6"}, inventoryIDs)
 	resetLastEvalTimestamp(t)
 }
 
@@ -46,10 +46,10 @@ func TestGetRepoBasedInventoryIDs(t *testing.T) {
 	core.SetupTestEnvironment()
 
 	repos := []string{"repo1", "repo3"}
-	inventoryIDs, err := getRepoBasedInventoryIDs(&repos)
+	inventoryIDs, err := getRepoBasedInventoryIDs(repos)
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(*inventoryIDs))
-	assert.Equal(t, []string{"INV-1", "INV-5", "INV-6"}, *inventoryIDs)
+	assert.Equal(t, 3, len(inventoryIDs))
+	assert.Equal(t, []string{"INV-1", "INV-5", "INV-6"}, inventoryIDs)
 }
 
 func TestGetUpdatedRepos(t *testing.T) {
@@ -59,7 +59,7 @@ func TestGetUpdatedRepos(t *testing.T) {
 	modifiedSince := time.Now()
 	repos, err := getUpdatedRepos(&modifiedSince)
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(*repos))
+	assert.Equal(t, 3, len(repos))
 }
 
 func resetLastEvalTimestamp(t *testing.T) {

--- a/vmaas_sync/repo_based_test.go
+++ b/vmaas_sync/repo_based_test.go
@@ -16,6 +16,7 @@ func TestGetCurrentRepoBasedInventoryIDs(t *testing.T) {
 	inventoryIDs, err := getCurrentRepoBasedInventoryIDs()
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"INV-1", "INV-2", "INV-5", "INV-6"}, *inventoryIDs)
+	resetLastEvalTimestamp(t)
 }
 
 func TestGetLastRepobasedEvalTms(t *testing.T) {
@@ -25,6 +26,19 @@ func TestGetLastRepobasedEvalTms(t *testing.T) {
 	ts, err := getLastRepobasedEvalTms()
 	assert.Nil(t, err)
 	assert.Equal(t, "2018-04-04 23:23:45 +0000 UTC", ts.String())
+}
+
+func TestUpdateRepoBaseEvalTimestamp(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+
+	updateRepoBaseEvalTimestamp(time.Now())
+
+	ts, err := getLastRepobasedEvalTms()
+	assert.Nil(t, err)
+	assert.Equal(t, time.Now().Year(), ts.Year())
+
+	resetLastEvalTimestamp(t)
 }
 
 func TestGetRepoBasedInventoryIDs(t *testing.T) {
@@ -46,4 +60,9 @@ func TestGetUpdatedRepos(t *testing.T) {
 	repos, err := getUpdatedRepos(&modifiedSince)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(*repos))
+}
+
+func resetLastEvalTimestamp(t *testing.T) {
+	err := updateRepoBaseEvalTimestampStr("2018-04-05T01:23:45+02:00")
+	assert.Nil(t, err)
 }

--- a/vmaas_sync/repo_based_test.go
+++ b/vmaas_sync/repo_based_test.go
@@ -15,7 +15,7 @@ func TestGetCurrentRepoBasedInventoryIDs(t *testing.T) {
 
 	inventoryIDs, err := getCurrentRepoBasedInventoryIDs()
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"INV-1", "INV-2", "INV-5", "INV-6"}, inventoryIDs)
+	assert.Equal(t, []string{"INV-2", "INV-3"}, inventoryIDs)
 	resetLastEvalTimestamp(t)
 }
 
@@ -45,11 +45,10 @@ func TestGetRepoBasedInventoryIDs(t *testing.T) {
 	utils.SkipWithoutDB(t)
 	core.SetupTestEnvironment()
 
-	repos := []string{"repo1", "repo3"}
+	repos := []string{"repo1"}
 	inventoryIDs, err := getRepoBasedInventoryIDs(repos)
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(inventoryIDs))
-	assert.Equal(t, []string{"INV-1", "INV-5", "INV-6"}, inventoryIDs)
+	assert.Equal(t, []string{"INV-2", "INV-3"}, inventoryIDs)
 }
 
 func TestGetUpdatedRepos(t *testing.T) {

--- a/vmaas_sync/repo_based_test.go
+++ b/vmaas_sync/repo_based_test.go
@@ -5,6 +5,7 @@ import (
 	"app/base/utils"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestGetLastRepobasedEvalTms(t *testing.T) {
@@ -25,4 +26,13 @@ func TestGetRepoBasedInventoryIDs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(*inventoryIDs))
 	assert.Equal(t, []string{"INV-1", "INV-5", "INV-6"}, *inventoryIDs)
+}
+
+func TestGetUpdatedRepos(t *testing.T) {
+	core.SetupTestEnvironment()
+	configure()
+
+	repos, err := getUpdatedRepos(time.Now())
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(*repos))
 }

--- a/vmaas_sync/repo_based_test.go
+++ b/vmaas_sync/repo_based_test.go
@@ -8,6 +8,16 @@ import (
 	"time"
 )
 
+func TestGetCurrentRepoBasedInventoryIDs(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+	configure()
+
+	inventoryIDs, err := getCurrentRepoBasedInventoryIDs()
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"INV-1", "INV-2", "INV-5", "INV-6"}, *inventoryIDs)
+}
+
 func TestGetLastRepobasedEvalTms(t *testing.T) {
 	utils.SkipWithoutDB(t)
 	core.SetupTestEnvironment()
@@ -22,7 +32,7 @@ func TestGetRepoBasedInventoryIDs(t *testing.T) {
 	core.SetupTestEnvironment()
 
 	repos := []string{"repo1", "repo3"}
-	inventoryIDs, err := getRepoBasedInventoryIDs(repos)
+	inventoryIDs, err := getRepoBasedInventoryIDs(&repos)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(*inventoryIDs))
 	assert.Equal(t, []string{"INV-1", "INV-5", "INV-6"}, *inventoryIDs)

--- a/vmaas_sync/repo_based_test.go
+++ b/vmaas_sync/repo_based_test.go
@@ -15,3 +15,14 @@ func TestGetLastRepobasedEvalTms(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "2018-04-04 23:23:45 +0000 UTC", ts.String())
 }
+
+func TestGetRepoBasedInventoryIDs(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+
+	repos := []string{"repo1", "repo3"}
+	inventoryIDs, err := getRepoBasedInventoryIDs(repos)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(*inventoryIDs))
+	assert.Equal(t, []string{"INV-1", "INV-5", "INV-6"}, *inventoryIDs)
+}

--- a/vmaas_sync/repo_based_test.go
+++ b/vmaas_sync/repo_based_test.go
@@ -42,7 +42,8 @@ func TestGetUpdatedRepos(t *testing.T) {
 	core.SetupTestEnvironment()
 	configure()
 
-	repos, err := getUpdatedRepos(time.Now())
+	modifiedSince := time.Now()
+	repos, err := getUpdatedRepos(&modifiedSince)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(*repos))
 }

--- a/vmaas_sync/send_messages.go
+++ b/vmaas_sync/send_messages.go
@@ -12,7 +12,14 @@ import (
 const BatchSize = 4000
 
 func sendReevaluationMessages() error {
-	inventoryIDs, err := getAllInventoryIDs()
+	var getInventorIDsFun func() (*[]string, error)
+
+	if enabledRepoBasedReeval {
+		getInventorIDsFun = getCurrentRepoBasedInventoryIDs
+	} else {
+		getInventorIDsFun = getAllInventoryIDs
+	}
+	inventoryIDs, err := getInventorIDsFun()
 	if err != nil {
 		return err
 	}

--- a/vmaas_sync/send_messages.go
+++ b/vmaas_sync/send_messages.go
@@ -12,14 +12,14 @@ import (
 const BatchSize = 4000
 
 func sendReevaluationMessages() error {
-	var getInventorIDsFun func() ([]string, error)
+	var inventoryIDs []string
+	var err error
 
 	if enabledRepoBasedReeval {
-		getInventorIDsFun = getCurrentRepoBasedInventoryIDs
+		inventoryIDs, err = getCurrentRepoBasedInventoryIDs()
 	} else {
-		getInventorIDsFun = getAllInventoryIDs
+		inventoryIDs, err = getAllInventoryIDs()
 	}
-	inventoryIDs, err := getInventorIDsFun()
 	if err != nil {
 		return err
 	}

--- a/vmaas_sync/send_messages.go
+++ b/vmaas_sync/send_messages.go
@@ -12,7 +12,7 @@ import (
 const BatchSize = 4000
 
 func sendReevaluationMessages() error {
-	var getInventorIDsFun func() (*[]string, error)
+	var getInventorIDsFun func() ([]string, error)
 
 	if enabledRepoBasedReeval {
 		getInventorIDsFun = getCurrentRepoBasedInventoryIDs
@@ -25,24 +25,24 @@ func sendReevaluationMessages() error {
 	}
 
 	ctx := context.Background()
-	for i := 0; i < len(*inventoryIDs); i += BatchSize {
+	for i := 0; i < len(inventoryIDs); i += BatchSize {
 		end := i + BatchSize
-		if end > len(*inventoryIDs) {
-			end = len(*inventoryIDs)
+		if end > len(inventoryIDs) {
+			end = len(inventoryIDs)
 		}
-		sendMessages(ctx, (*inventoryIDs)[i:end]...)
+		sendMessages(ctx, inventoryIDs[i:end]...)
 	}
 	return nil
 }
 
-func getAllInventoryIDs() (*[]string, error) {
+func getAllInventoryIDs() ([]string, error) {
 	var inventoryIDs []string
 	err := database.Db.Model(&models.SystemPlatform{}).
 		Pluck("inventory_id", &inventoryIDs).Error
 	if err != nil {
 		return nil, err
 	}
-	return &inventoryIDs, nil
+	return inventoryIDs, nil
 }
 
 func sendMessages(ctx context.Context, inventoryIDs ...string) {

--- a/vmaas_sync/vmaas_sync.go
+++ b/vmaas_sync/vmaas_sync.go
@@ -13,8 +13,9 @@ import (
 const SyncBatchSize = 1000
 
 var (
-	vmaasClient *vmaas.APIClient
-	evalWriter  mqueue.Writer
+	vmaasClient            *vmaas.APIClient
+	evalWriter             mqueue.Writer
+	enabledRepoBasedReeval bool
 )
 
 func configure() {
@@ -28,6 +29,7 @@ func configure() {
 
 	evalTopic := utils.GetenvOrFail("EVAL_TOPIC")
 	evalWriter = mqueue.WriterFromEnv(evalTopic)
+	enabledRepoBasedReeval = utils.GetBoolEnvOrFail("ENABLE_REPO_BASED_RE_EVALUATION")
 }
 
 type Handler func(data []byte, conn *websocket.Conn) error

--- a/vmaas_sync/vmaas_sync_test.go
+++ b/vmaas_sync/vmaas_sync_test.go
@@ -34,7 +34,7 @@ func TestSync(t *testing.T) {
 	database.CheckAdvisoriesInDb(t, expected)
 	assert.Nil(t, database.Db.Unscoped().Where("name IN (?)", expected).Delete(&models.AdvisoryMetadata{}).Error)
 
-	assert.Equal(t, 4, len(msgs))
+	assert.Equal(t, 2, len(msgs))
 
 	ts, err := getLastRepobasedEvalTms() // check updated timestamp
 	assert.Nil(t, err)

--- a/vmaas_sync/vmaas_sync_test.go
+++ b/vmaas_sync/vmaas_sync_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 var msgs []kafka.Message
@@ -34,4 +35,9 @@ func TestSync(t *testing.T) {
 	assert.Nil(t, database.Db.Unscoped().Where("name IN (?)", expected).Delete(&models.AdvisoryMetadata{}).Error)
 
 	assert.Equal(t, 4, len(msgs))
+
+	ts, err := getLastRepobasedEvalTms() // check updated timestamp
+	assert.Nil(t, err)
+	assert.Equal(t, time.Now().Year(), ts.Year())
+	resetLastEvalTimestamp(t)
 }

--- a/vmaas_sync/vmaas_sync_test.go
+++ b/vmaas_sync/vmaas_sync_test.go
@@ -33,5 +33,5 @@ func TestSync(t *testing.T) {
 	database.CheckAdvisoriesInDb(t, expected)
 	assert.Nil(t, database.Db.Unscoped().Where("name IN (?)", expected).Delete(&models.AdvisoryMetadata{}).Error)
 
-	assert.Equal(t, 12, len(msgs))
+	assert.Equal(t, 4, len(msgs))
 }


### PR DESCRIPTION
- Implemented repo-based recalculation in vmaas_sync.
- Added `ENABLE_REPO_BASED_RE_EVALUATION` env variable.
  - It's needed to be in vmaas_sync OpenShift config before merging.