### PR TITLE
SPM-1447: Make BatchSize configurable

### DIFF
--- a/base/mqueue/event.go
+++ b/base/mqueue/event.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const BatchSize = 4000
+var BatchSize = utils.GetIntEnvOrDefault("MSG_BATCH_SIZE", 4000)
 
 var policy = backoff.NewExponential(
 	backoff.WithInterval(time.Second),

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -141,6 +141,7 @@ objects:
         - {name: VMAAS_CALL_MAX_RETRIES, value: '${VMAAS_CALL_MAX_RETRIES}'}
         - {name: VMAAS_CALL_USE_EXP_RETRY, value: '${VMAAS_CALL_USE_EXP_RETRY}'}
         - {name: VMAAS_CALL_USE_OPTIMISTIC_UPDATES, value: '${VMAAS_CALL_USE_OPTIMISTIC_UPDATES}'}
+        - {name: MSG_BATCH_SIZE, value: '${MSG_BATCH_SIZE}'}
         resources:
           limits: {cpu: '${RES_CPU_EVALUATOR_UPLOAD}', memory: '${RES_MEM_EVALUATOR_UPLOAD}'}
           requests: {cpu: '${RES_CPU_EVALUATOR_UPLOAD}', memory: '${RES_MEM_EVALUATOR_UPLOAD}'}
@@ -194,6 +195,7 @@ objects:
         - {name: VMAAS_CALL_MAX_RETRIES, value: '${VMAAS_CALL_MAX_RETRIES}'}
         - {name: VMAAS_CALL_USE_EXP_RETRY, value: '${VMAAS_CALL_USE_EXP_RETRY}'}
         - {name: VMAAS_CALL_USE_OPTIMISTIC_UPDATES, value: '${VMAAS_CALL_USE_OPTIMISTIC_UPDATES}'}
+        - {name: MSG_BATCH_SIZE, value: '${MSG_BATCH_SIZE}'}
         resources:
           limits: {cpu: '${RES_CPU_EVALUATOR_RECALC}', memory: '${RES_MEM_EVALUATOR_RECALC}'}
           requests: {cpu: '${RES_CPU_EVALUATOR_RECALC}', memory: '${RES_MEM_EVALUATOR_RECALC}'}
@@ -249,6 +251,7 @@ objects:
         - {name: ENABLE_PACKAGES_COUNT_CHECK, value: '${ENABLE_PACKAGES_COUNT_CHECK}'}
         - {name: VMAAS_ADDRESS, value: '${VMAAS_ADDRESS}'}
         - {name: VMAAS_WS_ADDRESS, value: '${VMAAS_WS_ADDRESS}'}
+        - {name: MSG_BATCH_SIZE, value: '${MSG_BATCH_SIZE}'}
         resources:
           limits: {cpu: '${RES_CPU_VMAAS_SYNC}', memory: '${RES_MEM_VMAAS_SYNC}'}
           requests: {cpu: '${RES_CPU_VMAAS_SYNC}', memory: '${RES_MEM_VMAAS_SYNC}'}
@@ -548,6 +551,7 @@ parameters:
 - {name: VMAAS_CALL_MAX_RETRIES, value: '8'} # Limit of how many unsuccessful vmaas calls are allowed before panic.
 - {name: VMAAS_CALL_USE_EXP_RETRY, value: 'true'} # Use exponential retry policy for vmaas call.
 - {name: VMAAS_CALL_USE_OPTIMISTIC_UPDATES, value: 'true'} # Always use "optimistic_updates" in vmaas request (not only for third party usage).
+- {name: MSG_BATCH_SIZE, value: '4000'} # BatchSize for PlatformEvent message
 
 # Floorist parameters
 - {name: FLOORIST_SCHEDULE, value: '50 0 * * *', required: true} # Cronjob schedule definition

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -158,7 +158,7 @@ func sendPayloadStatus(w mqueue.Writer, event mqueue.PayloadTrackerEvent, status
 }
 
 // accumulate events and create group PlatformEvents to save some resources
-const evalBufferSize = 5 * mqueue.BatchSize
+var evalBufferSize = 5 * mqueue.BatchSize
 
 var evalBuffer = make(mqueue.EvalDataSlice, 0, evalBufferSize+1)
 var ptBuffer = make(mqueue.PayloadTrackerEvents, 0, evalBufferSize+1)


### PR DESCRIPTION
**NOTE**: we need to be careful when changing `BatchSize`. I experienced some OOMKilled errors in ephemeral. Probably due to usage of 8 consumers (default in clowdapp.yaml) in evaluator-recalc. 

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
