### PR TITLE
SPM-1574: don't panic when vmaas_json is null in db

### DIFF
--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -175,6 +175,14 @@ func tryGetVmaasRequest(tx *gorm.DB, accountID int, inventoryID string,
 		return nil, nil, nil
 	}
 
+	if system.VmaasJSON == "" {
+		evaluationCnt.WithLabelValues("error-parse-vmaas-json").Inc()
+		utils.Log("inventory_id", system.InventoryID).Warn("system with empty vmaas json")
+		// skip the system
+		// don't return error as it will cause panic of evaluator pod
+		return nil, nil, nil
+	}
+
 	updatesReq, err := parseVmaasJSON(system)
 	if err != nil {
 		evaluationCnt.WithLabelValues("error-parse-vmaas-json").Inc()


### PR DESCRIPTION
It should not really happen in stage/prod but it is possible to create such db record since vmaas_json is text type without not null constraint. 

Skip the system eval recalc when `VmaasJSON` field (string) is `"" `
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
