### PR TITLE
Make package downloads size limited

### DIFF
--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -214,7 +214,13 @@ type namedPackage struct {
 func getPackages(tx *gorm.DB, data vmaas.UpdatesV2Response) (map[utils.Nevra]models.Package, error) {
 	pkgNevras := make([]string, 0, len(data.UpdateList))
 	for nevra := range data.UpdateList {
-		pkgNevras = append(pkgNevras, nevra)
+		// Parse and reformat nevras to avoid issues with 0 epoch
+		parsed, err := utils.ParseNevra(nevra)
+		if err != nil {
+			utils.Log("err", err.Error(), "nevra", nevra).Warn("Unable to parse nevra")
+			continue
+		}
+		pkgNevras = append(pkgNevras, parsed.String())
 	}
 
 	var packages []namedPackage

--- a/vmaas_sync/repo_based.go
+++ b/vmaas_sync/repo_based.go
@@ -88,7 +88,7 @@ func getUpdatedRepos(modifiedSince *time.Time) ([]string, error) {
 		reposReq := vmaas.ReposRequest{
 			Page:           page,
 			RepositoryList: []string{".*"},
-			PageSize:       float32(defaultPageSize),
+			PageSize:       float32(advisoryPageSize),
 		}
 
 		if modifiedSince != nil {

--- a/vmaas_sync/vmaas_sync.go
+++ b/vmaas_sync/vmaas_sync.go
@@ -18,7 +18,8 @@ var (
 	vmaasClient            *vmaas.APIClient
 	evalWriter             mqueue.Writer
 	enabledRepoBasedReeval bool
-	defaultPageSize        int
+	advisoryPageSize       int
+	packagesPageSize       int
 )
 
 func configure() {
@@ -35,7 +36,8 @@ func configure() {
 	evalWriter = mqueue.WriterFromEnv(evalTopic)
 	enabledRepoBasedReeval = utils.GetBoolEnvOrFail("ENABLE_REPO_BASED_RE_EVALUATION")
 
-	defaultPageSize = utils.GetIntEnvOrDefault("DEFAULT_PAGE_SIZE", 500)
+	advisoryPageSize = utils.GetIntEnvOrDefault("DEFAULT_PAGE_SIZE", 500)
+	packagesPageSize = utils.GetIntEnvOrDefault("PACKAGES_PAGE_SIZE", 10000)
 }
 
 type Handler func(data []byte, conn *websocket.Conn) error


### PR DESCRIPTION
By repeatedly slicing the packages array. Should only happen when we have too many packages in a page of advisories