### PR TITLE
add Jenkins file for smoke tests

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -1,0 +1,11 @@
+@Library("github.com/RedHatInsights/insights-pipeline-lib@v3") _
+
+if (env.CHANGE_ID) {
+    execSmokeTest (
+        ocDeployerBuilderPath: "patchman",
+        ocDeployerComponentPath: "patchman",
+        ocDeployerServiceSets: "patchman,ingress,inventory,platform-mq,rbac",
+        iqePlugins: ["iqe-patchman-plugin"],
+        pytestMarker: "patch_smoke",
+    )
+}


### PR DESCRIPTION
Jenkins job for running smoke tests is looking for a job config in project repos, therefore adding one.