### PR TITLE
Fix cache calculation

### DIFF
--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -2,10 +2,91 @@ package database
 
 import (
 	"app/base/models"
+	"app/base/utils"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
+
+func DebugWithCachesCheck(part string, fun func()) {
+	fun()
+	validAfter, err := CheckCachesValid()
+	if err != nil {
+		utils.Log("error", err).Error("Could not check validity of caches")
+	}
+
+	if !validAfter {
+		utils.Log("part", part).Panic("Cache mismatch created")
+	}
+}
+
+type key struct {
+	AccountID  int
+	AdvisoryID int
+}
+
+type advisoryCount struct {
+	RhAccountID int
+	AdvisoryID  int
+	Count       int
+}
+
+func CheckCachesValid() (bool, error) {
+	valid := true
+	var aad []models.AdvisoryAccountData
+
+	tx := Db.Begin()
+	err := tx.Set("gorm:query_option", "FOR SHARE OF advisory_account_data").
+		Order("rh_account_id, advisory_id").Find(&aad).Error
+	if err != nil {
+		return false, err
+	}
+	var counts []advisoryCount
+
+	err = tx.Select("sp.rh_account_id, sa.advisory_id, count(system_id)").
+		Table("system_advisories sa").
+		Joins("JOIN system_platform sp on sa.system_id = sp.id").
+		Where("sa.when_patched is null AND sp.stale = false AND sp.last_evaluation is not null").
+		Order("sp.rh_account_id,  sa.advisory_id").
+		Group("sp.rh_account_id,  sa.advisory_id").
+		Find(&counts).Error
+	if err != nil {
+		return false, err
+	}
+
+	cached := map[key]int{}
+	calculated := map[key]int{}
+
+	for _, val := range aad {
+		cached[key{val.RhAccountID, val.AdvisoryID}] = val.SystemsAffected
+	}
+	for _, val := range counts {
+		calculated[key{val.RhAccountID, val.AdvisoryID}] = val.Count
+	}
+
+	for key, cachedCount := range cached {
+		calcCount := calculated[key]
+
+		if cachedCount != calcCount {
+			utils.Log("advisory_id", key.AdvisoryID, "account_id", key.AccountID,
+				"cached", cachedCount, "calculated", calcCount).Error("Cached counts mismatch")
+			valid = false
+		}
+	}
+
+	for key, calcCount := range calculated {
+		cachedCount := calculated[key]
+
+		if cachedCount != calcCount {
+			utils.Log("advisory_id", key.AdvisoryID, "account_id", key.AccountID,
+				"cached", cachedCount, "calculated", calcCount).Error("Cached counts mismatch")
+			valid = false
+		}
+	}
+	tx.Commit()
+	tx.RollbackUnlessCommitted()
+	return valid, nil
+}
 
 func CheckAdvisoriesInDb(t *testing.T, advisories []string) []int {
 	var advisoriesObjs []models.AdvisoryMetadata

--- a/database_admin/migrations/015_fix_caches.up.sql
+++ b/database_admin/migrations/015_fix_caches.up.sql
@@ -1,0 +1,68 @@
+-- set_last_updated
+CREATE OR REPLACE FUNCTION on_system_timestamp_update()
+    RETURNS TRIGGER AS
+$set_last_updated$
+BEGIN
+    IF (TG_OP = 'UPDATE') OR (TG_OP = 'INSERT') THEN
+        NEW.stale := COALESCE(NEW.stale_warning_timestamp < CURRENT_TIMESTAMP, FALSE);
+    END IF;
+    RETURN NEW;
+END;
+$set_last_updated$
+    LANGUAGE 'plpgsql';
+
+
+CREATE TRIGGER system_platform_on_update_timestamp
+    BEFORE UPDATE OF stale_timestamp, stale_warning_timestamp, culled_timestamp
+    ON system_platform
+    FOR EACH ROW
+EXECUTE PROCEDURE on_system_timestamp_update();
+
+
+
+CREATE OR REPLACE FUNCTION delete_culled_systems()
+    RETURNS INTEGER
+AS
+$fun$
+DECLARE
+    culled integer;
+BEGIN
+    WITH ids AS (SELECT inventory_id
+                 FROM system_platform
+                 WHERE culled_timestamp < now()
+                 ORDER BY id FOR UPDATE OF system_platform
+    ),
+         deleted AS (SELECT delete_system(inventory_id) from ids)
+    SELECT count(*)
+    FROM deleted
+    INTO culled;
+    RETURN culled;
+END;
+$fun$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION mark_stale_systems()
+    RETURNS INTEGER
+AS
+$fun$
+DECLARE
+    marked integer;
+BEGIN
+    WITH ids AS (SELECT id
+                 FROM system_platform
+                 WHERE stale_warning_timestamp < now()
+                   AND stale = false
+                 ORDER BY id FOR UPDATE OF system_platform
+    ),
+         updated as (
+             UPDATE system_platform
+                 SET stale = true
+                 FROM ids
+                 RETURNING ids.id
+         )
+    SELECT count(*)
+    FROM updated
+    INTO marked;
+    RETURN marked;
+END;
+$fun$ LANGUAGE plpgsql;

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (14, false);
+VALUES (15, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -50,6 +50,19 @@ BEGIN
     IF (TG_OP = 'UPDATE') OR
        NEW.last_updated IS NULL THEN
         NEW.last_updated := CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+END;
+$set_last_updated$
+    LANGUAGE 'plpgsql';
+
+-- set_last_updated
+CREATE OR REPLACE FUNCTION on_system_timestamp_update()
+    RETURNS TRIGGER AS
+$set_last_updated$
+BEGIN
+    IF (TG_OP = 'UPDATE') OR (TG_OP = 'INSERT') THEN
+        NEW.stale := COALESCE(NEW.stale_warning_timestamp < CURRENT_TIMESTAMP, FALSE);
     END IF;
     RETURN NEW;
 END;
@@ -367,16 +380,19 @@ $fun$
 DECLARE
     culled integer;
 BEGIN
-    select count(*)
-    from (
-             select delete_system(inventory_id)
-             from system_platform
-             where culled_timestamp < now()
-         ) t
+    WITH ids AS (SELECT inventory_id
+                 FROM system_platform
+                 WHERE culled_timestamp < now()
+                 ORDER BY id FOR UPDATE OF system_platform
+    ),
+         deleted AS (SELECT delete_system(inventory_id) from ids)
+    SELECT count(*)
+    FROM deleted
     INTO culled;
     RETURN culled;
 END;
 $fun$ LANGUAGE plpgsql;
+
 
 CREATE OR REPLACE FUNCTION mark_stale_systems()
     RETURNS INTEGER
@@ -385,16 +401,22 @@ $fun$
 DECLARE
     marked integer;
 BEGIN
-    with updated as (UPDATE system_platform
-        SET stale = true
-        -- Systems AFTER stale_warning timestamp
-        WHERE now() > stale_warning_timestamp
-        RETURNING id
-    )
-    select count(*)
-    from updated
+    WITH ids AS (SELECT id
+                 FROM system_platform
+                 WHERE stale_warning_timestamp < now()
+                   AND stale = false
+                 ORDER BY id FOR UPDATE OF system_platform
+    ),
+         updated as (
+             UPDATE system_platform
+                 SET stale = true
+                 FROM ids
+                 RETURNING ids.id
+         )
+    SELECT count(*)
+    FROM updated
     INTO marked;
-    return marked;
+    RETURN marked;
 END;
 $fun$ LANGUAGE plpgsql;
 
@@ -466,6 +488,12 @@ CREATE TRIGGER system_platform_on_update
     ON system_platform
     FOR EACH ROW
 EXECUTE PROCEDURE on_system_update();
+
+CREATE TRIGGER system_platform_on_update_timestamp
+    BEFORE UPDATE OF stale_timestamp, stale_warning_timestamp, culled_timestamp
+    ON system_platform
+    FOR EACH ROW
+EXECUTE PROCEDURE on_system_timestamp_update();
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON system_platform TO listener;
 -- evaluator needs to update last_evaluation

--- a/evaluator/evaluate_test.go
+++ b/evaluator/evaluate_test.go
@@ -86,38 +86,36 @@ func TestUpdatePatchedSystemAdvisories(t *testing.T) {
 	utils.SkipWithoutDB(t)
 	core.SetupTestEnvironment()
 
-	systemID := 12
-	rhAccountID := 3
+	system := models.SystemPlatform{ID: 12, RhAccountID: 3}
 	advisoryIDs := []int{2, 3, 4}
-	createSystemAdvisories(t, systemID, advisoryIDs, nil)
-	createAdvisoryAccountData(t, rhAccountID, advisoryIDs, 1)
+	createSystemAdvisories(t, system.ID, advisoryIDs, nil)
+	createAdvisoryAccountData(t, system.RhAccountID, advisoryIDs, 1)
 
-	err := updateSystemAdvisoriesWhenPatched(database.Db, systemID, rhAccountID, advisoryIDs, &testDate)
+	err := updateSystemAdvisoriesWhenPatched(database.Db, &system, advisoryIDs, &testDate)
 	assert.Nil(t, err)
-	checkSystemAdvisoriesWhenPatched(t, systemID, advisoryIDs, &testDate)
-	database.CheckAdvisoriesAccountData(t, rhAccountID, advisoryIDs, 0)
+	checkSystemAdvisoriesWhenPatched(t, system.ID, advisoryIDs, &testDate)
+	database.CheckAdvisoriesAccountData(t, system.RhAccountID, advisoryIDs, 0)
 
-	deleteSystemAdvisories(t, systemID, advisoryIDs)
-	deleteAdvisoryAccountData(t, rhAccountID, advisoryIDs)
+	deleteSystemAdvisories(t, system.ID, advisoryIDs)
+	deleteAdvisoryAccountData(t, system.RhAccountID, advisoryIDs)
 }
 
 func TestUpdateUnpatchedSystemAdvisories(t *testing.T) {
 	utils.SkipWithoutDB(t)
 	core.SetupTestEnvironment()
 
-	systemID := 12
-	rhAccountID := 3
+	system := models.SystemPlatform{ID: 12, RhAccountID: 3}
 	advisoryIDs := []int{2, 3, 4}
-	createSystemAdvisories(t, systemID, advisoryIDs, &testDate)
-	createAdvisoryAccountData(t, rhAccountID, advisoryIDs, 1)
+	createSystemAdvisories(t, system.ID, advisoryIDs, &testDate)
+	createAdvisoryAccountData(t, system.RhAccountID, advisoryIDs, 1)
 
-	err := updateSystemAdvisoriesWhenPatched(database.Db, systemID, rhAccountID, advisoryIDs, nil)
+	err := updateSystemAdvisoriesWhenPatched(database.Db, &system, advisoryIDs, nil)
 	assert.Nil(t, err)
-	checkSystemAdvisoriesWhenPatched(t, systemID, advisoryIDs, nil)
-	database.CheckAdvisoriesAccountData(t, rhAccountID, advisoryIDs, 2)
+	checkSystemAdvisoriesWhenPatched(t, system.ID, advisoryIDs, nil)
+	database.CheckAdvisoriesAccountData(t, system.RhAccountID, advisoryIDs, 2)
 
-	deleteSystemAdvisories(t, systemID, advisoryIDs)
-	deleteAdvisoryAccountData(t, rhAccountID, advisoryIDs)
+	deleteSystemAdvisories(t, system.ID, advisoryIDs)
+	deleteAdvisoryAccountData(t, system.RhAccountID, advisoryIDs)
 }
 
 func TestEnsureAdvisoriesInDb(t *testing.T) {

--- a/listener/common_test.go
+++ b/listener/common_test.go
@@ -63,7 +63,7 @@ func assertSystemNotInDb(t *testing.T) {
 }
 
 func getOrCreateTestAccount(t *testing.T) int {
-	accountID, err := getOrCreateAccount(database.Db, id)
+	accountID, err := getOrCreateAccount(id)
 	assert.Nil(t, err)
 	return accountID
 }

--- a/vmaas_sync/system_culling.go
+++ b/vmaas_sync/system_culling.go
@@ -2,16 +2,24 @@ package vmaas_sync //nolint:golint,stylecheck
 
 import (
 	"app/base/database"
+	"app/base/utils"
 	"time"
 )
 
 func RunSystemCulling() {
-	ticker := time.NewTicker(time.Hour)
+	ticker := time.NewTicker(time.Minute * 10)
 
 	for {
 		<-ticker.C
+		tx := database.Db.Begin()
+		tx.Exec("select delete_culled_systems()")
+		tx.Exec("select mark_stale_systems()")
 
-		database.Db.Exec("select delete_culled_systems()")
-		database.Db.Exec("select mark_stale_systems()")
+		if err := tx.Commit().Error; err != nil {
+			utils.Log("err", err.Error()).Info("Commit of system culling failed")
+			tx.RollbackUnlessCommitted()
+			return
+		}
+		utils.Log().Info("System culling tasks performed successfully")
 	}
 }


### PR DESCRIPTION
There were several issues which caused invalid caches.
- Not locking `advisory_account_data` in between 2 updates when evaluation could result in an inconsistencies when evaluating 2 package profiles with same advisories from same account
- Not locking `system_platform` rows when performing system culling tasks
- Not locking `system_platform` when inserting from listener