### PR TITLE
use initContainer for db migration

### DIFF
--- a/database_admin/entrypoint.sh
+++ b/database_admin/entrypoint.sh
@@ -6,5 +6,3 @@ MIGRATION_FILES=file://./database_admin/migrations
 
 echo "Running in $(pwd) as $(id)"
 ${GORUN:+go run} ./main${GORUN:+.go} migrate $MIGRATION_FILES
-
-exec sleep infinity

--- a/database_admin/migrate.go
+++ b/database_admin/migrate.go
@@ -68,8 +68,8 @@ func MigrateUp(conn database.Driver, sourceURL string) {
 	}
 
 	if err != nil {
-		// Don't panic on error, Log and keep the container running so we can diagnose it
 		fmt.Fprintf(os.Stderr, "Error upgrading the database: %v", err.Error())
+		panic(err)
 	}
 }
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -21,6 +21,34 @@ objects:
           enabled: false
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG_MANAGER}
+        initContainers:
+          - name: db-migration
+            image: ${IMAGE}:${IMAGE_TAG_DATABASE_ADMIN}
+            command:
+              - ./database_admin/entrypoint.sh
+            env:
+            - {name: LOG_LEVEL, value: '${LOG_LEVEL_DATABASE_ADMIN}'}
+            - {name: GODEBUG, value: '${GODEBUG_DATABASE_ADMIN}'}
+            - {name: DB_DEBUG, value: '${DB_DEBUG_DATABASE_ADMIN}'}
+            - {name: GIN_MODE, value: '${GIN_MODE}'}
+            - {name: SHOW_CLOWDER_VARS, value: ''}
+            - {name: CLOWDER_ENABLED, value: '${CLOWDER_ENABLED}'}
+            - {name: SHOW_CLOWDER_VARS, value: ''}
+            - {name: SCHEMA_MIGRATION, value: '${SCHEMA_MIGRATION}'}
+            - {name: RESET_SCHEMA, value: '${RESET_SCHEMA}'}
+            - {name: FORCE_SCHEMA_VERSION, value: '${FORCE_SCHEMA_VERSION}'}
+            - {name: UPDATE_CYNDI_PASSWD, value: '${UPDATE_CYNDI_PASSWD}'}
+            - {name: WAIT_FOR_DB, value: 'empty'}
+            - {name: MANAGER_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
+                                                                  key: manager-database-password}}}
+            - {name: LISTENER_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
+                                                                  key: listener-database-password}}}
+            - {name: EVALUATOR_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
+                                                                    key: evaluator-database-password}}}
+            - {name: VMAAS_SYNC_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
+                                                                    key: vmaas-sync-database-password}}}
+            - {name: CYNDI_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
+                                                                key: cyndi-database-password}}}
         command:
           - ./scripts/entrypoint.sh
           - manager
@@ -261,52 +289,6 @@ objects:
         resources:
           limits: {cpu: '${RES_LIMIT_CPU_VMAAS_SYNC}', memory: '${RES_LIMIT_MEM_VMAAS_SYNC}'}
           requests: {cpu: '${RES_REQUEST_CPU_VMAAS_SYNC}', memory: '${RES_REQUEST_MEM_VMAAS_SYNC}'}
-
-    - name: database-admin
-      minReplicas: 1
-      webServices:
-        public:
-          enabled: false
-        private:
-          enabled: false
-        metrics:
-          enabled: false
-      podSpec:
-        image: ${IMAGE}:${IMAGE_TAG_DATABASE_ADMIN}
-        command:
-          - ./database_admin/entrypoint.sh
-        livenessProbe:
-          exec:
-            command: [echo]
-        readinessProbe:
-          exec:
-            command: [echo]
-        env:
-        - {name: LOG_LEVEL, value: '${LOG_LEVEL_DATABASE_ADMIN}'}
-        - {name: GODEBUG, value: '${GODEBUG_DATABASE_ADMIN}'}
-        - {name: DB_DEBUG, value: '${DB_DEBUG_DATABASE_ADMIN}'}
-        - {name: GIN_MODE, value: '${GIN_MODE}'}
-        - {name: SHOW_CLOWDER_VARS, value: ''}
-        - {name: CLOWDER_ENABLED, value: '${CLOWDER_ENABLED}'}
-        - {name: SHOW_CLOWDER_VARS, value: ''}
-        - {name: SCHEMA_MIGRATION, value: '${SCHEMA_MIGRATION}'}
-        - {name: RESET_SCHEMA, value: '${RESET_SCHEMA}'}
-        - {name: FORCE_SCHEMA_VERSION, value: '${FORCE_SCHEMA_VERSION}'}
-        - {name: UPDATE_CYNDI_PASSWD, value: '${UPDATE_CYNDI_PASSWD}'}
-        - {name: WAIT_FOR_DB, value: 'empty'}
-        - {name: MANAGER_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
-                                                              key: manager-database-password}}}
-        - {name: LISTENER_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
-                                                               key: listener-database-password}}}
-        - {name: EVALUATOR_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
-                                                                key: evaluator-database-password}}}
-        - {name: VMAAS_SYNC_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
-                                                                 key: vmaas-sync-database-password}}}
-        - {name: CYNDI_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
-                                                            key: cyndi-database-password}}}
-        resources:
-          limits: {cpu: '${RES_LIMIT_CPU_DATABASE_ADMIN}', memory: '${RES_LIMIT_MEM_DATABASE_ADMIN}'}
-          requests: {cpu: '${RES_REQUEST_CPU_DATABASE_ADMIN}', memory: '${RES_REQUEST_MEM_DATABASE_ADMIN}'}
 
     jobs:
     - name: floorist


### PR DESCRIPTION
Initially I wanted to use k8s job which runs migrations and add initContainer to all deployements to wait till migration is ready. However, using plain job suffers from clowder usage - it doesn't have the correct config and can't pull the image and ClowdJob triggered by ClowdJobInvoction can't be run if the app is not running so it can't be used for migrations.

The implementation is basically the same as in Vulnerability
1. manager pod has initContainer which runs migrations
2. to avoid concurrency we are using pg_advisory_lock
3. if the migration is not successful, init container panics which _should_ result in failure and new manager won't be deployed
4. other pods (evaluators, listeners,...) will start immediately and they may be in CrashLoop state until migrations are not successful

It is not the ideal solution, any recommendations?

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
