### PR TITLE
Send only 1 payload status for skipped messages

### DIFF
--- a/listener/upload.go
+++ b/listener/upload.go
@@ -84,29 +84,29 @@ func HandleUpload(event HostEvent) error {
 		InventoryID: event.Host.ID,
 		Status:      "received",
 	}
-	sendPayloadStatus(ptWriter, payloadTrackerEvent, "", "")
 
 	if _, ok := excludedReporters[event.Host.Reporter]; ok {
 		utils.Log("inventoryID", event.Host.ID, "reporter", event.Host.Reporter).Warn(WarnSkippingReporter)
 		messagesReceivedCnt.WithLabelValues(EventUpload, ReceivedWarnExcludedReporter).Inc()
-		sendPayloadStatus(ptWriter, payloadTrackerEvent, ErrorStatus, WarnSkippingReporter)
+		sendPayloadStatus(ptWriter, payloadTrackerEvent, "", WarnSkippingReporter)
 		return nil
 	}
 
 	if _, ok := excludedHostTypes[event.Host.SystemProfile.HostType]; ok {
 		utils.Log("inventoryID", event.Host.ID, "hostType", event.Host.SystemProfile.HostType).Warn(WarnSkippingHostType)
 		messagesReceivedCnt.WithLabelValues(EventUpload, ReceivedWarnExcludedHostType).Inc()
-		sendPayloadStatus(ptWriter, payloadTrackerEvent, ErrorStatus, WarnSkippingHostType)
+		sendPayloadStatus(ptWriter, payloadTrackerEvent, "", WarnSkippingHostType)
 		return nil
 	}
 
 	if (event.Host.Account == nil || *event.Host.Account == "") && (event.Host.OrgID == nil || *event.Host.OrgID == "") {
 		utils.Log("inventoryID", event.Host.ID).Error(ErrorNoAccountProvided)
 		messagesReceivedCnt.WithLabelValues(EventUpload, ReceivedErrorIdentity).Inc()
-		sendPayloadStatus(ptWriter, payloadTrackerEvent, ErrorStatus, ErrorNoAccountProvided)
+		sendPayloadStatus(ptWriter, payloadTrackerEvent, "", ErrorNoAccountProvided)
 		return nil
 	}
 
+	sendPayloadStatus(ptWriter, payloadTrackerEvent, "", "")
 	yumUpdates := getYumUpdates(event)
 	utils.Log("inventoryID", event.Host.ID, "yum_updates", yumUpdates).Trace()
 


### PR DESCRIPTION
We don;t need to send 2 messages - `received` and `error` when the message will not be evaluated (e.g. coming from yupana). Instead we will send only `received` msg with `StatusMsg` explaining the message was skipped.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
