### PR TITLE
[DEBUG] Revert SPM-1626: Include OrgID in notification messages

### DIFF
--- a/base/mqueue/platform_event.go
+++ b/base/mqueue/platform_event.go
@@ -61,13 +61,6 @@ func (event *PlatformEvent) GetAccountName() string {
 	return *event.Account
 }
 
-func (event *PlatformEvent) GetOrgID() string {
-	if event.OrgID == nil {
-		return ""
-	}
-	return *event.OrgID
-}
-
 func writePlatformEvents(ctx context.Context, w Writer, events ...PlatformEvent) error {
 	var err error
 	msgs := make([]KafkaMessage, len(events))

--- a/base/notification/notification.go
+++ b/base/notification/notification.go
@@ -69,7 +69,7 @@ type Advisory struct {
 	Synopsis     string `json:"synopsis"`
 }
 
-func MakeNotification(inventoryID, accountName, orgID, eventType string, events []Event) *Notification {
+func MakeNotification(inventoryID, accountName, eventType string, events []Event) *Notification {
 	return &Notification{
 		Version:     Version,
 		Bundle:      Bundle,
@@ -80,6 +80,5 @@ func MakeNotification(inventoryID, accountName, orgID, eventType string, events 
 		AccountID: accountName,
 		Context:   Context{InventoryID: inventoryID},
 		Events:    events,
-		OrgID:     orgID,
 	}
 }

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -178,7 +178,7 @@ func evaluateInDatabase(ctx context.Context, event *mqueue.PlatformEvent, invent
 		return nil, nil, nil
 	}
 
-	vmaasData, err := evaluateWithVmaas(tx, updatesData, system, event)
+	vmaasData, err := evaluateWithVmaas(tx, updatesData, system, event.GetAccountName())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "evaluation with vmaas failed")
 	}
@@ -206,7 +206,7 @@ func tryGetYumUpdates(system *models.SystemPlatform) (*vmaas.UpdatesV2Response, 
 }
 
 func evaluateWithVmaas(tx *gorm.DB, updatesData *vmaas.UpdatesV2Response,
-	system *models.SystemPlatform, event *mqueue.PlatformEvent) (*vmaas.UpdatesV2Response, error) {
+	system *models.SystemPlatform, accountName string) (*vmaas.UpdatesV2Response, error) {
 	if enableBaselineEval {
 		err := limitVmaasToBaseline(tx, system, updatesData)
 		if err != nil {
@@ -214,7 +214,7 @@ func evaluateWithVmaas(tx *gorm.DB, updatesData *vmaas.UpdatesV2Response,
 		}
 	}
 
-	err := evaluateAndStore(tx, system, updatesData, event)
+	err := evaluateAndStore(tx, system, updatesData, accountName)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to evaluate and store results")
 	}
@@ -345,7 +345,7 @@ func commitWithObserve(tx *gorm.DB) error {
 }
 
 func evaluateAndStore(tx *gorm.DB, system *models.SystemPlatform,
-	vmaasData *vmaas.UpdatesV2Response, event *mqueue.PlatformEvent) error {
+	vmaasData *vmaas.UpdatesV2Response, accountName string) error {
 	newSystemAdvisories, err := analyzeAdvisories(tx, system, vmaasData)
 	if err != nil {
 		return errors.Wrap(err, "Advisory analysis failed")
@@ -364,7 +364,7 @@ func evaluateAndStore(tx *gorm.DB, system *models.SystemPlatform,
 
 	// Send instant notification with new advisories
 	if enableInstantNotifications {
-		err = publishNewAdvisoriesNotification(tx, system.InventoryID, event, system.RhAccountID, newSystemAdvisories)
+		err = publishNewAdvisoriesNotification(tx, system.InventoryID, accountName, system.RhAccountID, newSystemAdvisories)
 		if err != nil {
 			evaluationCnt.WithLabelValues("error-advisory-notification").Inc()
 			utils.Log("err", err.Error()).Error("publishing new advisories notification failed")

--- a/evaluator/notifications.go
+++ b/evaluator/notifications.go
@@ -33,7 +33,8 @@ func getUnnotifiedAdvisories(tx *gorm.DB, accountID int, newAdvs SystemAdvisoryM
 	err := tx.Table("advisory_account_data as acd").
 		Select("am.name").
 		Joins("inner join advisory_metadata am on am.id = acd.advisory_id").
-		Where("acd.rh_account_id = ? AND acd.advisory_id IN (?) AND acd.notified IS NULL", accountID, advIDs).
+		Where("acd.rh_account_id = ? AND acd.advisory_id IN (?)"+
+			"AND acd.notified IS NULL AND acd.systems_affected > 0", accountID, advIDs).
 		Scan(&advNames).Error
 	if err != nil {
 		return nil, errors.Wrap(err, "querying unnotified advisories from DB failed")

--- a/evaluator/notifications_test.go
+++ b/evaluator/notifications_test.go
@@ -57,13 +57,11 @@ func TestAdvisoriesNotificationPublish(t *testing.T) {
 	database.CheckCachesValid(t)
 	database.CheckAdvisoriesAccountDataNotified(t, rhAccountID, oldSystemAdvisoryIDs, false)
 
-	orgID := "1234567"
 	// do evaluate the system
 	err := evaluateHandler(mqueue.PlatformEvent{
 		SystemIDs:  []string{"00000000-0000-0000-0000-000000000012"},
 		RequestIDs: []string{"request-2"},
-		AccountID:  rhAccountID,
-		OrgID:      &orgID})
+		AccountID:  rhAccountID})
 	assert.NoError(t, err)
 	advisoryIDs := database.CheckAdvisoriesInDB(t, expectedAddedAdvisories)
 	database.CheckAdvisoriesAccountDataNotified(t, rhAccountID, expectedAdvisoryIDs, true)
@@ -90,9 +88,7 @@ func TestAdvisoriesNotificationMessage(t *testing.T) {
 		},
 	}
 
-	orgID := "1234567"
-	notification := ntf.MakeNotification(inventoryID, strconv.Itoa(rhAccountID), orgID, NewAdvisoryEvent, events)
-	assert.Equal(t, orgID, notification.OrgID)
+	notification := ntf.MakeNotification(inventoryID, strconv.Itoa(rhAccountID), NewAdvisoryEvent, events)
 	msg, err := mqueue.MessageFromJSON(inventoryID, notification)
 	assert.Nil(t, err)
 	assert.Equal(t, inventoryID, string(msg.Key))


### PR DESCRIPTION
After merging these changes, `notifications-backend` stopped pushing emails. It still receives events, so it possibly has some problems with processing the payload. Unfortunately it does not produce any insightful logs so I should be able to verify it with this revert.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
