### PR TITLE
SPM-674 respect vmaas resource settings in ephemeral

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -7,6 +7,7 @@ APP_NAME="patchman"  # name of app-sre "application" folder this component lives
 COMPONENT_NAME="patchman"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/patchman-engine-app"
 DOCKERFILE="Dockerfile.rhel8"
+COMPONENTS_W_RESOURCES="vmaas"
 
 IQE_PLUGINS="patchman"
 IQE_MARKER_EXPRESSION=""


### PR DESCRIPTION
vmaas-reposcan gets OOMKilled during sync if it does not have enough resources, default resource limit in ephemeral is 256Mb which is not enough, so we need to respect settings from vmaas clowdapp.yaml


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
