### PR TITLE
Indicate engine version in docs and API

### DIFF
--- a/base/metrics/metrics.go
+++ b/base/metrics/metrics.go
@@ -21,6 +21,7 @@ var (
 		Name:      "info",
 	}, []string{"version"})
 
+	// ENGINEVERSION - DO NOT EDIT this variable MANUALLY - it is modified by generate_docs.sh
 	ENGINEVERSION = "v1.4.1"
 )
 

--- a/base/metrics/metrics.go
+++ b/base/metrics/metrics.go
@@ -13,12 +13,23 @@ var (
 		Subsystem: "core",
 		Name:      "kafka_connection_errors",
 	}, []string{"type"})
+
+	EngineVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Help:      "Patchman project deployment information",
+		Namespace: "patchman_engine",
+		Subsystem: "core",
+		Name:      "info",
+	}, []string{"version"})
+
+	ENGINEVERSION = "v1.4.1"
 )
 
 func init() {
 	if os.Getenv("KAFKA_ADDRESS") != "" {
 		prometheus.MustRegister(KafkaConnectionErrorCnt)
 	}
+	prometheus.MustRegister(EngineVersion)
+	EngineVersion.WithLabelValues(ENGINEVERSION).Set(1)
 }
 
 func Configure() {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -11,7 +11,7 @@ import (
 )
 
 // @title Patchman-engine API
-// @version 1.0
+// @version  v1.4.1
 // @description Description here
 
 // @license.name GPLv3

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -11,6 +11,7 @@ import (
 )
 
 // @title Patchman-engine API
+// DO NOT EDIT version MANUALLY - this variable is modified by generate_docs.sh
 // @version  v1.4.1
 // @description Description here
 

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -27,6 +27,7 @@ esac
 if [ -n "$RELEASE" ] ; then
   # Substitute version
   sed -i "s|\(// @version \).*$|\1 $RELEASE|;" manager/manager.go
+  sed -i 's|^\(var ENGINEVERSION = "\)[^"]*\("\)$|'"\1$RELEASE\2|;" base/metrics/metrics.go
 fi
 
 DOCS_TMP_DIR=/tmp

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -1,5 +1,33 @@
 #!/usr/bin/bash
 
+# Usage:
+# ./generate_docs.sh --increment
+#         Reads curent X.Y.Z version (last git tag) and increments Z part
+# ./generate_docs.sh --keep
+#         Keeps current version untouched
+# ./generate_docs.sh --release "A.B.C"
+#         Sets version exactly to "A.B.C"
+#
+
+RELEASE=""
+case "$1" in
+  -i|--increment)
+        CURRENT_RELEASE=$(git tag | tail -n1)
+        RELEASE="${CURRENT_RELEASE%.*}.$((${CURRENT_RELEASE##*.}+1))"
+        ;;
+  -k|--keep) # don't change anything, just keep current release
+        ;;
+  -r|--release) RELEASE=$2
+        ;;
+  *) >&2 echo "Usage: $0 [ [-k|--keep] | [-i|--increment] | [-r|--release] <release> ]"
+        exit 1
+        ;;
+esac
+
+if [ -n "$RELEASE" ] ; then
+  # Substitute version
+  sed -i "s|\(// @version \).*$|\1 $RELEASE|;" manager/manager.go
+fi
 
 DOCS_TMP_DIR=/tmp
 CONVERT_URL="https://converter.swagger.io/api/convert"


### PR DESCRIPTION
engine version is shown in metrics as
```
# HELP patchman_engine_core_info Patchman project deployment information
# TYPE patchman_engine_core_info gauge
patchman_engine_core_info{version="v1.4.2"} 1

```