### PR TITLE
SPM-1484: Notify new advisory only once per account

### DIFF
--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -152,6 +152,21 @@ func CheckAdvisoriesAccountData(t *testing.T, rhAccountID int, advisoryIDs []int
 	assert.Equal(t, systemsAffected*len(advisoryIDs), sum, "sum of systems_affected does not match")
 }
 
+func CheckAdvisoriesAccountDataNotified(t *testing.T, rhAccountID int, advisoryIDs []int, notified bool) {
+	var advisoryAccountData []models.AdvisoryAccountData
+	err := Db.Where("rh_account_id = ? AND advisory_id IN (?)", rhAccountID, advisoryIDs).
+		Find(&advisoryAccountData).Error
+	assert.Nil(t, err)
+
+	for _, item := range advisoryAccountData {
+		if notified {
+			assert.NotNil(t, item.Notified)
+		} else {
+			assert.Nil(t, item.Notified)
+		}
+	}
+}
+
 func CheckSystemUpdatesCount(t *testing.T, accountID, systemID int) []int {
 	var cnt []int
 	assert.NoError(t, Db.Table("system_package spkg").

--- a/base/models/models.go
+++ b/base/models/models.go
@@ -193,6 +193,7 @@ type AdvisoryAccountData struct {
 	StatusID               int
 	SystemsAffected        int
 	SystemsStatusDivergent int
+	Notified               *time.Time
 }
 
 func (AdvisoryAccountData) TableName() string {

--- a/base/notification/notification.go
+++ b/base/notification/notification.go
@@ -61,6 +61,7 @@ type Notification struct {
 }
 
 type Advisory struct {
+	AdvisoryID   int    `json:"advisory_id"`
 	AdvisoryName string `json:"advisory_name"`
 	AdvisoryType string `json:"advisory_type"`
 	Synopsis     string `json:"synopsis"`

--- a/database_admin/migrations/082_advisory_notified_column.down.sql
+++ b/database_admin/migrations/082_advisory_notified_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE advisory_account_data DROP COLUMN IF EXISTS notified;

--- a/database_admin/migrations/082_advisory_notified_column.up.sql
+++ b/database_admin/migrations/082_advisory_notified_column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE advisory_account_data ADD COLUMN notified TIMESTAMP WITH TIME ZONE NULL;

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (81, false);
+VALUES (82, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -848,6 +848,7 @@ CREATE TABLE IF NOT EXISTS advisory_account_data
     status_id                INT NOT NULL DEFAULT 0,
     systems_affected         INT NOT NULL DEFAULT 0,
     systems_status_divergent INT NOT NULL DEFAULT 0,
+    notified                 TIMESTAMP WITH TIME ZONE NULL,
     CONSTRAINT advisory_metadata_id
         FOREIGN KEY (advisory_id)
             REFERENCES advisory_metadata (id),

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -320,7 +320,7 @@ func evaluateAndStore(tx *gorm.DB, system *models.SystemPlatform,
 	}
 
 	// Send instant notification with new advisories
-	err = publishNewAdvisoriesNotification(system.InventoryID, accountName, newSystemAdvisories)
+	err = publishNewAdvisoriesNotification(tx, system.InventoryID, accountName, system.RhAccountID, newSystemAdvisories)
 	if err != nil {
 		evaluationCnt.WithLabelValues("error-advisory-notification").Inc()
 		utils.Log("err", err.Error()).Error("publishing new advisories notification failed")

--- a/evaluator/notifications.go
+++ b/evaluator/notifications.go
@@ -7,6 +7,8 @@ import (
 	ntf "app/base/notification"
 	"app/base/utils"
 	"github.com/pkg/errors"
+	"gorm.io/gorm"
+	"time"
 )
 
 const NewAdvisoryEvent = "new-advisory"
@@ -19,29 +21,58 @@ func configureNotifications() {
 	}
 }
 
-func getNotificationAdvisories(newAdvisories SystemAdvisoryMap) []ntf.Advisory {
-	advisories := make([]ntf.Advisory, 0, len(newAdvisories))
+func getUnnotifiedAdvisories(tx *gorm.DB, accountID int, newAdvs SystemAdvisoryMap) ([]ntf.Advisory, error) {
+	unAdvs := make([]ntf.Advisory, 0, len(newAdvs))
 
-	for _, a := range newAdvisories {
-
-		advisory := ntf.Advisory{
-			AdvisoryName: a.Advisory.Name,
-			AdvisoryType: database.AdvisoryTypes[a.Advisory.AdvisoryTypeID],
-			Synopsis:     a.Advisory.Synopsis,
-		}
-
-		advisories = append(advisories, advisory)
+	advIDs := make([]int, 0, len(newAdvs))
+	for _, a := range newAdvs {
+		advIDs = append(advIDs, a.AdvisoryID)
 	}
 
-	return advisories
+	var advNames []string
+	err := tx.Table("advisory_account_data as acd").
+		Select("am.name").
+		Joins("inner join advisory_metadata am on am.id = acd.advisory_id").
+		Where("acd.rh_account_id = ? AND acd.advisory_id IN (?) AND acd.notified IS NULL", accountID, advIDs).
+		Scan(&advNames).Error
+	if err != nil {
+		return nil, errors.Wrap(err, "querying unnotified advisories from DB failed")
+	}
+
+	if len(advNames) == 0 {
+		return nil, nil
+	}
+
+	for _, n := range advNames {
+		if a, ok := newAdvs[n]; ok {
+			unAdvs = append(
+				unAdvs,
+				ntf.Advisory{
+					AdvisoryID:   a.AdvisoryID,
+					AdvisoryName: a.Advisory.Name,
+					AdvisoryType: database.AdvisoryTypes[a.Advisory.AdvisoryTypeID],
+					Synopsis:     a.Advisory.Synopsis,
+				})
+		}
+	}
+
+	return unAdvs, nil
 }
 
-func publishNewAdvisoriesNotification(inventoryID, accountName string, newAdvisories SystemAdvisoryMap) error {
+func publishNewAdvisoriesNotification(tx *gorm.DB, inventoryID, accountName string,
+	accountID int, newAdvisories SystemAdvisoryMap) error {
 	if notificationsPublisher == nil {
 		return nil
 	}
 
-	advisories := getNotificationAdvisories(newAdvisories)
+	advisories, err := getUnnotifiedAdvisories(tx, accountID, newAdvisories)
+	if err != nil {
+		return errors.Wrap(err, "getting unnotified advisories failed")
+	}
+	if advisories == nil {
+		return nil
+	}
+
 	events := make([]ntf.Event, 0, len(advisories))
 	for _, advisory := range advisories {
 		events = append(events, ntf.Event{Payload: advisory})
@@ -57,6 +88,18 @@ func publishNewAdvisoriesNotification(inventoryID, accountName string, newAdviso
 	err = notificationsPublisher.WriteMessages(base.Context, msg)
 	if err != nil {
 		return errors.Wrap(err, "writing message to notifications publisher failed")
+	}
+
+	advisoryIDs := make([]int, 0, len(advisories))
+	for _, a := range advisories {
+		advisoryIDs = append(advisoryIDs, a.AdvisoryID)
+	}
+
+	err = tx.Table("advisory_account_data").
+		Where("rh_account_id = ? AND advisory_id IN (?)", accountID, advisoryIDs).
+		Update("notified", time.Now()).Error
+	if err != nil {
+		return errors.Wrap(err, "updating notified column failed")
 	}
 
 	return nil

--- a/evaluator/notifications.go
+++ b/evaluator/notifications.go
@@ -23,6 +23,7 @@ func getNotificationAdvisories(newAdvisories SystemAdvisoryMap) []ntf.Advisory {
 	advisories := make([]ntf.Advisory, 0, len(newAdvisories))
 
 	for _, a := range newAdvisories {
+
 		advisory := ntf.Advisory{
 			AdvisoryName: a.Advisory.Name,
 			AdvisoryType: database.AdvisoryTypes[a.Advisory.AdvisoryTypeID],

--- a/evaluator/notifications_test.go
+++ b/evaluator/notifications_test.go
@@ -55,6 +55,7 @@ func TestAdvisoriesNotificationPublish(t *testing.T) {
 	database.CreateSystemAdvisories(t, rhAccountID, systemID, oldSystemAdvisoryIDs, nil)
 	database.CreateAdvisoryAccountData(t, rhAccountID, oldSystemAdvisoryIDs, 1)
 	database.CheckCachesValid(t)
+	database.CheckAdvisoriesAccountDataNotified(t, rhAccountID, oldSystemAdvisoryIDs, false)
 
 	// do evaluate the system
 	err := evaluateHandler(mqueue.PlatformEvent{
@@ -63,6 +64,7 @@ func TestAdvisoriesNotificationPublish(t *testing.T) {
 		AccountID:  rhAccountID})
 	assert.NoError(t, err)
 	advisoryIDs := database.CheckAdvisoriesInDB(t, expectedAddedAdvisories)
+	database.CheckAdvisoriesAccountDataNotified(t, rhAccountID, expectedAdvisoryIDs, true)
 
 	assert.Equal(t, 1, len(mockWriter.Messages))
 
@@ -86,7 +88,7 @@ func TestAdvisoriesNotificationMessage(t *testing.T) {
 		},
 	}
 
-	notification := ntf.MakeNotification(strconv.Itoa(rhAccountID), inventoryID, NewAdvisoryEvent, events)
+	notification := ntf.MakeNotification(inventoryID, strconv.Itoa(rhAccountID), NewAdvisoryEvent, events)
 	msg, err := mqueue.MessageFromJSON(inventoryID, notification)
 	assert.Nil(t, err)
 	assert.Equal(t, inventoryID, string(msg.Key))


### PR DESCRIPTION
After these changes we would notify each new advisory only once per account because it is too verbose to do it for every system.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
