### PR TITLE
SPM-853 Fix package detail request with empty advisory_id

### DIFF
--- a/base/database/utils.go
+++ b/base/database/utils.go
@@ -30,7 +30,7 @@ func Packages(tx *gorm.DB) *gorm.DB {
 		Joins("JOIN package_name pn on p.name_id = pn.id").
 		Joins("JOIN (SELECT id, value FROM strings) descr ON p.description_hash = descr.id").
 		Joins("JOIN (SELECT id, value from strings) sum ON p.summary_hash = sum.id").
-		Joins("JOIN (SELECT id, name, public_date from advisory_metadata) am ON p.advisory_id = am.id")
+		Joins("LEFT JOIN (SELECT id, name, public_date from advisory_metadata) am ON p.advisory_id = am.id")
 }
 
 func PackageByName(tx *gorm.DB, pkgName string) *gorm.DB {


### PR DESCRIPTION
We don't store advisory_id in package info in new approach - syncing from vmaas/pkgtree. Anyway this info (package - advisory relation) was not shown anywhere.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
