### PR TITLE
SPM-937: Add support for pruning updates (storing only latest)

### DIFF
--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -151,6 +151,16 @@ func CheckAdvisoriesAccountData(t *testing.T, rhAccountID int, advisoryIDs []int
 	assert.Equal(t, systemsAffected*len(advisoryIDs), sum, "sum of systems_affected does not match")
 }
 
+func CheckSystemUpdatesCount(t *testing.T, accountID, systemID int) []int {
+	var cnt []int
+	assert.NoError(t, Db.Table("system_package spkg").
+		Select("json_array_length(spkg.update_data::json) as len").
+		Where("spkg.update_data is not null").
+		Where("spkg.system_id = ? AND spkg.rh_account_id = ? ", systemID, accountID).
+		Pluck("len", &cnt).Error)
+	return cnt
+}
+
 func CreateReportedAdvisories(reportedAdvisories ...string) map[string]bool {
 	reportedAdvisoriesMap := map[string]bool{}
 	for _, adv := range reportedAdvisories {

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -32,6 +32,7 @@ var (
 	enableBypass           bool
 	enableStaleSysEval     bool
 	enableLazyPackageSave  bool
+	prunePackageLatestOnly bool
 )
 
 func configure() {
@@ -49,6 +50,7 @@ func configure() {
 	enableRepoAnalysis = utils.GetBoolEnvOrDefault("ENABLE_REPO_ANALYSIS", true)
 	enableStaleSysEval = utils.GetBoolEnvOrDefault("ENABLE_STALE_SYSTEM_EVALUATION", true)
 	enableLazyPackageSave = utils.GetBoolEnvOrDefault("ENABLE_LAZY_PACKAGE_SAVE", true)
+	prunePackageLatestOnly = utils.GetBoolEnvOrDefault("PRUNE_UPDATES_LATEST_ONLY", false)
 	if enableLazyPackageSave {
 		ConfigurePackageNameCache()
 	}

--- a/evaluator/evaluate_packages.go
+++ b/evaluator/evaluate_packages.go
@@ -254,6 +254,9 @@ func vmaasResponse2UpdateDataJSON(updateData *vmaas.UpdatesV2ResponseUpdateList)
 			uniqUpdates[pkgUpdate] = true
 		}
 	}
+	if prunePackageLatestOnly && len(pkgUpdates) > 1 {
+		pkgUpdates = pkgUpdates[len(pkgUpdates)-1:]
+	}
 
 	var updateDataJSON []byte
 	var err error


### PR DESCRIPTION
If we don't use intermediate updates anywhere, why store them ? 