### PR TITLE
Fix caches, attempt #4

### DIFF
--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -116,12 +116,11 @@ func CheckAdvisoriesAccountData(t *testing.T, rhAccountID int, advisoryIDs []int
 	err := Db.Where("rh_account_id = ? AND advisory_id IN (?)", rhAccountID, advisoryIDs).
 		Find(&advisoryAccountData).Error
 	assert.Nil(t, err)
-	if systemsAffected > 0 {
-		assert.Equal(t, len(advisoryIDs), len(advisoryAccountData))
-		for _, item := range advisoryAccountData {
-			assert.Equal(t, systemsAffected, item.SystemsAffected)
-		}
-	} else {
-		assert.Equal(t, 0, len(advisoryAccountData))
+
+	sum := 0
+	for _, item := range advisoryAccountData {
+		sum += item.SystemsAffected
 	}
+	// covers both cases, when we have advisory_account_data stored with 0 systems_affected, and when we delete it
+	assert.Equal(t, systemsAffected*len(advisoryIDs), sum, "sum of systems_affected does not match")
 }

--- a/evaluator/evaluate_test.go
+++ b/evaluator/evaluate_test.go
@@ -93,14 +93,21 @@ func TestUpdatePatchedSystemAdvisories(t *testing.T) {
 
 	err := updateSystemAdvisoriesWhenPatched(database.Db, &system, advisoryIDs, &testDate)
 	assert.NoError(t, err)
-	err = updateCaches(database.Db, &system, advisoryIDs)
+	// Update as-if the advisories had become patched
+	err = updateAdvisoryAccountDatas(database.Db, &system, advisoryIDs, []int{})
+	assert.NoError(t, err)
+
+	err = updateCaches(database.Db, &system)
 	assert.NoError(t, err)
 	checkSystemAdvisoriesWhenPatched(t, system.ID, advisoryIDs, &testDate)
 	database.CheckAdvisoriesAccountData(t, system.RhAccountID, advisoryIDs, 0)
 
 	err = updateSystemAdvisoriesWhenPatched(database.Db, &system, advisoryIDs, nil)
 	assert.NoError(t, err)
-	err = updateCaches(database.Db, &system, advisoryIDs)
+	// Update as-if the advisories had become unpatched
+	err = updateAdvisoryAccountDatas(database.Db, &system, []int{}, advisoryIDs)
+	assert.NoError(t, err)
+	err = updateCaches(database.Db, &system)
 	assert.NoError(t, err)
 	database.CheckAdvisoriesAccountData(t, system.RhAccountID, advisoryIDs, 1)
 

--- a/manager/controllers/advisories.go
+++ b/manager/controllers/advisories.go
@@ -85,7 +85,7 @@ func AdvisoriesListHandler(c *gin.Context) {
 func buildQueryAdvisories(account string) *gorm.DB {
 	query := database.Db.Table("advisory_metadata am").
 		Select(AdvisoriesSelect).
-		Joins("JOIN advisory_account_data aad ON am.id = aad.advisory_id").
+		Joins("JOIN advisory_account_data aad ON am.id = aad.advisory_id and aad.systems_affected > 0").
 		Joins("JOIN rh_account ra ON aad.rh_account_id = ra.id").
 		Where("ra.name = ?", account)
 	return query


### PR DESCRIPTION
- Revert back to incremental calculation
- Sequence of actions is now based on tables, first locking `system_platform`, then updating `system_advisories`, and then updating `advisory_account_data`, instead of interleaving updating 
`system_advisories` and `advisory_account_data` for unpatched and patched advisories
- Fixes to system_culling in previous PR should fix some causes of cache inconsistencies
