### PR TITLE
Parse filter values

### DIFF
--- a/base/database/query.go
+++ b/base/database/query.go
@@ -6,14 +6,21 @@ import (
 	"github.com/pkg/errors"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
+	"time"
 )
 
+type AttrParser func(string) (interface{}, error)
+
 type AttrName = string
-type AttrQuery = string
+type AttrInfo struct {
+	Query  string
+	Parser AttrParser
+}
 
 // Used to store field name => sql query mapping
-type AttrMap = map[AttrName]AttrQuery
+type AttrMap = map[AttrName]AttrInfo
 
 var ColumnNameRe = regexp.MustCompile(`column:([\w_]+)`)
 
@@ -25,9 +32,41 @@ func MustGetSelect(t interface{}) string {
 	}
 	fields := make([]string, 0, len(names))
 	for _, n := range names {
-		fields = append(fields, fmt.Sprintf("%v as %v", attrs[n], n))
+		fields = append(fields, fmt.Sprintf("%v as %v", attrs[n].Query, n))
 	}
 	return strings.Join(fields, ", ")
+}
+
+func parserForType(v reflect.Type) (AttrParser, error) {
+	switch v.Kind() {
+	case reflect.String:
+		return func(s string) (i interface{}, err error) {
+			return s, nil
+		}, nil
+	case reflect.Bool:
+		return func(s string) (i interface{}, err error) {
+			return strconv.ParseBool(s)
+		}, nil
+	case reflect.Int64:
+		fallthrough
+	case reflect.Int32:
+		fallthrough
+	case reflect.Int:
+		return func(s string) (i interface{}, err error) {
+			return strconv.Atoi(s)
+		}, nil
+	case reflect.Ptr:
+		return parserForType(v.Elem())
+	case reflect.Struct:
+		if reflect.TypeOf(time.Time{}).AssignableTo(v) {
+			return func(s string) (i interface{}, err error) {
+				return time.Parse(time.RFC3339, s)
+			}, nil
+		}
+		fallthrough
+	default:
+		return nil, errors.Errorf("Unknown type %v", v.Name())
+	}
 }
 
 func getQueryFromTags(v reflect.Type) (AttrMap, []AttrName, error) {
@@ -57,11 +96,22 @@ func getQueryFromTags(v reflect.Type) (AttrMap, []AttrName, error) {
 				}
 			}
 
+			parser, err := parserForType(field.Type)
+			if err != nil {
+				return nil, nil, err
+			}
+
 			if expr, has := field.Tag.Lookup("query"); has {
-				res[columnName] = expr
+				res[columnName] = AttrInfo{
+					Query:  expr,
+					Parser: parser,
+				}
 			} else {
 				// If we dont have expr, we just use raw column name
-				res[columnName] = columnName
+				res[columnName] = AttrInfo{
+					Query:  columnName,
+					Parser: parser,
+				}
 			}
 			// Result HAS to contain all columns, because gorm loads by index, not by name
 			resNames = append(resNames, columnName)

--- a/manager/controllers/filter_test.go
+++ b/manager/controllers/filter_test.go
@@ -14,6 +14,10 @@ var testFilters = []string{
 	"between:12,13",
 }
 
+func dummyParser(v string) (interface{}, error) {
+	return v, nil
+}
+
 func TestFilterParse(t *testing.T) {
 	operators := []string{
 		"eq", "in", "gt", "lt", "between",
@@ -35,6 +39,7 @@ func TestFilterParse(t *testing.T) {
 	}
 }
 
+// nolint: govet
 func TestFilterToSql(t *testing.T) {
 	queries := []string{
 		"test = ? ",
@@ -47,12 +52,15 @@ func TestFilterToSql(t *testing.T) {
 	for i, f := range testFilters {
 		filter, err := ParseFilterValue(f)
 		assert.Equal(t, nil, err)
-		query, _, err := filter.ToWhere("test", database.AttrMap{"test": "test"})
+
+		attrMap := database.AttrMap{"test": {"test", dummyParser}}
+		query, _, err := filter.ToWhere("test", attrMap)
 		assert.Equal(t, nil, err)
 		assert.Equal(t, queries[i], query)
 	}
 }
 
+// nolint: govet
 func TestFilterToSqlAdvanced(t *testing.T) {
 	queries := []string{
 		"(NOT test) = ? ",
@@ -65,7 +73,8 @@ func TestFilterToSqlAdvanced(t *testing.T) {
 	for i, f := range testFilters {
 		filter, err := ParseFilterValue(f)
 		assert.Equal(t, nil, err)
-		query, _, err := filter.ToWhere("test", database.AttrMap{"test": "(NOT test)"})
+		attrMap := database.AttrMap{"test": {"(NOT test)", dummyParser}}
+		query, _, err := filter.ToWhere("test", attrMap)
 		assert.Equal(t, nil, err)
 		assert.Equal(t, queries[i], query)
 	}

--- a/manager/controllers/utils.go
+++ b/manager/controllers/utils.go
@@ -45,9 +45,9 @@ func ApplySort(c *gin.Context, tx *gorm.DB, fieldExprs database.AttrMap) (*gorm.
 	// We sort by a column expression and not the column name. The column expression is retrieved from fieldExprs
 	for _, enteredField := range fields {
 		if strings.HasPrefix(enteredField, "-") && allowedFieldSet[enteredField[1:]] { //nolint:gocritic
-			tx = tx.Order(fmt.Sprintf("%v DESC", fieldExprs[enteredField[1:]]))
+			tx = tx.Order(fmt.Sprintf("%s DESC", fieldExprs[enteredField[1:]].Query))
 		} else if allowedFieldSet[enteredField] {
-			tx = tx.Order(fmt.Sprintf("%v ASC", fieldExprs[enteredField]))
+			tx = tx.Order(fmt.Sprintf("%s ASC", fieldExprs[enteredField].Query))
 		} else {
 			// We have not found any matches in allowed fields, return an error
 			return nil, nil, errors.Errorf("Invalid sort field: %v", enteredField)


### PR DESCRIPTION
We used to rely on raw string values being accepted by postgresql as query parameters.

This PR implements parsing values in filter query parameters so we catch and properly report invalid values.