### PR TITLE
Change table fillfactor

### DIFF
--- a/database/migrations/014_table_config.up.sql
+++ b/database/migrations/014_table_config.up.sql
@@ -1,0 +1,16 @@
+ALTER TABLE system_platform
+    SET (fillfactor = 70);
+ALTER TABLE system_advisories
+    SET (fillfactor = 70);
+ALTER TABLE advisory_account_data
+    SET (fillfactor = 70);
+
+-- Vacuum the tables after 5% of tuples are updated
+ALTER TABLE system_platform
+    SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE system_advisories
+    SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE advisory_account_data
+    SET (autovacuum_vacuum_scale_factor = 0.05);
+
+DROP INDEX system_advisories_status_id_idx;

--- a/database/schema/create_schema.sql
+++ b/database/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (13, false);
+VALUES (14, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -438,7 +438,8 @@ CREATE TABLE IF NOT EXISTS system_platform
     CONSTRAINT rh_account_id
         FOREIGN KEY (rh_account_id)
             REFERENCES rh_account (id)
-) TABLESPACE pg_default;
+) WITH (fillfactor = '70', autovacuum_vacuum_scale_factor = '0.05')
+  TABLESPACE pg_default;
 
 CREATE INDEX ON system_platform (rh_account_id);
 
@@ -582,9 +583,8 @@ CREATE TABLE IF NOT EXISTS system_advisories
     CONSTRAINT status_id
         FOREIGN KEY (status_id)
             REFERENCES status (id)
-) TABLESPACE pg_default;
-
-CREATE INDEX ON system_advisories (status_id);
+) WITH (fillfactor = '70', autovacuum_vacuum_scale_factor = '0.05')
+  TABLESPACE pg_default;
 
 CREATE TRIGGER system_advisories_set_first_reported
     BEFORE INSERT
@@ -621,7 +621,8 @@ CREATE TABLE IF NOT EXISTS advisory_account_data
             REFERENCES status (id),
     UNIQUE (advisory_id, rh_account_id),
     PRIMARY KEY (rh_account_id, advisory_id)
-) TABLESPACE pg_default;
+) WITH (fillfactor = '70', autovacuum_vacuum_scale_factor = '0.05')
+  TABLESPACE pg_default;
 
 -- manager user needs to change this table for opt-out functionality
 GRANT SELECT, INSERT, UPDATE, DELETE ON advisory_account_data TO manager;

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -331,9 +331,8 @@ func ensureSystemAdvisories(tx *gorm.DB, systemID int, advisoryIDs []int) error 
 			models.SystemAdvisories{SystemID: systemID, AdvisoryID: advisoryID})
 	}
 
-	interfaceSlice := advisoriesObjs
 	txOnConflict := tx.Set("gorm:insert_option", "ON CONFLICT DO NOTHING")
-	err := database.BulkInsert(txOnConflict, interfaceSlice)
+	err := database.BulkInsert(txOnConflict, advisoriesObjs)
 	return err
 }
 

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -118,7 +118,11 @@ func getOrCreateAccount(tx *gorm.DB, account string) (int, error) {
 	rhAccount := models.RhAccount{
 		Name: account,
 	}
-
+	// Select, and only if not found attempt an insertion
+	tx.Where("name = ?", account).Find(&rhAccount)
+	if rhAccount.ID != 0 {
+		return rhAccount.ID, nil
+	}
 	err := database.OnConflictUpdate(tx, "name", "name").Create(&rhAccount).Error
 	return rhAccount.ID, err
 }


### PR DESCRIPTION
Should allow us to get less dead tuples due to [HOT](https://malisper.me/postgres-heap-only-tuples/) updates & more aggressive autovacuuming.

Will consume more disk space, but should significantly reduce performance degradation on insert heavy tables.

After the migration is applied, `VACUUM FULL` on the tables will need to be performed, and it can't be run from within the migrations.