### PR TITLE
fix(database): Fix ERROR message

### DIFF
--- a/database/init.sh
+++ b/database/init.sh
@@ -2,3 +2,4 @@
 
 # allow to create users for patchman database admin user
 psql -c "ALTER USER ${POSTGRESQL_USER} WITH CREATEROLE"
+psql -c "ALTER USER ${POSTGRESQL_USER} WITH SUPERUSER"

--- a/database_admin/config.sql
+++ b/database_admin/config.sql
@@ -1,2 +1,2 @@
 -- Log statements which take more than 2s
-SET log_min_duration_statement = 2000;
+ALTER DATABASE patchman SET log_min_duration_statement = 2000;


### PR DESCRIPTION
log_min_duration_statement can only be set by superuser, we can either grant db_admin superuser privileges, or set this in DB creation, when user is postgres