### PR TITLE
SPM-1580: don't block websocket client with msg handler

### DIFF
--- a/vmaas_sync/vmaas_sync_test.go
+++ b/vmaas_sync/vmaas_sync_test.go
@@ -9,12 +9,13 @@ import (
 	"app/base/utils"
 	"app/base/vmaas"
 	"context"
-	log "github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"os"
 	"testing"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 var msgs []mqueue.KafkaMessage
@@ -38,8 +39,7 @@ func TestSync(t *testing.T) {
 
 	evalWriter = &mockKafkaWriter{}
 
-	err := websocketHandler([]byte("webapps-refreshed"), nil)
-	assert.Nil(t, err)
+	websocketHandler([]byte("webapps-refreshed"), nil)
 
 	expected := []string{"RH-100"}
 	database.CheckAdvisoriesInDB(t, expected)


### PR DESCRIPTION
fixing 
```
time="2022-06-20T10:27:03Z" level=error msg="Failed to retrieve VMaaS websocket message" err="websocket: close 1005 (no status)"
time="2022-06-20T10:27:03Z" level=error msg="Websocket error occurred, waiting" err="websocket: close 1005 (no status)"
```

vmaas closes websocket connection if subscribed client won't respond to `ping` message in predetermined timeout. Patch is not responding because it's syncing data which blocks websocket client.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
