### PR TITLE
improve cyndi tag metrics query

### DIFF
--- a/vmaas_sync/metrics_cyndi.go
+++ b/vmaas_sync/metrics_cyndi.go
@@ -59,8 +59,9 @@ func getCyndiData() (stats InventoryHostsStats, err error) {
 		return stats, err
 	}
 
-	err = database.Db.Table("(SELECT DISTINCT jsonb_array_elements(tags) FROM inventory.hosts) as t").
-		Count(&stats.UniqueTags).Error
+	err = database.Db.Table("(SELECT jsonb_array_elements(tags) as tag FROM inventory.hosts" +
+		" where jsonb_array_length(tags) > 0) as t").
+		Select("count(DISTINCT tag)").Count(&stats.UniqueTags).Error
 	if err != nil {
 		utils.Log("err", err.Error()).Error("unable to update cyndi metrics")
 		return stats, err


### PR DESCRIPTION
it runs every 15s and does fullscan over inventory.hosts
this change reduces cost from
```
Aggregate  (cost=415838.35..415838.36 rows=1 width=8)
   ->  Unique  (cost=405794.02..408663.83 rows=573962 width=32)
         ->  Sort  (cost=405794.02..407228.92 rows=573962 width=32)
               Sort Key: (jsonb_array_elements(hosts_v1_1607594495056200400.tags))
               ->  Gather  (cost=1000.00..337158.84 rows=573962 width=32)
                     Workers Planned: 2
                     ->  ProjectSet  (cost=0.00..278762.64 rows=23915100 width=32)
                           ->  Parallel Seq Scan on hosts_v1_1607594495056200400  (cost=0.00..157393.51 rows=239151 width=319)

```
to
```
Aggregate  (cost=221569.25..221569.26 rows=1 width=8)
   ->  Gather  (cost=1000.00..219177.74 rows=191321 width=32)
         Workers Planned: 2
         ->  ProjectSet  (cost=0.00..199045.64 rows=7971700 width=32)
               ->  Parallel Seq Scan on hosts_v1_1607594495056200400  (cost=0.00..158589.26 rows=79717 width=319)
                     Filter: (jsonb_array_length(tags) > 0)
```