### PR TITLE
updated golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,9 +25,7 @@ linters:
     - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]
     - golint # Golint differs from gofmt. Gofmt reformats Go source code, whereas golint prints out style mistakes [fast: true, auto-fix: false]
     - gosec # (gas): Inspects source code for security problems [fast: true, auto-fix: false]
-    - interfacer # Linter that suggests narrower interface types [fast: true, auto-fix: false]
     - lll # Reports long lines [fast: true, auto-fix: false]
-    - maligned # Tool to detect Go structs that would take less memory if their fields were sorted [fast: true, auto-fix: false]
     - misspell # Finds commonly misspelled English words in comments [fast: true, auto-fix: true]
     - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
     - prealloc # Finds slice declarations that could potentially be preallocated [fast: true, auto-fix: false]
@@ -36,3 +34,9 @@ linters:
     - unconvert # Remove unnecessary type conversions [fast: true, auto-fix: false]
     - unparam # Reports unused function parameters [fast: true, auto-fix: false]
     - whitespace # Tool for detection of leading and trailing whitespace [fast: true, auto-fix: true]
+
+# linters-settings:
+#  govet:
+#    enable:
+#      - fieldalignment # TODO enable and optimize fields alignment in structs:
+# see: https://medium.com/@felipedutratine/how-to-organize-the-go-struct-in-order-to-save-memory-c78afcf59ec2


### PR DESCRIPTION
Resolve warnings printed by `golangci-lint run`:
~~~
WARN [runner] The linter 'interfacer' is deprecated due to: The repository of the linter has been archived by the owner. 
WARN [runner] The linter 'maligned' is deprecated due to: The repository of the linter has been archived by the owner. Use govet 'fieldalignment' instead.
~~~

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
