### PR TITLE
SPM-1331: Mark db systems with host_type=edge as stale (db migr.)

### DIFF
--- a/database_admin/migrations/074_stale_edge_systems.down.sql
+++ b/database_admin/migrations/074_stale_edge_systems.down.sql
@@ -1,0 +1,5 @@
+DO $$
+BEGIN
+    RAISE NOTICE 'No down migration for edge systems marking!';
+END;
+$$ LANGUAGE plpgsql;

--- a/database_admin/migrations/074_stale_edge_systems.up.sql
+++ b/database_admin/migrations/074_stale_edge_systems.up.sql
@@ -1,0 +1,25 @@
+DO $$
+DECLARE
+    cnt INT = 0;
+BEGIN
+    WITH n_updated AS (
+        WITH ids AS (
+            SELECT rh_account_id, sp.id AS id FROM system_platform sp
+            LEFT JOIN inventory.hosts ih ON sp.inventory_id = ih.id
+            WHERE ih.system_profile->>'host_type' = 'edge'
+            ORDER BY rh_account_id, sp.id
+            )
+        UPDATE system_platform sp
+        SET culled_timestamp = now()
+        FROM ids
+        WHERE sp.id = ids.id AND sp.rh_account_id = ids.rh_account_id
+        RETURNING sp.id
+        )
+    SELECT count(*) from n_updated into cnt;
+    RAISE NOTICE 'Edge systems count marked as culled: %', cnt;
+EXCEPTION
+     -- inventory.hosts is not in our schema, skip if not presented
+     WHEN others THEN
+        RAISE NOTICE 'Unable mark culled_timestamp in systems data!';
+END;
+$$ LANGUAGE plpgsql;

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (73, false);
+VALUES (74, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions


### PR DESCRIPTION
- the same approach used for SPM-626
- then it will be deleted automatically using system culling job (vmaas-sync)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
