### PR TITLE
Fix message processing, add more lenient datetime parser

### DIFF
--- a/base/base_test.go
+++ b/base/base_test.go
@@ -1,0 +1,13 @@
+package base
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTimeFormats(t *testing.T) {
+	_, err := ParseTime("2021-03-09T12:35:50")
+	assert.NoError(t, err)
+	_, err = ParseTime("2021-04-28T08:26:54.629140+00:00")
+	assert.NoError(t, err)
+}

--- a/listener/events.go
+++ b/listener/events.go
@@ -41,8 +41,9 @@ func EventsMessageHandler(m kafka.Message) error {
 	case "delete":
 		var event mqueue.PlatformEvent
 		if err := json.Unmarshal(m.Value, &event); err != nil {
-			utils.Log("inventoryID", msgData["id"], "msg", string(m.Value)).
+			utils.Log("inventoryID", msgData["id"], "msg", string(m.Value), "err", err).
 				Error("Invalid 'delete' message format")
+			return err
 		}
 		return HandleDelete(event)
 	case "updated":
@@ -50,9 +51,9 @@ func EventsMessageHandler(m kafka.Message) error {
 	case "created":
 		var event HostEvent
 		if err := json.Unmarshal(m.Value, &event); err != nil {
-			utils.Log("inventoryID", msgData["id"], "err", err, "msg", string(m.Value)).
+			utils.Log("inventoryID", msgData["id"], "msg", string(m.Value), "err", err).
 				Error("Invalid 'updated' message format")
-			return nil
+			return err
 		}
 		return HandleUpload(event)
 	default:

--- a/listener/upload_test.go
+++ b/listener/upload_test.go
@@ -30,7 +30,7 @@ func TestGetOrCreateAccount(t *testing.T) {
 }
 
 func createTestInvHost(t *testing.T) *Host {
-	correctTimestamp, err := time.Parse(base.Rfc3339NoTz, "2018-09-22T12:00:00-04:00")
+	correctTimestamp, err := base.ParseTime("2018-09-22T12:00:00-04:00")
 	correctTime := base.Rfc3339Timestamp(correctTimestamp)
 	assert.NoError(t, err)
 

--- a/vmaas_sync/advisory_sync.go
+++ b/vmaas_sync/advisory_sync.go
@@ -109,7 +109,7 @@ func vmaasData2AdvisoryMetadata(errataName string, vmaasData vmaas.ErrataRespons
 
 func checkUpdatedSummaryDescription(errataName string, vmaasData vmaas.ErrataResponseErrataList) (
 	modified time.Time, success bool) {
-	modified, err := time.Parse(base.Rfc3339NoTz, vmaasData.GetUpdated())
+	modified, err := base.ParseTime(vmaasData.GetUpdated())
 	if err != nil {
 		utils.Log("err", err.Error(), "erratum", errataName).Error("Invalid errata modified date")
 		return time.Time{}, false

--- a/vmaas_sync/advisory_sync_test.go
+++ b/vmaas_sync/advisory_sync_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/RedHatInsights/patchman-clients/vmaas"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"time"
 )
 
 func TestInit(t *testing.T) {
@@ -109,7 +108,7 @@ func TestParseAdvisories(t *testing.T) {
 	assert.Equal(t, len(res), 1)
 	adv := res[0]
 
-	time, err := time.Parse(base.Rfc3339NoTz, "2004-09-02T00:00:00+00:00")
+	time, err := base.ParseTime("2004-09-02T00:00:00+00:00")
 	assert.Nil(t, err)
 	assert.Equal(t, time, adv.PublicDate)
 	assert.Equal(t, time, adv.ModifiedDate)

--- a/vmaas_sync/system_culling_test.go
+++ b/vmaas_sync/system_culling_test.go
@@ -9,10 +9,9 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
-	"time"
 )
 
-var staleDate, _ = time.Parse(base.Rfc3339NoTz, "2006-01-02T15:04:05-07:00")
+var staleDate, _ = base.ParseTime("2006-01-02T15:04:05-07:00")
 
 func TestSingleSystemStale(t *testing.T) {
 	utils.SkipWithoutDB(t)


### PR DESCRIPTION
We should accept datetime formats with optional fields. Go doesn't like what the platform is sending us, so let's add multiple formats for parsing. 

Also added logging and reporting error that occur when parsing messages.
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [x] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
