### PR TITLE
Use no content response when account is not found

### DIFF
--- a/manager/middlewares/authentication.go
+++ b/manager/middlewares/authentication.go
@@ -27,7 +27,7 @@ func findAccount(c *gin.Context, identity *identity.Identity) bool {
 	} else {
 		var acc models.RhAccount
 		if err := database.Db.Where("name = ?", identity.AccountNumber).Find(&acc).Error; err != nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, utils.ErrorResponse{Error: "Could not find rh_account"})
+			c.AbortWithStatus(http.StatusNoContent)
 			return false
 		}
 		AccountIDCache.Values[acc.Name] = acc.ID


### PR DESCRIPTION
Failure to find an account is not an authentication failure. The account could be valid. Fixes SPM-815