### PR TITLE
Repo based fix

### DIFF
--- a/dev/test_data.sql
+++ b/dev/test_data.sql
@@ -68,7 +68,8 @@ INSERT INTO repo (id, name) VALUES
 
 INSERT INTO system_repo (system_id, repo_id) VALUES
 (2, 1),
-(3, 1);
+(3, 1),
+(2, 2);
 
 INSERT INTO timestamp_kv (name, value) VALUES
 ('last_eval_repo_based', '2018-04-05T01:23:45+02:00');

--- a/vmaas_sync/repo_based.go
+++ b/vmaas_sync/repo_based.go
@@ -73,7 +73,7 @@ func getRepoBasedInventoryIDs(repos []string) ([]string, error) {
 		Joins("JOIN system_platform sp ON sp.id = sr.system_id").
 		Where("repo.name IN (?)", repos).
 		Order("inventory_id ASC").
-		Pluck("inventory_id", &intentoryIDs).Error
+		Pluck("distinct inventory_id", &intentoryIDs).Error
 	if err != nil {
 		return nil, err
 	}

--- a/vmaas_sync/repo_based_test.go
+++ b/vmaas_sync/repo_based_test.go
@@ -45,7 +45,7 @@ func TestGetRepoBasedInventoryIDs(t *testing.T) {
 	utils.SkipWithoutDB(t)
 	core.SetupTestEnvironment()
 
-	repos := []string{"repo1"}
+	repos := []string{"repo1", "repo2"}
 	inventoryIDs, err := getRepoBasedInventoryIDs(repos)
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"INV-2", "INV-3"}, inventoryIDs)


### PR DESCRIPTION
- Fixed repo-base inventory IDs selecting, use `DISTINCT`
