### PR TITLE
Manual updating of stale flag in listener

### DIFF
--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -47,7 +47,7 @@ func CheckCachesValid() (bool, error) {
 	err = tx.Select("sp.rh_account_id, sa.advisory_id, count(*)").
 		Table("system_advisories sa").
 		Joins("JOIN system_platform sp on sa.system_id = sp.id").
-		Where("sa.when_patched is null AND sp.opt_out = false AND sp.stale = false AND sp.last_evaluation is not null").
+		Where("sa.when_patched IS NULL AND sp.opt_out = false AND sp.stale = false AND sp.last_evaluation IS NOT NULL").
 		Order("sp.rh_account_id, sa.advisory_id").
 		Group("sp.rh_account_id, sa.advisory_id").
 		Find(&counts).Error

--- a/database_admin/migrations/019_caches_fix_v2.up.sql
+++ b/database_admin/migrations/019_caches_fix_v2.up.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER IF EXISTS system_platform_on_update_timestamp ON system_platform;
+
+DROP FUNCTION IF EXISTS on_system_timestamp_update();

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (18, false);
+VALUES (19, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -50,19 +50,6 @@ BEGIN
     IF (TG_OP = 'UPDATE') OR
        NEW.last_updated IS NULL THEN
         NEW.last_updated := CURRENT_TIMESTAMP;
-    END IF;
-    RETURN NEW;
-END;
-$set_last_updated$
-    LANGUAGE 'plpgsql';
-
--- set_last_updated
-CREATE OR REPLACE FUNCTION on_system_timestamp_update()
-    RETURNS TRIGGER AS
-$set_last_updated$
-BEGIN
-    IF (TG_OP = 'UPDATE') OR (TG_OP = 'INSERT') THEN
-        NEW.stale := COALESCE(NEW.stale_warning_timestamp < CURRENT_TIMESTAMP, FALSE);
     END IF;
     RETURN NEW;
 END;
@@ -502,12 +489,6 @@ CREATE TRIGGER system_platform_on_update
     ON system_platform
     FOR EACH ROW
 EXECUTE PROCEDURE on_system_update();
-
-CREATE TRIGGER system_platform_on_update_timestamp
-    BEFORE UPDATE OF stale_timestamp, stale_warning_timestamp, culled_timestamp
-    ON system_platform
-    FOR EACH ROW
-EXECUTE PROCEDURE on_system_timestamp_update();
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON system_platform TO listener;
 -- evaluator needs to update last_evaluation

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -157,6 +157,7 @@ func updateSystemPlatform(tx *gorm.DB, inventoryID string, accountID int, host *
 	var colsToUpdate = []string{
 		"display_name",
 		"last_upload",
+		"stale",
 		"stale_timestamp",
 		"stale_warning_timestamp",
 		"culled_timestamp",
@@ -168,6 +169,8 @@ func updateSystemPlatform(tx *gorm.DB, inventoryID string, accountID int, host *
 		displayName = *host.DisplayName
 	}
 
+	staleWarning := optParseTimestamp(host.StaleWarningTimestamp)
+
 	systemPlatform := models.SystemPlatform{
 		InventoryID:           inventoryID,
 		RhAccountID:           accountID,
@@ -178,6 +181,7 @@ func updateSystemPlatform(tx *gorm.DB, inventoryID string, accountID int, host *
 		StaleTimestamp:        optParseTimestamp(host.StaleTimestamp),
 		StaleWarningTimestamp: optParseTimestamp(host.StaleWarningTimestamp),
 		CulledTimestamp:       optParseTimestamp(host.CulledTimestamp),
+		Stale:                 staleWarning != nil && staleWarning.Before(time.Now()),
 	}
 
 	var oldJSONChecksum []string

--- a/vmaas_sync/system_culling_test.go
+++ b/vmaas_sync/system_culling_test.go
@@ -29,6 +29,9 @@ func TestSingleSystemStale(t *testing.T) {
 		systems[0].StaleTimestamp = &staleDate
 		systems[0].StaleWarningTimestamp = &staleDate
 		assert.NoError(t, database.Db.Save(&systems[0]).Error)
+
+		assert.NoError(t, database.Db.Exec("select * from mark_stale_systems()").Error)
+
 		oldAffected = accountData[0].SystemsAffected
 		assert.NoError(t, database.Db.Find(&accountData, "rh_account_id = ? AND advisory_id = ?",
 			accountData[0].RhAccountID, accountData[0].AdvisoryID).Error)
@@ -131,7 +134,7 @@ func TestCullSystems(t *testing.T) {
 	database.DebugWithCachesCheck("delete-culled", func() {
 		assert.NoError(t, database.Db.Model(&models.SystemPlatform{}).Count(&cnt).Error)
 
-		assert.NoError(t, database.Db.Model(&models.SystemPlatform{}).Find(&systems).Error)
+		assert.NoError(t, database.Db.Model(&models.SystemPlatform{}).Order("id DESC").Find(&systems).Error)
 		systems[0].CulledTimestamp = &staleDate
 		assert.NoError(t, database.Db.Model(&models.SystemPlatform{}).Save(&systems[0]).Error)
 


### PR DESCRIPTION
The `on_system_timestamp_update` did not call the trigger to update cached counts after updating the `stale` flag.
This changes so that listener updates this flag manually.