### PR TITLE
Don't log system ids in vmaas sync

### DIFF
--- a/vmaas_sync/send_messages.go
+++ b/vmaas_sync/send_messages.go
@@ -53,7 +53,6 @@ func sendMessages(ctx context.Context, inventoryIDs ...string) {
 	events := make([]mqueue.PlatformEvent, len(inventoryIDs))
 
 	for i, id := range inventoryIDs {
-		utils.Log("inventoryID", id).Debug("Sending evaluation kafka message")
 		events[i] = mqueue.PlatformEvent{
 			ID: id,
 		}


### PR DESCRIPTION
Last recalc we spent 15 minutes just logging all of the systems and sending messages