### PR TITLE
SPM-1622: fix api links

### DIFF
--- a/manager/controllers/advisories.go
+++ b/manager/controllers/advisories.go
@@ -119,7 +119,7 @@ func AdvisoriesListHandler(c *gin.Context) {
 		query = buildQueryAdvisories(account)
 	}
 
-	query, meta, links, err := ListCommon(query, c, filters, "/api/patch/v1/advisories", AdvisoriesOpts)
+	query, meta, links, err := ListCommon(query, c, filters, AdvisoriesOpts)
 	if err != nil {
 		// Error handling and setting of result code & content is done in ListCommon
 		return

--- a/manager/controllers/advisories_test.go
+++ b/manager/controllers/advisories_test.go
@@ -5,10 +5,11 @@ import (
 	"app/base/database"
 	"app/base/utils"
 	"fmt"
-	"github.com/pkg/errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -45,8 +46,8 @@ func TestAdvisoriesDefault(t *testing.T) {
 	assert.Equal(t, false, output.Data[0].Attributes.RebootRequired)
 
 	// links
-	assert.Equal(t, "/api/patch/v1/advisories?offset=0&limit=20&sort=-public_date", output.Links.First)
-	assert.Equal(t, "/api/patch/v1/advisories?offset=0&limit=20&sort=-public_date", output.Links.Last)
+	assert.Equal(t, "/?offset=0&limit=20&sort=-public_date", output.Links.First)
+	assert.Equal(t, "/?offset=0&limit=20&sort=-public_date", output.Links.Last)
 	assert.Nil(t, output.Links.Next)
 	assert.Nil(t, output.Links.Previous)
 
@@ -136,7 +137,7 @@ func TestAdvisoriesFilterTypeID1(t *testing.T) {
 	assert.Equal(t, "RH-7", output.Data[2].ID)
 	assert.Equal(t, FilterData{Values: []string{"enhancement"}, Operator: "eq"}, output.Meta.Filter["advisory_type_name"])
 	assert.Equal(t,
-		"/api/patch/v1/advisories?offset=0&limit=20&filter[advisory_type_name]=eq:enhancement&sort=id",
+		"/?offset=0&limit=20&filter[advisory_type_name]=eq:enhancement&sort=id",
 		output.Links.First)
 }
 
@@ -240,9 +241,9 @@ func TestAdvisoriesSearch(t *testing.T) {
 	assert.Equal(t, 1, output.Data[0].Attributes.ApplicableSystems)
 
 	// links
-	assert.Equal(t, "/api/patch/v1/advisories?offset=0&limit=20&sort=-public_date&search=h-3",
+	assert.Equal(t, "/?offset=0&limit=20&sort=-public_date&search=h-3",
 		output.Links.First)
-	assert.Equal(t, "/api/patch/v1/advisories?offset=0&limit=20&sort=-public_date&search=h-3",
+	assert.Equal(t, "/?offset=0&limit=20&sort=-public_date&search=h-3",
 		output.Links.Last)
 	assert.Nil(t, output.Links.Next)
 	assert.Nil(t, output.Links.Previous)
@@ -269,7 +270,7 @@ func TestAdvisoriesTags(t *testing.T) {
 	output := testAdvisories(t, "/?sort=id&tags=ns1/k2=val2")
 	assert.Equal(t, 8, len(output.Data))
 	assert.Equal(t, 2, output.Data[0].Attributes.ApplicableSystems)
-	assert.Equal(t, "/api/patch/v1/advisories?offset=0&limit=20&sort=id&tags=ns1/k2=val2", output.Links.First)
+	assert.Equal(t, "/?offset=0&limit=20&sort=id&tags=ns1/k2=val2", output.Links.First)
 }
 
 func TestListAdvisoriesTagsInvalid(t *testing.T) {

--- a/manager/controllers/advisory_systems.go
+++ b/manager/controllers/advisory_systems.go
@@ -5,7 +5,6 @@ import (
 	"app/base/models"
 	"app/base/utils"
 	"app/manager/middlewares"
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -101,8 +100,7 @@ func AdvisorySystemsListHandler(c *gin.Context) {
 		return
 	} // Error handled in method itself
 	query, _ = ApplyTagsFilter(filters, query, "sp.inventory_id")
-	path := fmt.Sprintf("/api/patch/v1/advisories/%v/systems", advisoryName)
-	query, meta, links, err := ListCommon(query, c, filters, path, AdvisorySystemOpts)
+	query, meta, links, err := ListCommon(query, c, filters, AdvisorySystemOpts)
 	if err != nil {
 		return
 	} // Error handled in method itself

--- a/manager/controllers/baseline_systems.go
+++ b/manager/controllers/baseline_systems.go
@@ -5,7 +5,6 @@ import (
 	"app/base/models"
 	"app/base/utils"
 	"app/manager/middlewares"
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -95,8 +94,7 @@ func BaselineSystemsListHandler(c *gin.Context) {
 	} // Error handled in method itself
 	query, _ = ApplyTagsFilter(filters, query, "sp.inventory_id")
 
-	path := fmt.Sprintf("/api/patch/v1/baselines/%v/systems", baselineID)
-	query, meta, links, err := ListCommon(query, c, nil, path, BaselineSystemOpts)
+	query, meta, links, err := ListCommon(query, c, nil, BaselineSystemOpts)
 	if err != nil {
 		// Error handling and setting of result code & content is done in ListCommon
 		return

--- a/manager/controllers/baseline_systems_test.go
+++ b/manager/controllers/baseline_systems_test.go
@@ -36,8 +36,8 @@ func TestBaselineSystemsDefault(t *testing.T) {
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[1].Attributes.DisplayName)
 
 	// links
-	assert.Equal(t, "/api/patch/v1/baselines/1/systems?offset=0&limit=20&sort=-display_name", output.Links.First)
-	assert.Equal(t, "/api/patch/v1/baselines/1/systems?offset=0&limit=20&sort=-display_name", output.Links.Last)
+	assert.Equal(t, "/1/systems?offset=0&limit=20&sort=-display_name", output.Links.First)
+	assert.Equal(t, "/1/systems?offset=0&limit=20&sort=-display_name", output.Links.Last)
 	assert.Nil(t, output.Links.Next)
 	assert.Nil(t, output.Links.Previous)
 
@@ -52,8 +52,8 @@ func TestBaselinesystemsEmpty(t *testing.T) {
 
 	assert.Equal(t, 0, len(output.Data))
 	// links
-	assert.Equal(t, "/api/patch/v1/baselines/3/systems?offset=0&limit=20&sort=-display_name", output.Links.First)
-	assert.Equal(t, "/api/patch/v1/baselines/3/systems?offset=0&limit=20&sort=-display_name", output.Links.Last)
+	assert.Equal(t, "/3/systems?offset=0&limit=20&sort=-display_name", output.Links.First)
+	assert.Equal(t, "/3/systems?offset=0&limit=20&sort=-display_name", output.Links.Last)
 	assert.Nil(t, output.Links.Next)
 	assert.Nil(t, output.Links.Previous)
 
@@ -123,9 +123,9 @@ func TestBaselineSystemsSearch(t *testing.T) {
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].Attributes.DisplayName)
 
 	// links
-	assert.Equal(t, "/api/patch/v1/baselines/1/systems?offset=0&limit=20&sort=-display_name&search=00000000-0000-0000-0000-000000000001",
+	assert.Equal(t, "/1/systems?offset=0&limit=20&sort=-display_name&search=00000000-0000-0000-0000-000000000001",
 		output.Links.First)
-	assert.Equal(t, "/api/patch/v1/baselines/1/systems?offset=0&limit=20&sort=-display_name&search=00000000-0000-0000-0000-000000000001",
+	assert.Equal(t, "/1/systems?offset=0&limit=20&sort=-display_name&search=00000000-0000-0000-0000-000000000001",
 		output.Links.Last)
 	assert.Nil(t, output.Links.Next)
 	assert.Nil(t, output.Links.Previous)

--- a/manager/controllers/baselines.go
+++ b/manager/controllers/baselines.go
@@ -79,7 +79,7 @@ func BaselinesListHandler(c *gin.Context) {
 		return
 	} // Error handled in method itself
 
-	query, meta, links, err := ListCommon(query, c, filters, "/api/patch/v1/baselines", BaselineOpts)
+	query, meta, links, err := ListCommon(query, c, filters, BaselineOpts)
 	if err != nil {
 		// Error handling and setting of result code & content is done in ListCommon
 		return

--- a/manager/controllers/baselines_test.go
+++ b/manager/controllers/baselines_test.go
@@ -54,8 +54,8 @@ func TestBaselinesDefault(t *testing.T) {
 	assert.Equal(t, 0, output.Data[2].Attributes.Systems)
 
 	// links
-	assert.Equal(t, "/api/patch/v1/baselines?offset=0&limit=20&sort=-name", output.Links.First)
-	assert.Equal(t, "/api/patch/v1/baselines?offset=0&limit=20&sort=-name", output.Links.Last)
+	assert.Equal(t, "/?offset=0&limit=20&sort=-name", output.Links.First)
+	assert.Equal(t, "/?offset=0&limit=20&sort=-name", output.Links.Last)
 	assert.Nil(t, output.Links.Next)
 	assert.Nil(t, output.Links.Previous)
 
@@ -100,7 +100,7 @@ func TestBaselinesFilterTypeID(t *testing.T) {
 	assert.Equal(t, "baseline_1-1", output.Data[0].Attributes.Name)
 
 	assert.Equal(t,
-		"/api/patch/v1/baselines?offset=0&limit=20&filter[id]=eq:1&sort=-name",
+		"/?offset=0&limit=20&filter[id]=eq:1&sort=-name",
 		output.Links.First)
 }
 
@@ -159,9 +159,9 @@ func TestBaselinesSearch(t *testing.T) {
 	assert.Equal(t, 2, output.Data[0].Attributes.Systems)
 
 	// links
-	assert.Equal(t, "/api/patch/v1/baselines?offset=0&limit=20&sort=-name&search=baseline_1-1",
+	assert.Equal(t, "/?offset=0&limit=20&sort=-name&search=baseline_1-1",
 		output.Links.First)
-	assert.Equal(t, "/api/patch/v1/baselines?offset=0&limit=20&sort=-name&search=baseline_1-1",
+	assert.Equal(t, "/?offset=0&limit=20&sort=-name&search=baseline_1-1",
 		output.Links.Last)
 	assert.Nil(t, output.Links.Next)
 	assert.Nil(t, output.Links.Previous)

--- a/manager/controllers/baselines_test.go
+++ b/manager/controllers/baselines_test.go
@@ -144,7 +144,7 @@ func TestBaselinesWrongSort(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/?sort=unknown_key", nil)
-	core.InitRouter(AdvisoriesListHandler).ServeHTTP(w, req)
+	core.InitRouter(BaselinesListHandler).ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/manager/controllers/package_systems.go
+++ b/manager/controllers/package_systems.go
@@ -5,7 +5,6 @@ import (
 	"app/base/utils"
 	"app/manager/middlewares"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -115,8 +114,7 @@ func PackageSystemsListHandler(c *gin.Context) {
 		return
 	} // Error handled in method itself
 	query, _ = ApplyTagsFilter(filters, query, "sp.inventory_id")
-	packageEndpoint := fmt.Sprintf("/packages/%s/systems", packageName)
-	query, meta, links, err := ListCommon(query, c, filters, packageEndpoint, PackageSystemsOpts)
+	query, meta, links, err := ListCommon(query, c, filters, PackageSystemsOpts)
 	if err != nil {
 		return
 	} // Error handled in method itself

--- a/manager/controllers/package_versions.go
+++ b/manager/controllers/package_versions.go
@@ -83,8 +83,7 @@ func PackageVersionsListHandler(c *gin.Context) {
 
 	query := packageVersionsQuery(account, packageNameIDs)
 	// we don't support tags and filters for this endpoint
-	packageEndpoint := fmt.Sprintf("/packages/%s/versions", packageName)
-	query, meta, links, err := ListCommon(query, c, nil, packageEndpoint, PackageVersionsOpts)
+	query, meta, links, err := ListCommon(query, c, nil, PackageVersionsOpts)
 	if err != nil {
 		return
 	} // Error handled in method itself

--- a/manager/controllers/packages.go
+++ b/manager/controllers/packages.go
@@ -100,7 +100,7 @@ func PackagesListHandler(c *gin.Context) {
 	if err != nil {
 		return
 	} // Error handled in method itself
-	query, meta, links, err := ListCommon(query, c, filters, "/packages", PackagesOpts)
+	query, meta, links, err := ListCommon(query, c, filters, PackagesOpts)
 	if err != nil {
 		return
 	} // Error handled in method itself

--- a/manager/controllers/system_advisories.go
+++ b/manager/controllers/system_advisories.go
@@ -5,7 +5,6 @@ import (
 	"app/base/models"
 	"app/base/utils"
 	"app/manager/middlewares"
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -116,8 +115,7 @@ func SystemAdvisoriesHandler(c *gin.Context) {
 	}
 
 	query := buildSystemAdvisoriesQuery(account, inventoryID)
-	path := fmt.Sprintf("/api/patch/v1/systems/%v/advisories", inventoryID)
-	query, meta, links, err := ListCommon(query, c, nil, path, SystemAdvisoriesOpts)
+	query, meta, links, err := ListCommon(query, c, nil, SystemAdvisoriesOpts)
 	if err != nil {
 		// Error handling and setting of result code & content is done in ListCommon
 		return

--- a/manager/controllers/system_packages.go
+++ b/manager/controllers/system_packages.go
@@ -94,7 +94,7 @@ func SystemPackagesHandler(c *gin.Context) {
 
 	var loaded []SystemPackageDBLoad
 	q := systemPackageQuery(account, inventoryID)
-	q, meta, links, err := ListCommon(q, c, nil, fmt.Sprintf("/systems/%s/packages", inventoryID), SystemPackagesOpts)
+	q, meta, links, err := ListCommon(q, c, nil, SystemPackagesOpts)
 	if err != nil {
 		return
 	}

--- a/manager/controllers/systems.go
+++ b/manager/controllers/systems.go
@@ -176,7 +176,7 @@ func SystemsListHandler(c *gin.Context) {
 		return
 	} // Error handled method itself
 	query, _ = ApplyTagsFilter(filters, query, "sp.inventory_id")
-	query, meta, links, err := ListCommon(query, c, filters, "/api/patch/v1/systems", SystemOpts)
+	query, meta, links, err := ListCommon(query, c, filters, SystemOpts)
 	if err != nil {
 		return
 	} // Error handled method itself

--- a/manager/controllers/systems_test.go
+++ b/manager/controllers/systems_test.go
@@ -40,8 +40,8 @@ func TestSystemsDefault(t *testing.T) {
 	assert.Equal(t, true, *output.Data[0].Attributes.BaselineUpToDate)
 
 	// links
-	assert.Equal(t, "/api/patch/v1/systems?offset=0&limit=20&filter[stale]=eq:false&sort=-last_upload", output.Links.First)
-	assert.Equal(t, "/api/patch/v1/systems?offset=0&limit=20&filter[stale]=eq:false&sort=-last_upload", output.Links.Last)
+	assert.Equal(t, "/?offset=0&limit=20&filter[stale]=eq:false&sort=-last_upload", output.Links.First)
+	assert.Equal(t, "/?offset=0&limit=20&filter[stale]=eq:false&sort=-last_upload", output.Links.Last)
 	assert.Nil(t, output.Links.Next)
 	assert.Nil(t, output.Links.Previous)
 

--- a/manager/controllers/utils.go
+++ b/manager/controllers/utils.go
@@ -174,7 +174,7 @@ func CountRows(tx *gorm.DB) (total int, subTotals map[string]int, err error) {
 }
 
 //nolint: funlen, lll
-func ListCommon(tx *gorm.DB, c *gin.Context, tagFilter map[string]FilterData, path string, opts ListOpts, params ...string) (
+func ListCommon(tx *gorm.DB, c *gin.Context, tagFilter map[string]FilterData, opts ListOpts, params ...string) (
 	*gorm.DB, *ListMeta, *Links, error) {
 	limit, offset, err := utils.LoadLimitOffset(c, core.DefaultLimit)
 	if err != nil {
@@ -232,6 +232,7 @@ func ListCommon(tx *gorm.DB, c *gin.Context, tagFilter map[string]FilterData, pa
 
 	tagQ := extractTagsQueryString(c)
 
+	path := c.Request.URL.Path
 	params = append(params, filters.ToQueryParams(), sortQ, tagQ, searchQ)
 	links := CreateLinks(path, offset, limit, total, params...)
 	mergeMaps(meta.Filter, tagFilter)


### PR DESCRIPTION
Some links in response metadata were like `/api/patch/v1/advisories`, others were just `/packages`. Either way, they were hardcoded and didn't show the correct path for v2 api. Use `gin.Context.FullPath` to get the correct path for links
 
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
