### PR TITLE
Optimize listener message handling

### DIFF
--- a/base/models/models.go
+++ b/base/models/models.go
@@ -19,19 +19,18 @@ type SystemPlatform struct {
 	InventoryID string `sql:"unique" gorm:"unique"`
 	RhAccountID int
 	// All times need to be stored as pointers, since they are set to 0000-00-00 00:00 by gorm if not present
-	FirstReported         *time.Time
+	FirstReported         *time.Time `gorm:"default:null"`
 	VmaasJSON             string
 	JSONChecksum          string
-	LastUpdated           *time.Time
-	UnchangedSince        *time.Time
-	LastEvaluation        *time.Time
+	LastUpdated           *time.Time `gorm:"default:null"`
+	UnchangedSince        *time.Time `gorm:"default:null"`
+	LastEvaluation        *time.Time `gorm:"default:null"`
 	OptOut                bool
 	AdvisoryCountCache    int
 	AdvisoryEnhCountCache int
 	AdvisoryBugCountCache int
 	AdvisorySecCountCache int
-	LastUpload            *time.Time
-
+	LastUpload            *time.Time `gorm:"default:null"`
 	StaleTimestamp        *time.Time
 	StaleWarningTimestamp *time.Time
 	CulledTimestamp       *time.Time

--- a/listener/common_test.go
+++ b/listener/common_test.go
@@ -63,7 +63,7 @@ func assertSystemNotInDb(t *testing.T) {
 }
 
 func getOrCreateTestAccount(t *testing.T) int {
-	accountID, err := getOrCreateAccount(id)
+	accountID, err := getOrCreateAccount(database.Db, id)
 	assert.Nil(t, err)
 	return accountID
 }

--- a/listener/metrics.go
+++ b/listener/metrics.go
@@ -10,7 +10,8 @@ import (
 const (
 	EventUpload             = "upload"
 	EventDelete             = "delete"
-	ReceivedSuccess         = "success"
+	ReceivedSuccess         = "success-eval"
+	ReceivedSuccessNoEval   = "success-unchanged"
 	ReceivedErrorIdentity   = "error-identity"
 	ReceivedErrorParsing    = "error-parsing"
 	ReceivedErrorProcessing = "error-processing"

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -145,10 +145,8 @@ func updateSystemPlatform(tx *gorm.DB, inventoryID string, accountID int, host *
 	}
 
 	hash := sha256.New()
-	_, err = hash.Write(updatesReqJSON)
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to hash updates json")
-	}
+	// Never returns an error
+	hash.Write(updatesReqJSON) // nolint: errcheck
 
 	jsonChecksum := hex.EncodeToString(hash.Sum([]byte{}))
 	var colsToUpdate = []string{
@@ -185,7 +183,7 @@ func updateSystemPlatform(tx *gorm.DB, inventoryID string, accountID int, host *
 	}
 
 	query := database.OnConflictUpdate(tx, "inventory_id", colsToUpdate...).
-		Create(&systemPlatform)
+		Save(&systemPlatform)
 
 	if query.Error != nil {
 		return nil, errors.Wrap(query.Error, "Unable to save or update system in database")

--- a/listener/upload_test.go
+++ b/listener/upload_test.go
@@ -127,7 +127,7 @@ func TestUploadHandlerError2(t *testing.T) {
 	_ = getOrCreateTestAccount(t)
 	event := createTestUploadEvent(id, true)
 	uploadHandler(event)
-	assert.Equal(t, ErrorProcessUpload, logHook.LogEntries[len(logHook.LogEntries)-1].Message)
+	assert.Equal(t, ErrorKafkaSend, logHook.LogEntries[len(logHook.LogEntries)-1].Message)
 	deleteData(t)
 }
 

--- a/listener/upload_test.go
+++ b/listener/upload_test.go
@@ -3,7 +3,10 @@ package listener
 import (
 	"app/base/core"
 	"app/base/database"
+<<<<<<< HEAD
 	"app/base/models"
+=======
+>>>>>>> Wrap listener code in transaction
 	"app/base/utils"
 	"context"
 	"errors"
@@ -51,13 +54,13 @@ func TestUpdateSystemPlatform(t *testing.T) {
 		Basearch:       "x86_64",
 	}
 
-	sys1, err := updateSystemPlatform(id, accountID1, createTestInvHost(), &req)
+	sys1, err := updateSystemPlatform(database.Db, id, accountID1, createTestInvHost(), &req)
 	assert.Nil(t, err)
 
 	assertSystemInDb(t, id, &accountID1)
 	assertReposInDb(t, req.RepositoryList)
 
-	sys2, err := updateSystemPlatform(id, accountID2, createTestInvHost(), &req)
+	sys2, err := updateSystemPlatform(database.Db, id, accountID2, createTestInvHost(), &req)
 	assert.Nil(t, err)
 
 	assertSystemInDb(t, id, &accountID2)

--- a/listener/upload_test.go
+++ b/listener/upload_test.go
@@ -3,10 +3,7 @@ package listener
 import (
 	"app/base/core"
 	"app/base/database"
-<<<<<<< HEAD
 	"app/base/models"
-=======
->>>>>>> Wrap listener code in transaction
 	"app/base/utils"
 	"context"
 	"errors"


### PR DESCRIPTION
- Wrap code in single transaction, previously it would run in 2 transactions
- Skip sending eval messages for systems, which haven't had their `system_profile` changed.
- Skip re-writing `vmaas_json` if it haven't changed