### PR TITLE
SPM-812 fix wait-for-services criteria

### DIFF
--- a/scripts/feed_db.sh
+++ b/scripts/feed_db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# wait untill database is ready
-./scripts/wait-for-services.sh
+# wait for all migrations applied
+WAIT_FOR_FULL_DB=1 ./scripts/wait-for-services.sh
 
 # fill database with testing data
 PGPASSWORD=$DB_PASSWD psql -h $DB_HOST -d $DB_NAME -U $DB_USER -p $DB_PORT \

--- a/scripts/go_test_db.sh
+++ b/scripts/go_test_db.sh
@@ -5,9 +5,6 @@ set -e -o pipefail
 # Create database
 ./database_admin/update.sh
 
-# Wait untill database is ready
-./scripts/wait-for-services.sh
-
 # Run database test, destroys and recreates database
 go test -v app/database_admin
 

--- a/scripts/wait-for-services.sh
+++ b/scripts/wait-for-services.sh
@@ -8,9 +8,12 @@ if [ ! -z "$DB_HOST" ]; then
   >&2 echo "Checking if PostgreSQL is up"
   if [ ! -z "$WAIT_FOR_EMPTY_DB" ]; then
     CHECK_QUERY="\q" # Wait only for empty database.
-  else
-    # Wait even for database schema initialization.
+  elif [ ! -z "$WAIT_FOR_FULL_DB" ]; then
+    # Wait for full schema, all migrations, e.g. before tests (schema_migrations.dirty='f').
     CHECK_QUERY="SELECT 1/count(*) FROM schema_migrations WHERE dirty='f';"
+  else
+    # Wait for created schema.
+    CHECK_QUERY="SELECT * FROM schema_migrations;"
   fi
   until PGPASSWORD="$DB_PASSWD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -c "${CHECK_QUERY}" -q 2>/dev/null; do
     >&2 echo "PostgreSQL is unavailable - sleeping"


### PR DESCRIPTION
wait for full db schema when running tests and dirty=f
allow components running on schema dirty=t

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
