### PR TITLE
SPM-1549: fix packages info in advisory_detail api

### DIFF
--- a/.github/workflows/open_api_spec.yml
+++ b/.github/workflows/open_api_spec.yml
@@ -12,8 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Spec validation with OpenAPIv3 (docs/openapi.json)
-      run: docker run --rm -v ${PWD}/docs:/docs:Z openapitools/openapi-generator-cli:v5.0.1 validate -i /docs/openapi.json
+    - name: Spec validation with OpenAPIv3 (docs/v2/openapi.json)
+      run: docker run --rm -v ${PWD}/docs:/docs:Z openapitools/openapi-generator-cli:v5.0.1 validate -i /docs/v2/openapi.json
 
   gen_client:
     name: Generate Python Client
@@ -24,8 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Generate Python client with OpenAPIv3 (docs/openapi.json)
-      run: docker run --rm -v ${PWD}/docs:/local:Z openapitools/openapi-generator-cli:v5.0.1 generate -i /local/openapi.json -g python -o /local/client
+    - name: Generate Python client with OpenAPIv3 (docs/v2/openapi.json)
+      run: docker run --rm -v ${PWD}/docs/v2:/local:Z openapitools/openapi-generator-cli:v5.0.1 generate -i /local/openapi.json -g python -o /local/client
     - uses: actions/upload-artifact@v2
       with:
         name: Python-Client

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         MANAGER_FILE=manager/manager.go
         METRICS_FILE=base/metrics/metrics.go
-        DOC_FILE=docs/openapi.json
+        DOC_FILE=docs/v2/openapi.json
         VERSION=$(awk '/^\/\/ @version/ {print $3}' $MANAGER_FILE)
         RELEASE_TYPE=$(git log -1 | tail -n1) # Check release type (/major, /minor, /patch (default))
         VERSION_NEXT=$(./scripts/increment_version.sh $VERSION $RELEASE_TYPE)

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,8 @@ ADD --chown=insights:root database_admin/*.sh        /go/src/app/database_admin/
 ADD --chown=insights:root database_admin/*.sql       /go/src/app/database_admin/
 ADD --chown=insights:root database_admin/schema      /go/src/app/database_admin/schema
 ADD --chown=insights:root database_admin/migrations  /go/src/app/database_admin/migrations
-ADD --chown=insights:root docs/openapi.json          /go/src/app/docs/
+ADD --chown=insights:root docs/v1/openapi.json       /go/src/app/docs/v1/
+ADD --chown=insights:root docs/v2/openapi.json       /go/src/app/docs/v2/
 ADD --chown=insights:root vmaas_sync/entrypoint.sh   /go/src/app/vmaas_sync/
 
 COPY --from=buildimg /go/src/app/main /go/src/app/

--- a/base/models/models.go
+++ b/base/models/models.go
@@ -144,7 +144,7 @@ func (AdvisoryType) TableName() string {
 	return "advisory_type"
 }
 
-type AdvisoryPackageData map[string]string
+type AdvisoryPackageData []string
 
 type AdvisoryMetadata struct {
 	ID              int

--- a/dev/test_data.sql
+++ b/dev/test_data.sql
@@ -59,7 +59,7 @@ INSERT INTO advisory_metadata (id, name, description, synopsis, summary, solutio
 (12, 'CUSTOM-12', 'adv-12-des', 'adv-12-syn', 'adv-12-sum', 'adv-12-sol', 0, '2016-09-22 12:00:00-08', '2018-09-22 12:00:00-08', 'url12', NULL, NULL, NULL),
 (13, 'CUSTOM-13', 'adv-13-des', 'adv-13-syn', 'adv-13-sum', 'adv-13-sol', 0, '2016-09-22 12:00:00-08', '2018-09-22 12:00:00-08', 'url13', NULL, NULL, NULL);
 
-UPDATE advisory_metadata SET package_data = '{"firefox": "77.0.1-1.fc31.x86_64"}' WHERE name = 'RH-9';
+UPDATE advisory_metadata SET package_data = '["firefox-77.0.1-1.fc31.x86_64", "firefox-77.0.1-1.fc31.s390"]' WHERE name = 'RH-9';
 
 INSERT INTO system_advisories (rh_account_id, system_id, advisory_id, first_reported, when_patched, status_id) VALUES
 (1, 1, 1, '2016-09-22 12:00:00-04', NULL, 0),

--- a/docs/docs_test.go
+++ b/docs/docs_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const openAPIPath = "openapi.json"
+const openAPIPath = "v2/openapi.json"
 
 func TestValidateOpenAPI3DocStr(t *testing.T) {
 	doc, err := ioutil.ReadFile(openAPIPath)

--- a/docs/v1/openapi.json
+++ b/docs/v1/openapi.json
@@ -246,7 +246,7 @@
             "get": {
                 "summary": "Show me details an advisory by given advisory name",
                 "description": "Show me details an advisory by given advisory name",
-                "operationId": "detailAdvisory",
+                "operationId": "detailAdvisoryV1",
                 "parameters": [
                     {
                         "name": "advisory_id",
@@ -264,7 +264,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/controllers.AdvisoryDetailResponse"
+                                    "$ref": "#/components/schemas/controllers.AdvisoryDetailResponseV1"
                                 }
                             }
                         }
@@ -300,6 +300,7 @@
                         }
                     }
                 },
+                "deprecated": true,
                 "security": [
                     {
                         "RhIdentity": []
@@ -3831,7 +3832,7 @@
                     }
                 }
             },
-            "controllers.AdvisoryDetailAttributes": {
+            "controllers.AdvisoryDetailAttributesV1": {
                 "type": "object",
                 "properties": {
                     "advisory_type_name": {
@@ -3853,10 +3854,7 @@
                         "type": "string"
                     },
                     "packages": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
-                        }
+                        "$ref": "#/components/schemas/controllers.packagesV1"
                     },
                     "public_date": {
                         "type": "string"
@@ -3890,11 +3888,11 @@
                     }
                 }
             },
-            "controllers.AdvisoryDetailItem": {
+            "controllers.AdvisoryDetailItemV1": {
                 "type": "object",
                 "properties": {
                     "attributes": {
-                        "$ref": "#/components/schemas/controllers.AdvisoryDetailAttributes"
+                        "$ref": "#/components/schemas/controllers.AdvisoryDetailAttributesV1"
                     },
                     "id": {
                         "type": "string"
@@ -3904,11 +3902,11 @@
                     }
                 }
             },
-            "controllers.AdvisoryDetailResponse": {
+            "controllers.AdvisoryDetailResponseV1": {
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/controllers.AdvisoryDetailItem"
+                        "$ref": "#/components/schemas/controllers.AdvisoryDetailItemV1"
                     }
                 }
             },
@@ -4917,6 +4915,12 @@
                         "description": "Updated baseline unique ID, it can not be changed",
                         "example": 1
                     }
+                }
+            },
+            "controllers.packagesV1": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "string"
                 }
             },
             "models.PackageUpdate": {

--- a/docs/v2/openapi.json
+++ b/docs/v2/openapi.json
@@ -1,0 +1,4950 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Patchman-engine API",
+        "description": "API of the Patch application on [console.redhat.com](https://console.redhat.com)\n\nSyntax of the `filter[name]` query parameters is described in  [Filters documentation](https://github.com/RedHatInsights/patchman-engine/wiki/API-custom-filters)",
+        "contact": {},
+        "license": {
+            "name": "GPLv3",
+            "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
+        },
+        "version": "v1.18.93"
+    },
+    "servers": [
+        {
+            "url": "/api/patch/v2"
+        }
+    ],
+    "paths": {
+        "/advisories": {
+            "get": {
+                "summary": "Show me all applicable advisories for all my systems",
+                "description": "Show me all applicable advisories for all my systems",
+                "operationId": "listAdvisories",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sort field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "id",
+                                "name",
+                                "advisory_type",
+                                "synopsis",
+                                "public_date",
+                                "applicable_systems"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[id]",
+                        "in": "query",
+                        "description": "Filter ",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[description]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[public_date]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[synopsis]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[advisory_type]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[advisory_type_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[severity]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[applicable_systems]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tag filter",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_system]",
+                        "in": "query",
+                        "description": "Filter only SAP systems",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_sids][in]",
+                        "in": "query",
+                        "description": "Filter systems by their SAP SIDs",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible]",
+                        "in": "query",
+                        "description": "Filter systems by ansible",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible][controller_version]",
+                        "in": "query",
+                        "description": "Filter systems by ansible version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql][version]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.AdvisoriesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/advisories/{advisory_id}": {
+            "get": {
+                "summary": "Show me details an advisory by given advisory name",
+                "description": "Show me details an advisory by given advisory name",
+                "operationId": "detailAdvisoryV2",
+                "parameters": [
+                    {
+                        "name": "advisory_id",
+                        "in": "path",
+                        "description": "Advisory ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.AdvisoryDetailResponseV2"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/advisories/{advisory_id}/systems": {
+            "get": {
+                "summary": "Show me systems on which the given advisory is applicable",
+                "description": "Show me systems on which the given advisory is applicable",
+                "operationId": "listAdvisorySystems",
+                "parameters": [
+                    {
+                        "name": "advisory_id",
+                        "in": "path",
+                        "description": "Advisory ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sort field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "id",
+                                "display_name",
+                                "last_evaluation",
+                                "last_upload",
+                                "rhsa_count",
+                                "rhba_count",
+                                "rhea_count",
+                                "other_count",
+                                "stale"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[id]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[insights_id]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[display_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[last_evaluation]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[last_upload]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhsa_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhba_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhea_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[other_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[stale]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[stale_timestamp]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[stale_warning_timestamp]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[culled_timestamp]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[created]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osname]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osminor]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osmajor]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[os]",
+                        "in": "query",
+                        "description": "Filter OS version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tag filter",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_system]",
+                        "in": "query",
+                        "description": "Filter only SAP systems",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_sids][in]",
+                        "in": "query",
+                        "description": "Filter systems by their SAP SIDs",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible]",
+                        "in": "query",
+                        "description": "Filter systems by ansible",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible][controller_version]",
+                        "in": "query",
+                        "description": "Filter systems by ansible version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql][version]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.AdvisorySystemsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/baselines": {
+            "get": {
+                "summary": "Show me all baselines for all my systems",
+                "description": "Show me all baselines for all my systems",
+                "operationId": "listBaseline",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sort field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "id",
+                                "name",
+                                "config"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[id]",
+                        "in": "query",
+                        "description": "Filter ",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[systems]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tag filter",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.BaselinesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            },
+            "put": {
+                "summary": "Create a baseline for my set of systems",
+                "description": "Create a baseline for my set of systems",
+                "operationId": "createBaseline",
+                "requestBody": {
+                    "description": "Request body",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/controllers.CreateBaselineRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.CreateBaselineResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ],
+                "x-codegen-request-body-name": "body"
+            }
+        },
+        "/baselines/systems/remove": {
+            "post": {
+                "summary": "Remove systems from baseline",
+                "description": "Remove systems from baseline",
+                "operationId": "removeBaselineSystems",
+                "requestBody": {
+                    "description": "Request body",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/controllers.BaselineSystemsRemoveRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {}
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ],
+                "x-codegen-request-body-name": "body"
+            }
+        },
+        "/baselines/{baseline_id}": {
+            "get": {
+                "summary": "Show baseline detail by given baseline ID",
+                "description": "Show baseline detail by given baseline ID",
+                "operationId": "detailBaseline",
+                "parameters": [
+                    {
+                        "name": "baseline_id",
+                        "in": "path",
+                        "description": "Baseline ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.BaselineDetailResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            },
+            "put": {
+                "summary": "Update a baseline for my set of systems",
+                "description": "Update a baseline for my set of systems",
+                "operationId": "updateBaseline",
+                "parameters": [
+                    {
+                        "name": "baseline_id",
+                        "in": "path",
+                        "description": "Baseline ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "description": "Request body",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/controllers.UpdateBaselineRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.UpdateBaselineResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ],
+                "x-codegen-request-body-name": "body"
+            },
+            "delete": {
+                "summary": "Delete a baseline",
+                "description": "Delete a baseline",
+                "operationId": "baselineDelete",
+                "parameters": [
+                    {
+                        "name": "baseline_id",
+                        "in": "path",
+                        "description": "Baseline ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.DeleteBaselineResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/baselines/{baseline_id}/systems": {
+            "get": {
+                "summary": "Show me all systems belonging to a baseline",
+                "description": "Show me all systems applicable to a baseline",
+                "operationId": "listBaselineSystems",
+                "parameters": [
+                    {
+                        "name": "baseline_id",
+                        "in": "path",
+                        "description": "Baseline ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sort field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "id",
+                                "name",
+                                "config"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[display_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tag filter",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.BaselineSystemsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/export/advisories": {
+            "get": {
+                "summary": "Export applicable advisories for all my systems",
+                "description": "Export applicable advisories for all my systems",
+                "operationId": "exportAdvisories",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[id]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[description]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[public_date]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[synopsis]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[advisory_type]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[advisory_type_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[severity]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[applicable_systems]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.AdvisoryInlineItem"
+                                    }
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.AdvisoryInlineItem"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/export/advisories/{advisory_id}/systems": {
+            "get": {
+                "summary": "Export systems for my account",
+                "description": "Export systems for my account",
+                "operationId": "exportAdvisorySystems",
+                "parameters": [
+                    {
+                        "name": "advisory_id",
+                        "in": "path",
+                        "description": "Advisory ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[id]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[display_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[last_evaluation]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[last_upload]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhsa_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhba_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhea_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[other_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[stale]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[packages_installed]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[packages_updatable]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_system]",
+                        "in": "query",
+                        "description": "Filter only SAP systems",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_sids][in]",
+                        "in": "query",
+                        "description": "Filter systems by their SAP SIDs",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible]",
+                        "in": "query",
+                        "description": "Filter systems by ansible",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible][controller_version]",
+                        "in": "query",
+                        "description": "Filter systems by ansible version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql][version]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osname]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osminor]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osmajor]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[os]",
+                        "in": "query",
+                        "description": "Filter OS version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tag filter",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.SystemInlineItem"
+                                    }
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.SystemInlineItem"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/export/packages": {
+            "get": {
+                "summary": "Show me all installed packages across my systems",
+                "description": "Show me all installed packages across my systems",
+                "operationId": "exportPackages",
+                "parameters": [
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sort field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "id",
+                                "name",
+                                "systems_installed",
+                                "systems_updatable"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[systems_installed]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[systems_updatable]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[summary]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.PackageItem"
+                                    }
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.PackageItem"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/export/packages/{package_name}/systems": {
+            "get": {
+                "summary": "Show me all my systems which have a package installed",
+                "description": "Show me all my systems which have a package installed",
+                "operationId": "exportPackageSystems",
+                "parameters": [
+                    {
+                        "name": "package_name",
+                        "in": "path",
+                        "description": "Package name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_system]",
+                        "in": "query",
+                        "description": "Filter only SAP systems",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_sids][in]",
+                        "in": "query",
+                        "description": "Filter systems by their SAP SIDs",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible]",
+                        "in": "query",
+                        "description": "Filter systems by ansible",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible][controller_version]",
+                        "in": "query",
+                        "description": "Filter systems by ansible version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql][version]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tag filter",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.PackageSystemItem"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/export/systems": {
+            "get": {
+                "summary": "Export systems for my account",
+                "description": "Export systems for my account",
+                "operationId": "exportSystems",
+                "parameters": [
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[id]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[display_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[last_evaluation]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[last_upload]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhsa_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhba_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhea_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[other_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[stale]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[packages_installed]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[packages_updatable]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_system]",
+                        "in": "query",
+                        "description": "Filter only SAP systems",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_sids][in]",
+                        "in": "query",
+                        "description": "Filter systems by their SAP SIDs",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible]",
+                        "in": "query",
+                        "description": "Filter systems by ansible",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible][controller_version]",
+                        "in": "query",
+                        "description": "Filter systems by ansible version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql][version]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osname]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osminor]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osmajor]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[baseline_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[os]",
+                        "in": "query",
+                        "description": "Filter OS version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tag filter",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.SystemInlineItem"
+                                    }
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.SystemInlineItem"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/export/systems/{inventory_id}/advisories": {
+            "get": {
+                "summary": "Export applicable advisories for all my systems",
+                "description": "Export applicable advisories for all my systems",
+                "operationId": "exportSystemAdvisories",
+                "parameters": [
+                    {
+                        "name": "inventory_id",
+                        "in": "path",
+                        "description": "Inventory ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[id]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[description]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[public_date]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[synopsis]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[advisory_type]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[advisory_type_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[severity]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.SystemAdvisoriesDBLookup"
+                                    }
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.SystemAdvisoriesDBLookup"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            },
+                            "text/csv": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/export/systems/{inventory_id}/packages": {
+            "get": {
+                "summary": "Show me details about a system packages by given inventory id",
+                "description": "Show me details about a system packages by given inventory id",
+                "operationId": "exportSystemPackages",
+                "parameters": [
+                    {
+                        "name": "inventory_id",
+                        "in": "path",
+                        "description": "Inventory ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[description]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[evra]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[summary]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[updatable]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/controllers.SystemPackageInline"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "Unsupported Media Type",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/packages/": {
+            "get": {
+                "summary": "Show me all installed packages across my systems",
+                "description": "Show me all installed packages across my systems",
+                "operationId": "listPackages",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sort field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "id",
+                                "name",
+                                "systems_installed",
+                                "systems_updatable"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[systems_installed]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[systems_updatable]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[summary]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tag filter",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_system]",
+                        "in": "query",
+                        "description": "Filter only SAP systems",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_sids][in]",
+                        "in": "query",
+                        "description": "Filter systems by their SAP SIDs",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible]",
+                        "in": "query",
+                        "description": "Filter systems by ansible",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible][controller_version]",
+                        "in": "query",
+                        "description": "Filter systems by ansible version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql][version]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.PackagesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/packages/{package_name}": {
+            "get": {
+                "summary": "Show me metadata of selected package",
+                "description": "Show me metadata of selected package",
+                "operationId": "LatestPackage",
+                "parameters": [
+                    {
+                        "name": "package_name",
+                        "in": "path",
+                        "description": "package_name - latest, nevra - exact version",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.PackageDetailResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/packages/{package_name}/systems": {
+            "get": {
+                "summary": "Show me all my systems which have a package installed",
+                "description": "Show me all my systems which have a package installed",
+                "operationId": "packageSystems",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "package_name",
+                        "in": "path",
+                        "description": "Package name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tag filter",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_system]",
+                        "in": "query",
+                        "description": "Filter only SAP systems",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_sids][in]",
+                        "in": "query",
+                        "description": "Filter systems by their SAP SIDs",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible]",
+                        "in": "query",
+                        "description": "Filter systems by ansible",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible][controller_version]",
+                        "in": "query",
+                        "description": "Filter systems by ansible version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql][version]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.PackageSystemsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/packages/{package_name}/versions": {
+            "get": {
+                "summary": "Show me all package versions installed on some system",
+                "description": "Show me all package versions installed on some system",
+                "operationId": "packageVersions",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "package_name",
+                        "in": "path",
+                        "description": "Package name",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.PackageVersionsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/systems": {
+            "get": {
+                "summary": "Show me all my systems",
+                "description": "Show me all my systems",
+                "operationId": "listSystems",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sort field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "id",
+                                "display_name",
+                                "last_evaluation",
+                                "last_upload",
+                                "rhsa_count",
+                                "rhba_count",
+                                "rhea_count",
+                                "other_count",
+                                "stale",
+                                "packages_installed",
+                                "packages_updatable"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[insights_id]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[id]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[display_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[last_evaluation]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[last_upload]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhsa_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhba_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[rhea_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[other_count]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[stale]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[packages_installed]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[packages_updatable]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[stale_timestamp]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[stale_warning_timestamp]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[culled_timestamp]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[created]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osname]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osminor]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[osmajor]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[baseline_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[os]",
+                        "in": "query",
+                        "description": "Filter OS version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "Tag filter",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_system]",
+                        "in": "query",
+                        "description": "Filter only SAP systems",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][sap_sids][in]",
+                        "in": "query",
+                        "description": "Filter systems by their SAP SIDs",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible]",
+                        "in": "query",
+                        "description": "Filter systems by ansible",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][ansible][controller_version]",
+                        "in": "query",
+                        "description": "Filter systems by ansible version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[system_profile][mssql][version]",
+                        "in": "query",
+                        "description": "Filter systems by mssql version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.SystemsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/systems/{inventory_id}": {
+            "get": {
+                "summary": "Show me details about a system by given inventory id",
+                "description": "Show me details about a system by given inventory id",
+                "operationId": "detailSystem",
+                "parameters": [
+                    {
+                        "name": "inventory_id",
+                        "in": "path",
+                        "description": "Inventory ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.SystemDetailResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            },
+            "delete": {
+                "summary": "Delete system by inventory id",
+                "description": "Delete system by inventory id",
+                "operationId": "deletesystem",
+                "parameters": [
+                    {
+                        "name": "inventory_id",
+                        "in": "path",
+                        "description": "Inventory ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {}
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/systems/{inventory_id}/advisories": {
+            "get": {
+                "summary": "Show me advisories for a system by given inventory id",
+                "description": "Show me advisories for a system by given inventory id",
+                "operationId": "listSystemAdvisories",
+                "parameters": [
+                    {
+                        "name": "inventory_id",
+                        "in": "path",
+                        "description": "Inventory ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sort field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "id",
+                                "name",
+                                "type",
+                                "synopsis",
+                                "public_date"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[id]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[description]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[public_date]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[synopsis]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[advisory_type]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[advisory_type_name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[severity]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.SystemAdvisoriesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/systems/{inventory_id}/packages": {
+            "get": {
+                "summary": "Show me details about a system packages by given inventory id",
+                "description": "Show me details about a system packages by given inventory id",
+                "operationId": "systemPackages",
+                "parameters": [
+                    {
+                        "name": "inventory_id",
+                        "in": "path",
+                        "description": "Inventory ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[name]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[description]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[evra]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[summary]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "filter[updatable]",
+                        "in": "query",
+                        "description": "Filter",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.SystemPackageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/views/advisories/systems": {
+            "post": {
+                "summary": "View advisory-system pairs for selected systems and advisories",
+                "description": "View advisory-system pairs for selected systems and advisories",
+                "operationId": "viewAdvisoriesSystems",
+                "requestBody": {
+                    "description": "Request body",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/controllers.SystemsAdvisoriesRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.AdvisoriesSystemsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ],
+                "x-codegen-request-body-name": "body"
+            }
+        },
+        "/views/systems/advisories": {
+            "post": {
+                "summary": "View system-advisory pairs for selected systems and advisories",
+                "description": "View system-advisory pairs for selected systems and advisories",
+                "operationId": "viewSystemsAdvisories",
+                "requestBody": {
+                    "description": "Request body",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/controllers.SystemsAdvisoriesRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.SystemsAdvisoriesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ],
+                "x-codegen-request-body-name": "body"
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "controllers.AdvisoriesResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.AdvisoryItem"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
+                    }
+                }
+            },
+            "controllers.AdvisoriesSystemsResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "controllers.AdvisoryDetailAttributesV2": {
+                "type": "object",
+                "properties": {
+                    "advisory_type_name": {
+                        "type": "string"
+                    },
+                    "cves": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "fixes": {
+                        "type": "string"
+                    },
+                    "modified_date": {
+                        "type": "string"
+                    },
+                    "packages": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "public_date": {
+                        "type": "string"
+                    },
+                    "reboot_required": {
+                        "type": "boolean"
+                    },
+                    "references": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "release_versions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "severity": {
+                        "type": "integer"
+                    },
+                    "solution": {
+                        "type": "string"
+                    },
+                    "synopsis": {
+                        "type": "string"
+                    },
+                    "topic": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.AdvisoryDetailItemV2": {
+                "type": "object",
+                "properties": {
+                    "attributes": {
+                        "$ref": "#/components/schemas/controllers.AdvisoryDetailAttributesV2"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.AdvisoryDetailResponseV2": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/controllers.AdvisoryDetailItemV2"
+                    }
+                }
+            },
+            "controllers.AdvisoryInlineItem": {
+                "type": "object",
+                "properties": {
+                    "advisory_type": {
+                        "type": "integer",
+                        "description": "Deprecated, not useful database ID (0 - unknown, 1 -, enhancement, 2 - bugfix, 3 - security, 4 - unspecified)"
+                    },
+                    "advisory_type_name": {
+                        "type": "string",
+                        "description": "Advisory type name, proper ordering ensured (unknown, unspecified, other, enhancement, bugfix, security)"
+                    },
+                    "applicable_systems": {
+                        "type": "integer"
+                    },
+                    "cve_count": {
+                        "type": "integer"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_date": {
+                        "type": "string"
+                    },
+                    "reboot_required": {
+                        "type": "boolean"
+                    },
+                    "release_versions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "severity": {
+                        "type": "integer"
+                    },
+                    "synopsis": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.AdvisoryItem": {
+                "type": "object",
+                "properties": {
+                    "attributes": {
+                        "$ref": "#/components/schemas/controllers.AdvisoryItemAttributes"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.AdvisoryItemAttributes": {
+                "type": "object",
+                "properties": {
+                    "advisory_type": {
+                        "type": "integer",
+                        "description": "Deprecated, not useful database ID (0 - unknown, 1 -, enhancement, 2 - bugfix, 3 - security, 4 - unspecified)"
+                    },
+                    "advisory_type_name": {
+                        "type": "string",
+                        "description": "Advisory type name, proper ordering ensured (unknown, unspecified, other, enhancement, bugfix, security)"
+                    },
+                    "applicable_systems": {
+                        "type": "integer"
+                    },
+                    "cve_count": {
+                        "type": "integer"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "public_date": {
+                        "type": "string"
+                    },
+                    "reboot_required": {
+                        "type": "boolean"
+                    },
+                    "release_versions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "severity": {
+                        "type": "integer"
+                    },
+                    "synopsis": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.AdvisorySystemsResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.SystemItem"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
+                    }
+                }
+            },
+            "controllers.BaselineConfig": {
+                "type": "object",
+                "properties": {
+                    "to_time": {
+                        "type": "string",
+                        "description": "Filter applicable advisories (updates) by the latest publish time.",
+                        "example": "2022-12-31T12:00:00-04:00"
+                    }
+                }
+            },
+            "controllers.BaselineDetailAttributes": {
+                "type": "object",
+                "properties": {
+                    "config": {
+                        "$ref": "#/components/schemas/controllers.BaselineConfig"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Baseline name",
+                        "example": "my_baseline"
+                    }
+                }
+            },
+            "controllers.BaselineDetailItem": {
+                "type": "object",
+                "properties": {
+                    "attributes": {
+                        "$ref": "#/components/schemas/controllers.BaselineDetailAttributes"
+                    },
+                    "id": {
+                        "type": "integer",
+                        "description": "Baseline ID",
+                        "example": 1
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Document type name",
+                        "example": "baseline"
+                    }
+                }
+            },
+            "controllers.BaselineDetailResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/controllers.BaselineDetailItem"
+                    }
+                }
+            },
+            "controllers.BaselineItem": {
+                "type": "object",
+                "properties": {
+                    "attributes": {
+                        "$ref": "#/components/schemas/controllers.BaselineItemAttributes"
+                    },
+                    "id": {
+                        "type": "integer",
+                        "description": "Unique baseline id",
+                        "example": 10
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Document type name",
+                        "example": "baseline"
+                    }
+                }
+            },
+            "controllers.BaselineItemAttributes": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Baseline name",
+                        "example": "my-baseline"
+                    },
+                    "systems": {
+                        "type": "integer",
+                        "description": "Count of the systems associated with the baseline",
+                        "example": 22
+                    }
+                }
+            },
+            "controllers.BaselineSystemAttributes": {
+                "type": "object",
+                "properties": {
+                    "display_name": {
+                        "type": "string",
+                        "description": "Baseline system display name",
+                        "example": "my-baselined-system"
+                    }
+                }
+            },
+            "controllers.BaselineSystemItem": {
+                "type": "object",
+                "properties": {
+                    "attributes": {
+                        "$ref": "#/components/schemas/controllers.BaselineSystemAttributes"
+                    },
+                    "inventory_id": {
+                        "type": "string",
+                        "description": "Baseline system inventory ID (uuid format)",
+                        "example": "00000000-0000-0000-0000-000000000001"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Document type name",
+                        "example": "baseline_system"
+                    }
+                }
+            },
+            "controllers.BaselineSystemsRemoveRequest": {
+                "type": "object",
+                "properties": {
+                    "inventory_ids": {
+                        "type": "array",
+                        "description": "List of inventory IDs to have baselines removed",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "controllers.BaselineSystemsResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.BaselineSystemItem"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
+                    }
+                }
+            },
+            "controllers.BaselinesResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "description": "Baseline items",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.BaselineItem"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
+                    }
+                }
+            },
+            "controllers.CreateBaselineRequest": {
+                "type": "object",
+                "properties": {
+                    "config": {
+                        "$ref": "#/components/schemas/controllers.BaselineConfig"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the baseline (optional)."
+                    },
+                    "inventory_ids": {
+                        "type": "array",
+                        "description": "Inventory IDs list of systems to associate with this baseline (optional).",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Baseline name"
+                    }
+                }
+            },
+            "controllers.CreateBaselineResponse": {
+                "type": "object",
+                "properties": {
+                    "baseline_id": {
+                        "type": "integer",
+                        "description": "Updated baseline unique ID, it can not be changed",
+                        "example": 1
+                    }
+                }
+            },
+            "controllers.DeleteBaselineResponse": {
+                "type": "object",
+                "properties": {
+                    "baseline_id": {
+                        "type": "integer",
+                        "description": "Updated baseline unique ID, it can not be changed",
+                        "example": 1
+                    }
+                }
+            },
+            "controllers.FilterData": {
+                "type": "object",
+                "properties": {
+                    "op": {
+                        "type": "string"
+                    },
+                    "values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "controllers.Links": {
+                "type": "object",
+                "properties": {
+                    "first": {
+                        "type": "string",
+                        "example": "/link/to/the/first"
+                    },
+                    "last": {
+                        "type": "string",
+                        "example": "/link/to/the/last"
+                    },
+                    "next": {
+                        "type": "string",
+                        "example": "/link/to/the/next"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "example": "/link/to/the/previous"
+                    }
+                }
+            },
+            "controllers.ListMeta": {
+                "type": "object",
+                "properties": {
+                    "filter": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/controllers.FilterData"
+                        },
+                        "description": "Used filters"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Used response limit (page size) - pagination",
+                        "example": 20
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "description": "Used response offset - pagination",
+                        "example": 0
+                    },
+                    "search": {
+                        "type": "string",
+                        "description": "Used search terms",
+                        "example": "kernel"
+                    },
+                    "sort": {
+                        "type": "array",
+                        "description": "Used sorting fields",
+                        "example": [
+                            "name"
+                        ],
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "subtotals": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "integer"
+                        },
+                        "description": "Some subtotals used by some endpoints"
+                    },
+                    "total_items": {
+                        "type": "integer",
+                        "description": "Total items count to return",
+                        "example": 1000
+                    }
+                }
+            },
+            "controllers.PackageDetailAttributes": {
+                "type": "object",
+                "properties": {
+                    "advisory_id": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "version": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.PackageDetailItem": {
+                "type": "object",
+                "properties": {
+                    "attributes": {
+                        "$ref": "#/components/schemas/controllers.PackageDetailAttributes"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.PackageDetailResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/controllers.PackageDetailItem"
+                    }
+                }
+            },
+            "controllers.PackageItem": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "systems_installed": {
+                        "type": "integer"
+                    },
+                    "systems_updatable": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "controllers.PackageSystemItem": {
+                "type": "object",
+                "properties": {
+                    "available_evra": {
+                        "type": "string"
+                    },
+                    "baseline_name": {
+                        "type": "string"
+                    },
+                    "baseline_uptodate": {
+                        "type": "boolean"
+                    },
+                    "display_name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "installed_evra": {
+                        "type": "string"
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.SystemTag"
+                        }
+                    },
+                    "updatable": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "controllers.PackageSystemsResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.PackageSystemItem"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
+                    }
+                }
+            },
+            "controllers.PackageVersionItem": {
+                "type": "object",
+                "properties": {
+                    "evra": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.PackageVersionsResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.PackageVersionItem"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
+                    }
+                }
+            },
+            "controllers.PackagesResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.PackageItem"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
+                    }
+                }
+            },
+            "controllers.SystemAdvisoriesDBLookup": {
+                "type": "object",
+                "properties": {
+                    "advisory_type": {
+                        "type": "integer",
+                        "description": "Deprecated, not useful database ID (0 - unknown, 1 -, enhancement, 2 - bugfix, 3 - security, 4 - unspecified)"
+                    },
+                    "advisory_type_name": {
+                        "type": "string",
+                        "description": "Advisory type name, proper ordering ensured (unknown, unspecified, other, enhancement, bugfix, security)"
+                    },
+                    "cve_count": {
+                        "type": "integer"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "public_date": {
+                        "type": "string"
+                    },
+                    "reboot_required": {
+                        "type": "boolean"
+                    },
+                    "release_versions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "severity": {
+                        "type": "integer"
+                    },
+                    "synopsis": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.SystemAdvisoriesResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "description": "advisories items",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.SystemAdvisoryItem"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
+                    }
+                }
+            },
+            "controllers.SystemAdvisoryItem": {
+                "type": "object",
+                "properties": {
+                    "attributes": {
+                        "$ref": "#/components/schemas/controllers.SystemAdvisoryItemAttributes"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.SystemAdvisoryItemAttributes": {
+                "type": "object",
+                "properties": {
+                    "advisory_type": {
+                        "type": "integer",
+                        "description": "Deprecated, not useful database ID (0 - unknown, 1 -, enhancement, 2 - bugfix, 3 - security, 4 - unspecified)"
+                    },
+                    "advisory_type_name": {
+                        "type": "string",
+                        "description": "Advisory type name, proper ordering ensured (unknown, unspecified, other, enhancement, bugfix, security)"
+                    },
+                    "cve_count": {
+                        "type": "integer"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "public_date": {
+                        "type": "string"
+                    },
+                    "reboot_required": {
+                        "type": "boolean"
+                    },
+                    "release_versions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "severity": {
+                        "type": "integer"
+                    },
+                    "synopsis": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.SystemDetailResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/controllers.SystemItem"
+                    }
+                }
+            },
+            "controllers.SystemInlineItem": {
+                "type": "object",
+                "properties": {
+                    "baseline_name": {
+                        "type": "string"
+                    },
+                    "baseline_uptodate": {
+                        "type": "boolean"
+                    },
+                    "created": {
+                        "type": "string"
+                    },
+                    "culled_timestamp": {
+                        "type": "string"
+                    },
+                    "display_name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "insights_id": {
+                        "type": "string"
+                    },
+                    "last_evaluation": {
+                        "type": "string"
+                    },
+                    "last_upload": {
+                        "type": "string"
+                    },
+                    "os": {
+                        "type": "string"
+                    },
+                    "os_major": {
+                        "type": "string"
+                    },
+                    "os_minor": {
+                        "type": "string"
+                    },
+                    "os_name": {
+                        "type": "string"
+                    },
+                    "other_count": {
+                        "type": "integer"
+                    },
+                    "packages_installed": {
+                        "type": "integer"
+                    },
+                    "packages_updatable": {
+                        "type": "integer"
+                    },
+                    "rhba_count": {
+                        "type": "integer"
+                    },
+                    "rhea_count": {
+                        "type": "integer"
+                    },
+                    "rhsa_count": {
+                        "type": "integer"
+                    },
+                    "rhsm": {
+                        "type": "string"
+                    },
+                    "stale": {
+                        "type": "boolean"
+                    },
+                    "stale_timestamp": {
+                        "type": "string"
+                    },
+                    "stale_warning_timestamp": {
+                        "type": "string"
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.SystemTag"
+                        }
+                    },
+                    "third_party": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "controllers.SystemItem": {
+                "type": "object",
+                "properties": {
+                    "attributes": {
+                        "$ref": "#/components/schemas/controllers.SystemItemAttributes"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.SystemItemAttributes": {
+                "type": "object",
+                "properties": {
+                    "baseline_name": {
+                        "type": "string"
+                    },
+                    "baseline_uptodate": {
+                        "type": "boolean"
+                    },
+                    "created": {
+                        "type": "string"
+                    },
+                    "culled_timestamp": {
+                        "type": "string"
+                    },
+                    "display_name": {
+                        "type": "string"
+                    },
+                    "insights_id": {
+                        "type": "string"
+                    },
+                    "last_evaluation": {
+                        "type": "string"
+                    },
+                    "last_upload": {
+                        "type": "string"
+                    },
+                    "os": {
+                        "type": "string"
+                    },
+                    "os_major": {
+                        "type": "string"
+                    },
+                    "os_minor": {
+                        "type": "string"
+                    },
+                    "os_name": {
+                        "type": "string"
+                    },
+                    "other_count": {
+                        "type": "integer"
+                    },
+                    "packages_installed": {
+                        "type": "integer"
+                    },
+                    "packages_updatable": {
+                        "type": "integer"
+                    },
+                    "rhba_count": {
+                        "type": "integer"
+                    },
+                    "rhea_count": {
+                        "type": "integer"
+                    },
+                    "rhsa_count": {
+                        "type": "integer"
+                    },
+                    "rhsm": {
+                        "type": "string"
+                    },
+                    "stale": {
+                        "type": "boolean"
+                    },
+                    "stale_timestamp": {
+                        "type": "string"
+                    },
+                    "stale_warning_timestamp": {
+                        "type": "string"
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.SystemTag"
+                        }
+                    },
+                    "third_party": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "controllers.SystemPackageData": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "evra": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "updatable": {
+                        "type": "boolean"
+                    },
+                    "updates": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/models.PackageUpdate"
+                        }
+                    }
+                }
+            },
+            "controllers.SystemPackageInline": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "evra": {
+                        "type": "string"
+                    },
+                    "latest_evra": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "summary": {
+                        "type": "string"
+                    },
+                    "updatable": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "controllers.SystemPackageResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.SystemPackageData"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
+                    }
+                }
+            },
+            "controllers.SystemTag": {
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "type": "string"
+                    },
+                    "namespace": {
+                        "type": "string"
+                    },
+                    "value": {
+                        "type": "string"
+                    }
+                }
+            },
+            "controllers.SystemsAdvisoriesRequest": {
+                "type": "object",
+                "properties": {
+                    "advisories": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "systems": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "controllers.SystemsAdvisoriesResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "controllers.SystemsResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.SystemItem"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
+                    }
+                }
+            },
+            "controllers.UpdateBaselineRequest": {
+                "type": "object",
+                "properties": {
+                    "config": {
+                        "$ref": "#/components/schemas/controllers.BaselineConfig"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the baseline (optional)."
+                    },
+                    "inventory_ids": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "boolean"
+                        },
+                        "description": "Map of inventories to add to (true) or remove (false) from given baseline (optional)"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Updated baseline name (optional)",
+                        "example": "my-changed-baseline-name"
+                    }
+                }
+            },
+            "controllers.UpdateBaselineResponse": {
+                "type": "object",
+                "properties": {
+                    "baseline_id": {
+                        "type": "integer",
+                        "description": "Updated baseline unique ID, it can not be changed",
+                        "example": 1
+                    }
+                }
+            },
+            "models.PackageUpdate": {
+                "type": "object",
+                "properties": {
+                    "advisory": {
+                        "type": "string"
+                    },
+                    "evra": {
+                        "type": "string"
+                    }
+                }
+            },
+            "utils.ErrorResponse": {
+                "type": "object",
+                "properties": {
+                    "error": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "RhIdentity": {
+                "type": "apiKey",
+                "name": "x-rh-identity",
+                "in": "header"
+            }
+        }
+    }
+}

--- a/manager/controllers/advisories.go
+++ b/manager/controllers/advisories.go
@@ -101,7 +101,7 @@ func advisoriesSubtotal(tx *gorm.DB) (total int, subTotals map[string]int, err e
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/advisories [get]
+// @Router /advisories [get]
 func AdvisoriesListHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 	var query *gorm.DB

--- a/manager/controllers/advisories_export.go
+++ b/manager/controllers/advisories_export.go
@@ -28,7 +28,7 @@ import (
 // @Success 200 {array} AdvisoryInlineItem
 // @Failure 415 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/export/advisories [get]
+// @Router /export/advisories [get]
 func AdvisoriesExportHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 	filters, err := ParseTagsFilters(c)

--- a/manager/controllers/advisory_detail.go
+++ b/manager/controllers/advisory_detail.go
@@ -27,16 +27,19 @@ type AdvisoryDetailResponseV2 struct {
 	Data AdvisoryDetailItemV2 `json:"data"`
 }
 
+type AdvisoryDetailItem struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
 type AdvisoryDetailItemV1 struct {
+	AdvisoryDetailItem
 	Attributes AdvisoryDetailAttributesV1 `json:"attributes"`
-	ID         string                     `json:"id"`
-	Type       string                     `json:"type"`
 }
 
 type AdvisoryDetailItemV2 struct {
+	AdvisoryDetailItem
 	Attributes AdvisoryDetailAttributesV2 `json:"attributes"`
-	ID         string                     `json:"id"`
-	Type       string                     `json:"type"`
 }
 
 type AdvisoryDetailAttributes struct {
@@ -68,19 +71,9 @@ type AdvisoryDetailAttributesV2 struct {
 type packagesV1 map[string]string
 type packagesV2 []string
 
-// @Summary Show me details an advisory by given advisory name
-// @Description Show me details an advisory by given advisory name
-// @ID detailAdvisoryV1
-// @Security RhIdentity
-// @Accept   json
-// @Produce  json
-// @Param    advisory_id    path    string   true "Advisory ID"
-// @Success 200 {object} AdvisoryDetailResponseV1
-// @Failure 400 {object} utils.ErrorResponse
-// @Failure 404 {object} utils.ErrorResponse
-// @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/advisories/{advisory_id} [get]
-// @Deprecated true
+// AdvisoryDetail handler for v1 API
+// Don't annotate it with swaggo/swag annotations
+// because we want to generated openapi.json only for v2 API
 func AdvisoryDetailHandlerV1(c *gin.Context) {
 	advisoryDetailHandler(c, "v1")
 }
@@ -96,7 +89,7 @@ func AdvisoryDetailHandlerV1(c *gin.Context) {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v2/advisories/{advisory_id} [get]
+// @Router /advisories/{advisory_id} [get]
 func AdvisoryDetailHandlerV2(c *gin.Context) {
 	advisoryDetailHandler(c, "v2")
 }
@@ -186,12 +179,11 @@ func getAdvisoryFromDBV1(advisoryName string) (*AdvisoryDetailResponseV1, error)
 	}
 
 	var resp = AdvisoryDetailResponseV1{Data: AdvisoryDetailItemV1{
+		AdvisoryDetailItem: AdvisoryDetailItem{ID: advisory.Name, Type: "advisory"},
 		Attributes: AdvisoryDetailAttributesV1{
 			AdvisoryDetailAttributes: *ada,
 			Packages:                 pkgs,
 		},
-		ID:   advisory.Name,
-		Type: "advisory",
 	}}
 	return &resp, nil
 }
@@ -208,12 +200,11 @@ func getAdvisoryFromDBV2(advisoryName string) (*AdvisoryDetailResponseV2, error)
 	}
 
 	var resp = AdvisoryDetailResponseV2{Data: AdvisoryDetailItemV2{
+		AdvisoryDetailItem: AdvisoryDetailItem{ID: advisory.Name, Type: "advisory"},
 		Attributes: AdvisoryDetailAttributesV2{
 			AdvisoryDetailAttributes: *ada,
 			Packages:                 pkgs,
 		},
-		ID:   advisory.Name,
-		Type: "advisory",
 	}}
 	return &resp, nil
 }

--- a/manager/controllers/advisory_detail.go
+++ b/manager/controllers/advisory_detail.go
@@ -16,48 +16,92 @@ import (
 
 var enableAdvisoryDetailCache = utils.GetBoolEnvOrDefault("ENABLE_ADVISORY_DETAIL_CACHE", true)
 var advisoryDetailCacheSize = utils.GetIntEnvOrDefault("ADVISORY_DETAIL_CACHE_SIZE", 100)
-var advisoryDetailCache = initAdvisoryDetailCache()
+var advisoryDetailCacheV1 = initAdvisoryDetailCache()
+var advisoryDetailCacheV2 = initAdvisoryDetailCache()
 
-type AdvisoryDetailResponse struct {
-	Data AdvisoryDetailItem `json:"data"`
+type AdvisoryDetailResponseV1 struct {
+	Data AdvisoryDetailItemV1 `json:"data"`
 }
 
-type AdvisoryDetailItem struct {
-	Attributes AdvisoryDetailAttributes `json:"attributes"`
-	ID         string                   `json:"id"`
-	Type       string                   `json:"type"`
+type AdvisoryDetailResponseV2 struct {
+	Data AdvisoryDetailItemV2 `json:"data"`
+}
+
+type AdvisoryDetailItemV1 struct {
+	Attributes AdvisoryDetailAttributesV1 `json:"attributes"`
+	ID         string                     `json:"id"`
+	Type       string                     `json:"type"`
+}
+
+type AdvisoryDetailItemV2 struct {
+	Attributes AdvisoryDetailAttributesV2 `json:"attributes"`
+	ID         string                     `json:"id"`
+	Type       string                     `json:"type"`
 }
 
 type AdvisoryDetailAttributes struct {
-	Description      string            `json:"description"`
-	ModifiedDate     time.Time         `json:"modified_date"`
-	PublicDate       time.Time         `json:"public_date"`
-	Topic            string            `json:"topic"`
-	Synopsis         string            `json:"synopsis"`
-	Solution         string            `json:"solution"`
-	AdvisoryTypeName string            `json:"advisory_type_name"`
-	Severity         *int              `json:"severity"`
-	Fixes            *string           `json:"fixes"`
-	Cves             []string          `json:"cves"`
-	Packages         map[string]string `json:"packages"`
-	References       []string          `json:"references"`
-	RebootRequired   bool              `json:"reboot_required"`
-	ReleaseVersions  []string          `json:"release_versions"`
+	Description      string    `json:"description"`
+	ModifiedDate     time.Time `json:"modified_date"`
+	PublicDate       time.Time `json:"public_date"`
+	Topic            string    `json:"topic"`
+	Synopsis         string    `json:"synopsis"`
+	Solution         string    `json:"solution"`
+	AdvisoryTypeName string    `json:"advisory_type_name"`
+	Severity         *int      `json:"severity"`
+	Fixes            *string   `json:"fixes"`
+	Cves             []string  `json:"cves"`
+	References       []string  `json:"references"`
+	RebootRequired   bool      `json:"reboot_required"`
+	ReleaseVersions  []string  `json:"release_versions"`
 }
+
+type AdvisoryDetailAttributesV1 struct {
+	AdvisoryDetailAttributes
+	Packages packagesV1 `json:"packages"`
+}
+
+type AdvisoryDetailAttributesV2 struct {
+	AdvisoryDetailAttributes
+	Packages packagesV2 `json:"packages"`
+}
+
+type packagesV1 map[string]string
+type packagesV2 []string
 
 // @Summary Show me details an advisory by given advisory name
 // @Description Show me details an advisory by given advisory name
-// @ID detailAdvisory
+// @ID detailAdvisoryV1
 // @Security RhIdentity
 // @Accept   json
 // @Produce  json
 // @Param    advisory_id    path    string   true "Advisory ID"
-// @Success 200 {object} AdvisoryDetailResponse
+// @Success 200 {object} AdvisoryDetailResponseV1
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
 // @Router /api/patch/v1/advisories/{advisory_id} [get]
-func AdvisoryDetailHandler(c *gin.Context) {
+// @Deprecated true
+func AdvisoryDetailHandlerV1(c *gin.Context) {
+	advisoryDetailHandler(c, "v1")
+}
+
+// @Summary Show me details an advisory by given advisory name
+// @Description Show me details an advisory by given advisory name
+// @ID detailAdvisoryV2
+// @Security RhIdentity
+// @Accept   json
+// @Produce  json
+// @Param    advisory_id    path    string   true "Advisory ID"
+// @Success 200 {object} AdvisoryDetailResponseV2
+// @Failure 400 {object} utils.ErrorResponse
+// @Failure 404 {object} utils.ErrorResponse
+// @Failure 500 {object} utils.ErrorResponse
+// @Router /api/patch/v2/advisories/{advisory_id} [get]
+func AdvisoryDetailHandlerV2(c *gin.Context) {
+	advisoryDetailHandler(c, "v2")
+}
+
+func advisoryDetailHandler(c *gin.Context, apiver string) {
 	advisoryName := c.Param("advisory_id")
 	if advisoryName == "" {
 		c.JSON(http.StatusBadRequest, utils.ErrorResponse{Error: "advisory_id param not found"})
@@ -68,7 +112,15 @@ func AdvisoryDetailHandler(c *gin.Context) {
 		return
 	}
 
-	resp, err := getAdvisory(advisoryName)
+	var err error
+	var respV1 *AdvisoryDetailResponseV1
+	var respV2 *AdvisoryDetailResponseV2
+	switch apiver {
+	case "v1":
+		respV1, err = getAdvisoryV1(advisoryName)
+	case "v2":
+		respV2, err = getAdvisoryV2(advisoryName)
+	}
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			LogAndRespNotFound(c, err, "advisory not found")
@@ -78,73 +130,122 @@ func AdvisoryDetailHandler(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, resp)
+	switch apiver {
+	case "v1":
+		c.JSON(http.StatusOK, respV1)
+	case "v2":
+		c.JSON(http.StatusOK, respV2)
+	}
 }
 
-func getAdvisoryFromDB(advisoryName string) (*AdvisoryDetailResponse, error) {
+func getAdvisoryFromDB(advisoryName string) (*models.AdvisoryMetadata, *AdvisoryDetailAttributes, error) {
 	var advisory models.AdvisoryMetadata
 	err := database.Db.Table(advisory.TableName()).
 		Take(&advisory, "name = ?", advisoryName).Error
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	cves, err := parseJSONList(advisory.CveList)
 	if err != nil {
-		return nil, errors.Wrap(err, "CVEs parsing error")
-	}
-
-	packages, err := parsePackages(advisory.PackageData)
-	if err != nil {
-		return nil, errors.Wrap(err, "packages parsing error")
+		return nil, nil, errors.Wrap(err, "CVEs parsing error")
 	}
 
 	releaseVersions, err := parseJSONList(advisory.ReleaseVersions)
 	if err != nil {
-		return nil, errors.Wrap(err, "release_versions parsing error")
+		return nil, nil, errors.Wrap(err, "release_versions parsing error")
 	}
 
-	var resp = AdvisoryDetailResponse{
-		Data: AdvisoryDetailItem{
-			Attributes: AdvisoryDetailAttributes{
-				Description:      advisory.Description,
-				ModifiedDate:     advisory.ModifiedDate,
-				PublicDate:       advisory.PublicDate,
-				Topic:            advisory.Summary,
-				Synopsis:         advisory.Synopsis,
-				Solution:         advisory.Solution,
-				Severity:         advisory.SeverityID,
-				AdvisoryTypeName: database.AdvisoryTypes[advisory.AdvisoryTypeID],
-				Fixes:            nil,
-				Cves:             cves,
-				Packages:         packages,
-				References:       []string{},
-				RebootRequired:   advisory.RebootRequired,
-				ReleaseVersions:  releaseVersions,
-			},
-			ID:   advisory.Name,
-			Type: "advisory",
-		}}
+	ada := AdvisoryDetailAttributes{
+		Description:      advisory.Description,
+		ModifiedDate:     advisory.ModifiedDate,
+		PublicDate:       advisory.PublicDate,
+		Topic:            advisory.Summary,
+		Synopsis:         advisory.Synopsis,
+		Solution:         advisory.Solution,
+		Severity:         advisory.SeverityID,
+		AdvisoryTypeName: database.AdvisoryTypes[advisory.AdvisoryTypeID],
+		Fixes:            nil,
+		Cves:             cves,
+		References:       []string{},
+		RebootRequired:   advisory.RebootRequired,
+		ReleaseVersions:  releaseVersions,
+	}
+	return &advisory, &ada, err
+}
+
+func getAdvisoryFromDBV1(advisoryName string) (*AdvisoryDetailResponseV1, error) {
+	advisory, ada, err := getAdvisoryFromDB(advisoryName)
+	if err != nil {
+		return nil, err
+	}
+
+	pkgs, _, err := parsePackages(advisory.PackageData)
+	if err != nil {
+		return nil, errors.Wrap(err, "packages parsing error")
+	}
+
+	var resp = AdvisoryDetailResponseV1{Data: AdvisoryDetailItemV1{
+		Attributes: AdvisoryDetailAttributesV1{
+			AdvisoryDetailAttributes: *ada,
+			Packages:                 pkgs,
+		},
+		ID:   advisory.Name,
+		Type: "advisory",
+	}}
 	return &resp, nil
 }
 
-func parsePackages(jsonb []byte) (map[string]string, error) {
+func getAdvisoryFromDBV2(advisoryName string) (*AdvisoryDetailResponseV2, error) {
+	advisory, ada, err := getAdvisoryFromDB(advisoryName)
+	if err != nil {
+		return nil, err
+	}
+
+	_, pkgs, err := parsePackages(advisory.PackageData)
+	if err != nil {
+		return nil, errors.Wrap(err, "packages parsing error")
+	}
+
+	var resp = AdvisoryDetailResponseV2{Data: AdvisoryDetailItemV2{
+		Attributes: AdvisoryDetailAttributesV2{
+			AdvisoryDetailAttributes: *ada,
+			Packages:                 pkgs,
+		},
+		ID:   advisory.Name,
+		Type: "advisory",
+	}}
+	return &resp, nil
+}
+
+func parsePackages(jsonb []byte) (packagesV1, packagesV2, error) {
 	if jsonb == nil {
-		return map[string]string{}, nil
+		return packagesV1{}, packagesV2{}, nil
 	}
 
 	js := json.RawMessage(string(jsonb))
 	b, err := json.Marshal(js)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	var packages map[string]string
-	err = json.Unmarshal(b, &packages)
+	pkgsV1 := make(packagesV1)
+	var pkgsV2 packagesV2
+	err = json.Unmarshal(b, &pkgsV2)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return packages, nil
+	// assigning first pkg to packages map in api/v1
+	// it shows incorrect packages info
+	// but we need to maintain backward compatibility
+	if len(pkgsV2) > 0 {
+		nevra, err := utils.ParseNevra(pkgsV2[0])
+		if err != nil {
+			return nil, pkgsV2, errors.Wrapf(err, "Could not parse nevra %s", pkgsV2[0])
+		}
+		pkgsV1[nevra.Name] = nevra.EVRAString()
+	}
+	return pkgsV1, pkgsV2, nil
 }
 
 func initAdvisoryDetailCache() *lru.Cache {
@@ -175,9 +276,13 @@ func PreloadAdvisoryCacheItems() {
 	}
 
 	for i, advisoryName := range advisoryNames {
-		_, err = getAdvisory(advisoryName)
+		_, err = getAdvisoryV1(advisoryName)
 		if err != nil {
-			utils.Log("advisoryName", advisoryName, "err", err.Error()).Error("can not re-load item to cache")
+			utils.Log("advisoryName", advisoryName, "err", err.Error()).Error("can not re-load item to cache - V1")
+		}
+		_, err = getAdvisoryV2(advisoryName)
+		if err != nil {
+			utils.Log("advisoryName", advisoryName, "err", err.Error()).Error("can not re-load item to cache - V2")
 		}
 		perc := 1000 * (i + 1) / len(advisoryNames)
 		if perc%10 == 0 { // log each 1% increment
@@ -186,40 +291,76 @@ func PreloadAdvisoryCacheItems() {
 	}
 }
 
-func tryGetAdvisoryFromCache(advisoryName string) *AdvisoryDetailResponse {
-	if advisoryDetailCache == nil {
+func tryGetAdvisoryFromCacheV1(advisoryName string) *AdvisoryDetailResponseV1 {
+	if advisoryDetailCacheV1 == nil {
 		return nil
 	}
 
-	val, ok := advisoryDetailCache.Get(advisoryName)
+	val, ok := advisoryDetailCacheV1.Get(advisoryName)
 	if !ok {
 		return nil
 	}
-
-	resp := val.(AdvisoryDetailResponse)
+	resp := val.(AdvisoryDetailResponseV1)
 	return &resp
 }
 
-func tryAddAdvisoryToCache(advisoryName string, resp *AdvisoryDetailResponse) {
-	if advisoryDetailCache == nil {
-		return
+func tryGetAdvisoryFromCacheV2(advisoryName string) *AdvisoryDetailResponseV2 {
+	if advisoryDetailCacheV2 == nil {
+		return nil
 	}
-	evicted := advisoryDetailCache.Add(advisoryName, *resp)
-	utils.Log("evicted", evicted, "advisoryName", advisoryName).Debug("saved to cache")
+
+	val, ok := advisoryDetailCacheV2.Get(advisoryName)
+	if !ok {
+		return nil
+	}
+	resp := val.(AdvisoryDetailResponseV2)
+	return &resp
 }
 
-func getAdvisory(advisoryName string) (*AdvisoryDetailResponse, error) {
-	resp := tryGetAdvisoryFromCache(advisoryName)
+func tryAddAdvisoryToCacheV1(advisoryName string, resp *AdvisoryDetailResponseV1) {
+	if advisoryDetailCacheV1 == nil {
+		return
+	}
+	evicted := advisoryDetailCacheV1.Add(advisoryName, *resp)
+	utils.Log("evictedV1", evicted, "advisoryName", advisoryName).Debug("saved to cache")
+}
+
+func tryAddAdvisoryToCacheV2(advisoryName string, resp *AdvisoryDetailResponseV2) {
+	if advisoryDetailCacheV2 == nil {
+		return
+	}
+	evicted := advisoryDetailCacheV2.Add(advisoryName, *resp)
+	utils.Log("evictedV2", evicted, "advisoryName", advisoryName).Debug("saved to cache")
+}
+
+func getAdvisoryV1(advisoryName string) (*AdvisoryDetailResponseV1, error) {
+	resp := tryGetAdvisoryFromCacheV1(advisoryName)
 	if resp != nil {
 		utils.Log("advisoryName", advisoryName).Debug("found in cache")
 		return resp, nil // return data found in cache
 	}
 
-	resp, err := getAdvisoryFromDB(advisoryName) // search for data in database
+	resp, err := getAdvisoryFromDBV1(advisoryName) // search for data in database
 	if err != nil {
 		return nil, err
 	}
 
-	tryAddAdvisoryToCache(advisoryName, resp) // save data to cache if initialized
+	tryAddAdvisoryToCacheV1(advisoryName, resp) // save data to cache if initialized
+	return resp, nil
+}
+
+func getAdvisoryV2(advisoryName string) (*AdvisoryDetailResponseV2, error) {
+	resp := tryGetAdvisoryFromCacheV2(advisoryName)
+	if resp != nil {
+		utils.Log("advisoryName", advisoryName).Debug("found in cache")
+		return resp, nil // return data found in cache
+	}
+
+	resp, err := getAdvisoryFromDBV2(advisoryName) // search for data in database
+	if err != nil {
+		return nil, err
+	}
+
+	tryAddAdvisoryToCacheV2(advisoryName, resp) // save data to cache if initialized
 	return resp, nil
 }

--- a/manager/controllers/advisory_systems.go
+++ b/manager/controllers/advisory_systems.go
@@ -74,7 +74,7 @@ var AdvisorySystemOpts = ListOpts{
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/advisories/{advisory_id}/systems [get]
+// @Router /advisories/{advisory_id}/systems [get]
 func AdvisorySystemsListHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/advisory_systems_export.go
+++ b/manager/controllers/advisory_systems_export.go
@@ -48,7 +48,7 @@ import (
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 415 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/export/advisories/{advisory_id}/systems [get]
+// @Router /export/advisories/{advisory_id}/systems [get]
 func AdvisorySystemsExportHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 	advisoryName := c.Param("advisory_id")

--- a/manager/controllers/baseline_create.go
+++ b/manager/controllers/baseline_create.go
@@ -43,7 +43,7 @@ type CreateBaselineResponse struct {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/baselines [put]
+// @Router /baselines [put]
 func CreateBaselineHandler(c *gin.Context) {
 	accountID := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/baseline_delete.go
+++ b/manager/controllers/baseline_delete.go
@@ -29,7 +29,7 @@ type DeleteBaselineResponse struct {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/baselines/{baseline_id} [delete]
+// @Router /baselines/{baseline_id} [delete]
 func BaselineDeleteHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/baseline_detail.go
+++ b/manager/controllers/baseline_detail.go
@@ -41,7 +41,7 @@ type BaselineDetailAttributes struct {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/baselines/{baseline_id} [get]
+// @Router /baselines/{baseline_id} [get]
 func BaselineDetailHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/baseline_systems.go
+++ b/manager/controllers/baseline_systems.go
@@ -6,10 +6,11 @@ import (
 	"app/base/utils"
 	"app/manager/middlewares"
 	"fmt"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"net/http"
 )
 
 var BaselineSystemFields = database.MustGetQueryAttrs(&BaselineSystemsDBLookup{})
@@ -66,7 +67,7 @@ type BaselineSystemsResponse struct {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/baselines/{baseline_id}/systems [get]
+// @Router /baselines/{baseline_id}/systems [get]
 func BaselineSystemsListHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/baseline_systems_remove.go
+++ b/manager/controllers/baseline_systems_remove.go
@@ -30,7 +30,7 @@ type BaselineSystemsRemoveRequest struct {
 // @Failure 400 {object} 	utils.ErrorResponse
 // @Failure 404 {object} 	utils.ErrorResponse
 // @Failure 500 {object} 	utils.ErrorResponse
-// @Router /api/patch/v1/baselines/systems/remove [POST]
+// @Router /baselines/systems/remove [POST]
 func BaselineSystemsRemoveHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/baseline_update.go
+++ b/manager/controllers/baseline_update.go
@@ -49,7 +49,7 @@ type UpdateBaselineResponse struct {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/baselines/{baseline_id} [put]
+// @Router /baselines/{baseline_id} [put]
 func BaselineUpdateHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/baselines.go
+++ b/manager/controllers/baselines.go
@@ -65,7 +65,7 @@ type BaselinesResponse struct {
 // @Success 200 {object} BaselinesResponse
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/baselines [get]
+// @Router /baselines [get]
 func BaselinesListHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 	filters, err := ParseTagsFilters(c)

--- a/manager/controllers/package_detail.go
+++ b/manager/controllers/package_detail.go
@@ -4,8 +4,9 @@ import (
 	"app/base/database"
 	"app/base/models"
 	"app/base/utils"
-	"github.com/gin-gonic/gin"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
 func packageNameIsValid(packageName string) bool {
@@ -100,7 +101,7 @@ func packageEvraHandler(c *gin.Context, nevra *utils.Nevra) {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/packages/{package_name} [get]
+// @Router /packages/{package_name} [get]
 func PackageDetailHandler(c *gin.Context) {
 	parameter := c.Param("package_name")
 	if parameter == "" {

--- a/manager/controllers/package_systems.go
+++ b/manager/controllers/package_systems.go
@@ -87,7 +87,7 @@ func packageSystemsQuery(acc int, packageName string, packageIDs []int) *gorm.DB
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/packages/{package_name}/systems [get]
+// @Router /packages/{package_name}/systems [get]
 func PackageSystemsListHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 	var filters map[string]FilterData

--- a/manager/controllers/package_systems_export.go
+++ b/manager/controllers/package_systems_export.go
@@ -5,9 +5,10 @@ import (
 	"app/manager/middlewares"
 	"errors"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 // @Summary Show me all my systems which have a package installed
@@ -29,7 +30,7 @@ import (
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 415 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/export/packages/{package_name}/systems [get]
+// @Router /export/packages/{package_name}/systems [get]
 func PackageSystemsExportHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/package_versions.go
+++ b/manager/controllers/package_versions.go
@@ -60,7 +60,7 @@ func packageVersionsQuery(acc int, packageNameIDs []int) *gorm.DB {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/packages/{package_name}/versions [get]
+// @Router /packages/{package_name}/versions [get]
 func PackageVersionsListHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/packages.go
+++ b/manager/controllers/packages.go
@@ -87,7 +87,7 @@ func packagesQuery(filters map[string]FilterData, acc int) *gorm.DB {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/packages/ [get]
+// @Router /packages/ [get]
 func PackagesListHandler(c *gin.Context) {
 	var filters map[string]FilterData
 	account := c.GetInt(middlewares.KeyAccount)

--- a/manager/controllers/packages_export.go
+++ b/manager/controllers/packages_export.go
@@ -3,9 +3,10 @@ package controllers
 import (
 	"app/manager/middlewares"
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 // @Summary Show me all installed packages across my systems
@@ -23,7 +24,7 @@ import (
 // @Success 200 {array} PackageItem
 // @Failure 415 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/export/packages [get]
+// @Router /export/packages [get]
 func PackagesExportHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 	filters, err := ParseTagsFilters(c)

--- a/manager/controllers/system_advisories.go
+++ b/manager/controllers/system_advisories.go
@@ -88,7 +88,7 @@ func (v RelList) String() string {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/systems/{inventory_id}/advisories [get]
+// @Router /systems/{inventory_id}/advisories [get]
 func SystemAdvisoriesHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/system_advisories_export.go
+++ b/manager/controllers/system_advisories_export.go
@@ -33,7 +33,7 @@ import (
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 415 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/export/systems/{inventory_id}/advisories [get]
+// @Router /export/systems/{inventory_id}/advisories [get]
 func SystemAdvisoriesExportHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/system_delete.go
+++ b/manager/controllers/system_delete.go
@@ -6,8 +6,9 @@ import (
 	"app/base/utils"
 	"app/manager/middlewares"
 	"errors"
-	"github.com/gin-gonic/gin"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
 // @Summary Delete system by inventory id
@@ -21,7 +22,7 @@ import (
 // @Failure 400 {object} 	utils.ErrorResponse
 // @Failure 404 {object} 	utils.ErrorResponse
 // @Failure 500 {object} 	utils.ErrorResponse
-// @Router /api/patch/v1/systems/{inventory_id} [delete]
+// @Router /systems/{inventory_id} [delete]
 func SystemDeleteHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/system_detail.go
+++ b/manager/controllers/system_detail.go
@@ -5,9 +5,10 @@ import (
 	"app/base/utils"
 	"app/manager/middlewares"
 	"errors"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
-	"net/http"
 )
 
 type SystemDetailResponse struct {
@@ -25,7 +26,7 @@ type SystemDetailResponse struct {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/systems/{inventory_id} [get]
+// @Router /systems/{inventory_id} [get]
 func SystemDetailHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/system_packages.go
+++ b/manager/controllers/system_packages.go
@@ -77,7 +77,7 @@ func systemPackageQuery(account int, inventoryID string) *gorm.DB {
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/systems/{inventory_id}/packages [get]
+// @Router /systems/{inventory_id}/packages [get]
 func SystemPackagesHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/system_packages_export.go
+++ b/manager/controllers/system_packages_export.go
@@ -7,10 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 	"net/http"
 	"strings"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 type SystemPackageInline struct {
@@ -36,7 +37,7 @@ type SystemPackageInline struct {
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 415 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/export/systems/{inventory_id}/packages [get]
+// @Router /export/systems/{inventory_id}/packages [get]
 func SystemPackagesExportHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 

--- a/manager/controllers/systems.go
+++ b/manager/controllers/systems.go
@@ -167,7 +167,7 @@ func systemSubtotals(tx *gorm.DB) (total int, subTotals map[string]int, err erro
 // @Success 200 {object} SystemsResponse
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/systems [get]
+// @Router /systems [get]
 func SystemsListHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 	query := querySystems(account)

--- a/manager/controllers/systems_advisories_view.go
+++ b/manager/controllers/systems_advisories_view.go
@@ -3,9 +3,10 @@ package controllers
 import (
 	"app/base/database"
 	"app/manager/middlewares"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
-	"net/http"
 )
 
 type AdvisoryName string
@@ -51,7 +52,7 @@ func systemsAdvisoriesQuery(acc int, systems []SystemID, advisories []AdvisoryNa
 // @Success 200 {object} SystemsAdvisoriesResponse
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/views/systems/advisories [post]
+// @Router /views/systems/advisories [post]
 func PostSystemsAdvisories(c *gin.Context) {
 	var req SystemsAdvisoriesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -84,7 +85,7 @@ func PostSystemsAdvisories(c *gin.Context) {
 // @Success 200 {object} AdvisoriesSystemsResponse
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/views/advisories/systems [post]
+// @Router /views/advisories/systems [post]
 func PostAdvisoriesSystems(c *gin.Context) {
 	var req SystemsAdvisoriesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/manager/controllers/systems_export.go
+++ b/manager/controllers/systems_export.go
@@ -42,7 +42,7 @@ import (
 // @Success 200 {array} SystemInlineItem
 // @Failure 415 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
-// @Router /api/patch/v1/export/systems [get]
+// @Router /export/systems [get]
 func SystemsExportHandler(c *gin.Context) {
 	account := c.GetInt(middlewares.KeyAccount)
 	query := querySystems(account)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -29,6 +29,8 @@ import (
 // @securityDefinitions.apikey RhIdentity
 // @in header
 // @name x-rh-identity
+
+// @BasePath /api/patch/v2
 func RunManager() {
 	core.ConfigureApp()
 
@@ -46,8 +48,10 @@ func RunManager() {
 
 	// routes
 	core.InitProbes(app)
-	api := app.Group("/api/patch/v1")
-	routes.InitAPI(api, endpointsConfig)
+	apiV1 := app.Group("/api/patch/v1")
+	apiV2 := app.Group("/api/patch/v2")
+	routes.InitAPI(apiV1, endpointsConfig)
+	routes.InitAPI(apiV2, endpointsConfig)
 
 	go base.TryExposeOnMetricsPort(app)
 

--- a/manager/middlewares/swagger.go
+++ b/manager/middlewares/swagger.go
@@ -2,6 +2,7 @@ package middlewares
 
 import (
 	"app/docs"
+
 	"github.com/gin-gonic/gin"
 
 	ginSwagger "github.com/swaggo/gin-swagger"
@@ -11,8 +12,8 @@ import (
 
 func SetSwagger(app *gin.Engine, config docs.EndpointsConfig) {
 	// Serving openapi docs
-	docs.Init(app, config)
+	openapiURL := docs.Init(app, config)
 
-	url := ginSwagger.URL(docs.OpenapiURL)
+	url := ginSwagger.URL(openapiURL)
 	app.GET("/openapi/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
 }

--- a/scripts/check-openapi-docs.sh
+++ b/scripts/check-openapi-docs.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 OPENAPI_COPY=$(mktemp -t openapi.json.XXX)
-cp docs/openapi.json $OPENAPI_COPY
+cp docs/v2/openapi.json $OPENAPI_COPY
 ./scripts/generate_docs.sh
-diff docs/openapi.json $OPENAPI_COPY
+diff docs/v2/openapi.json $OPENAPI_COPY
 rc=$?
 if [ $rc -gt 0 ]; then
-  echo "docs/openapi.json different from file generated with './scripts/generate_docs.sh'!"
+  echo "docs/v2/openapi.json different from file generated with './scripts/generate_docs.sh'!"
 else
-  echo "docs/openapi.json consistent with generated file."
+  echo "docs/v2/openapi.json consistent with generated file."
 fi
 
 rm $OPENAPI_COPY

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 # Usage:
 # ./generate_docs.sh
@@ -13,4 +13,4 @@ swag init --output $DOCS_TMP_DIR --generalInfo manager/manager.go
 curl -X "POST" -H "accept: application/json" -H  "Content-Type: application/json" \
   -d @$DOCS_TMP_DIR/swagger.json $CONVERT_URL \
   | python3 -m json.tool \
-  > docs/openapi.json
+  > docs/v2/openapi.json

--- a/scripts/go_test_on_ci.sh
+++ b/scripts/go_test_on_ci.sh
@@ -2,7 +2,7 @@
 
 set -e -o pipefail
 
-# Analyse generated docs/openapi.json
+# Analyse generated docs/v2/openapi.json
 ./scripts/check-openapi-docs.sh
 
 # Check dockerfiles and docker-composes consistency

--- a/vmaas_sync/advisory_sync.go
+++ b/vmaas_sync/advisory_sync.go
@@ -176,16 +176,7 @@ func getJSONFields(vmaasData *vmaas.ErrataResponseErrataList) ([]byte, []byte, [
 }
 
 func getPackageData(vmaasData *vmaas.ErrataResponseErrataList) ([]byte, error) {
-	packages := make(models.AdvisoryPackageData)
-	for _, p := range vmaasData.PackageList {
-		nevra, err := utils.ParseNevra(p)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Could not parse nevra %s", p)
-		}
-		packages[nevra.Name] = nevra.EVRAString()
-	}
-
-	packageData, err := json.Marshal(packages)
+	packageData, err := json.Marshal(vmaasData.PackageList)
 	if err != nil {
 		return nil, errors.Wrap(err, "Could not serialize package data")
 	}


### PR DESCRIPTION
- add advisory detail v2 api returning packages in `map[string][]string` format, instead of `map[string]string`
- expose v2 api for all other endpoints
- swaggo/swag does not make it easy to make multiple openapi.json files, ~it creates 1 big openapi.json with all paths and I split it into multiple files in `docs/docs.go:filterOpenAPI` and exposed them separately as `api/patch/v1/openapi.json` and `/api/patch/v2/openapi.json`. I'm open to suggestions.~ 
- move current `docs/openapi.json` to `docs/v1/openapi.json`
- generate only new spec in `docs/v2/openapi.json` and expose both specs on `api/patch/v1/openapi.json` and `/api/patch/v2/openapi.json`

TODO:
- [x] test in ephemeral
- [x] make sure unit tests are passing

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
