### PR TITLE
Fixed invalid offset handling

### DIFF
--- a/manager/controllers/advisory_systems_test.go
+++ b/manager/controllers/advisory_systems_test.go
@@ -149,3 +149,7 @@ func TestAdvisorySystemsTagsUnknown(t *testing.T) { //nolint:dupl
 	assert.Equal(t, 200, w.Code)
 	assert.Equal(t, 0, len(output.Data))
 }
+
+func TestAdvisorySystemsWrongOffset(t *testing.T) {
+	doTestWrongOffset(t, "/:advisory_id", "/RH-1?offset=1000", AdvisorySystemsListHandler)
+}

--- a/manager/controllers/package_systems.go
+++ b/manager/controllers/package_systems.go
@@ -66,14 +66,14 @@ func PackageSystemsListHandler(c *gin.Context) {
 	}
 
 	query := packageSystemsQuery(account, packageName)
-	query, meta, links, err := ListCommon(query, c, fmt.Sprintf("/packages/%s/systems", packageName), PackageSystemsOpts)
 	query = ApplySearch(c, query, "sp.display_name")
 	query, _ = ApplyTagsFilter(c, query, "sp.inventory_id")
-
+	query, meta, links, err := ListCommon(query, c, fmt.Sprintf("/packages/%s/systems", packageName), PackageSystemsOpts)
 	if err != nil {
-		LogAndRespError(c, err, "database error")
+		// Error handling and setting of result code & content is done in ListCommon
 		return
 	}
+
 	var systems []PackageSystemItem
 	err = query.Find(&systems).Error
 	if err != nil {

--- a/manager/controllers/package_systems_test.go
+++ b/manager/controllers/package_systems_test.go
@@ -28,3 +28,7 @@ func TestPackageSystems(t *testing.T) {
 	assert.Equal(t, "5.6.13-200.fc31.x86_64", output.Data[0].InstalledEVRA)
 	assert.Equal(t, "5.10.13-200.fc31.x86_64", output.Data[0].AvailableEVRA)
 }
+
+func TestPackageSystemsWrongOffset(t *testing.T) {
+	doTestWrongOffset(t, "/:package_name/systems", "/kernel/systems?offset=1000", PackageSystemsListHandler)
+}

--- a/manager/controllers/packages.go
+++ b/manager/controllers/packages.go
@@ -83,13 +83,13 @@ func PackagesListHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 
 	query := packagesQuery(c, account)
-	query, meta, links, err := ListCommon(query, c, "/packages", PackagesOpts)
 	query = ApplySearch(c, query, "res.name", "latest.summary")
-
+	query, meta, links, err := ListCommon(query, c, "/packages", PackagesOpts)
 	if err != nil {
-		LogAndRespError(c, err, "database error")
+		// Error handling and setting of result code & content is done in ListCommon
 		return
 	}
+
 	var systems []PackageItem
 	err = query.Scan(&systems).Error
 	if err != nil {

--- a/manager/controllers/packages_test.go
+++ b/manager/controllers/packages_test.go
@@ -53,3 +53,7 @@ func TestSearchPackages(t *testing.T) {
 		assert.Equal(t, "firefox", output.Data[0].Name)
 	})
 }
+
+func TestPackagesWrongOffset(t *testing.T) {
+	doTestWrongOffset(t, "/", "/?offset=1000", PackagesListHandler)
+}

--- a/manager/controllers/system_advisories_test.go
+++ b/manager/controllers/system_advisories_test.go
@@ -116,3 +116,8 @@ func TestSystemAdvisoriesSearch(t *testing.T) {
 	assert.Equal(t, "adv-3-des", output.Data[0].Attributes.Description)
 	assert.Equal(t, "adv-3-syn", output.Data[0].Attributes.Synopsis)
 }
+
+func TestSystemAdvisoriesWrongOffset(t *testing.T) {
+	doTestWrongOffset(t, "/:inventory_id", "/00000000-0000-0000-0000-000000000001?offset=1000",
+		SystemAdvisoriesHandler)
+}

--- a/manager/controllers/system_packages.go
+++ b/manager/controllers/system_packages.go
@@ -82,11 +82,11 @@ func SystemPackagesHandler(c *gin.Context) {
 	var loaded []SystemPackageDBLoad
 	q := systemPackageQuery(account, inventoryID).Select(SystemPackagesSelect)
 	q = ApplySearch(c, q, "pn.name", "sum.value", "descr.value")
-
 	q, meta, links, err := ListCommon(q, c, fmt.Sprintf("/systems/%s/packages", inventoryID), SystemPackagesOpts)
 	if err != nil {
 		return
 	}
+
 	err = q.Find(&loaded).Error
 	if gorm.IsRecordNotFoundError(err) {
 		LogAndRespNotFound(c, err, "inventory_id not found")

--- a/manager/controllers/system_packages_test.go
+++ b/manager/controllers/system_packages_test.go
@@ -71,3 +71,8 @@ func TestSystemPackagesUpdatableOnly(t *testing.T) {
 	assert.Equal(t, output.Data[0].Name, "firefox")
 	assert.Equal(t, output.Data[1].Name, "kernel")
 }
+
+func TestSystemPackagesWrongOffset(t *testing.T) {
+	doTestWrongOffset(t, "/:inventory_id/packages",
+		"/00000000-0000-0000-0000-000000000001/packages?offset=1000", SystemPackagesHandler)
+}

--- a/manager/controllers/systems_test.go
+++ b/manager/controllers/systems_test.go
@@ -80,17 +80,8 @@ func TestSystemsOffset(t *testing.T) { //nolint:dupl
 	assert.Equal(t, 8, output.Meta.TotalItems)
 }
 
-func TestSystemsOffsetOverflow(t *testing.T) {
-	utils.SkipWithoutDB(t)
-	core.SetupTestEnvironment()
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/?offset=13&limit=4", nil)
-	core.InitRouter(SystemsListHandler).ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	var errResp utils.ErrorResponse
-	ParseReponseBody(t, w.Body.Bytes(), &errResp)
-	assert.Equal(t, InvalidOffsetMsg, errResp.Error)
+func TestSystemsWrongOffset(t *testing.T) {
+	doTestWrongOffset(t, "/", "/?offset=13&limit=4", SystemsListHandler)
 }
 
 func TestSystemsWrongSort(t *testing.T) {


### PR DESCRIPTION
- don't return 500 (server error) but 400 (bad request) when too big `offset` param set for manager's listing endpoints