### PR TITLE
SPM-1484: Rename event to singular form

### DIFF
--- a/evaluator/notifications.go
+++ b/evaluator/notifications.go
@@ -10,7 +10,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const NewAdvisoriesEvent = "new-advisories"
+const NewAdvisoryEvent = "new-advisory"
 
 var notificationsPublisher mqueue.Writer
 
@@ -69,7 +69,7 @@ func publishNewAdvisoriesNotification(tx *gorm.DB, inventoryID string, accountID
 
 	msg, err := mqueue.MessageFromJSON(
 		inventoryID,
-		ntf.MakeNotification(accountID, inventoryID, NewAdvisoriesEvent, events))
+		ntf.MakeNotification(accountID, inventoryID, NewAdvisoryEvent, events))
 	if err != nil {
 		return errors.Wrap(err, "creating message from notification failed")
 	}

--- a/evaluator/notifications_test.go
+++ b/evaluator/notifications_test.go
@@ -72,7 +72,7 @@ func TestAdvisoriesNotificationMessage(t *testing.T) {
 		},
 	}
 
-	notification := ntf.MakeNotification(rhAccountID, inventoryID, NewAdvisoriesEvent, events)
+	notification := ntf.MakeNotification(rhAccountID, inventoryID, NewAdvisoryEvent, events)
 	msg, err := mqueue.MessageFromJSON(inventoryID, notification)
 	assert.Nil(t, err)
 	assert.Equal(t, inventoryID, string(msg.Key))


### PR DESCRIPTION
I should use singular form, here is a fix for it.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
