### PR TITLE
Remove the need for the packages endpoint to visit whole partition

### DIFF
--- a/database_admin/migrations/039_system_package_updatable.up.sql
+++ b/database_admin/migrations/039_system_package_updatable.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE system_package
+    ADD COLUMN IF NOT EXISTS updatable BOOL GENERATED ALWAYS AS ( update_data IS NOT NULL ) STORED;
+
+ALTER TABLE system_package
+    DROP CONSTRAINT IF EXISTS system_package_pkey;
+
+DROP INDEX IF EXISTS system_package_pkey;
+
+ALTER TABLE system_package
+    ADD PRIMARY KEY (rh_account_id, system_id, package_id) INCLUDE (updatable);

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (38, false);
+VALUES (39, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -342,7 +342,8 @@ $refresh_system_cached_counts$
 CREATE OR REPLACE FUNCTION refresh_latest_packages_view()
     RETURNS void
     SECURITY DEFINER
-AS $$
+AS
+$$
 BEGIN
     REFRESH MATERIALIZED VIEW package_latest_cache WITH DATA;
     RETURN;
@@ -834,7 +835,8 @@ CREATE TABLE IF NOT EXISTS system_package
     package_id    INT NOT NULL REFERENCES package,
     -- Use null to represent up-to-date packages
     update_data   JSONB DEFAULT NULL,
-    PRIMARY KEY (rh_account_id, system_id, package_id)
+    updatable     BOOL GENERATED ALWAYS AS ( update_data is not null ) STORED,
+    PRIMARY KEY (rh_account_id, system_id, package_id) INCLUDE (updatable)
 ) PARTITION BY HASH (rh_account_id);
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON system_package TO evaluator;
@@ -842,8 +844,9 @@ GRANT SELECT, UPDATE, DELETE ON system_package TO listener;
 GRANT SELECT, UPDATE, DELETE ON system_package TO manager;
 GRANT SELECT, UPDATE, DELETE ON system_package TO vmaas_sync;
 
-SELECT create_table_partitions('system_package', 16,
-                               $$WITH (fillfactor = '70', autovacuum_vacuum_scale_factor = '0.05')$$);
+SELECT create_table_partitions(
+               'system_package', 16,
+               $$WITH (fillfactor = '70', autovacuum_vacuum_scale_factor = '0.05')$$);
 
 -- timestamp_kv
 CREATE TABLE IF NOT EXISTS timestamp_kv


### PR DESCRIPTION
We currently require a `system_package_<part>`  table scan for packages endpoint. This adds computed column, which is then included in the index, and is used for the counts. This should remove the need to do full table scan on the partition, and remove the worst offender in the slowness of packages endpoint.