### PR TITLE
reword duplicate baseline name error message

### DIFF
--- a/manager/controllers/baseline_create.go
+++ b/manager/controllers/baseline_create.go
@@ -17,6 +17,7 @@ import (
 )
 
 const BaselineMissingNameErr = "missing required parameter 'name'"
+const DuplicateBaselineNameErr = "patch template name already exists"
 
 type CreateBaselineRequest struct {
 	// Baseline name
@@ -75,7 +76,7 @@ func CreateBaselineHandler(c *gin.Context) {
 	baselineID, err := buildCreateBaselineQuery(request, accountID)
 	if err != nil {
 		if database.IsPgErrorCode(err, database.PgErrorDuplicateKey) {
-			LogAndRespBadRequest(c, err, "baseline name already exists")
+			LogAndRespBadRequest(c, err, DuplicateBaselineNameErr)
 			return
 		}
 		LogAndRespError(c, err, "Database error")

--- a/manager/controllers/baseline_create_test.go
+++ b/manager/controllers/baseline_create_test.go
@@ -111,7 +111,7 @@ func TestCreateBaselineDuplicatedName(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	var errResp utils.ErrorResponse
 	ParseResponseBody(t, w.Body.Bytes(), &errResp)
-	assert.Equal(t, "baseline name already exists", errResp.Error)
+	assert.Equal(t, DuplicateBaselineNameErr, errResp.Error)
 }
 
 func TestCreateBaselineDescriptionEmptyString(t *testing.T) {

--- a/manager/controllers/baseline_update.go
+++ b/manager/controllers/baseline_update.go
@@ -99,7 +99,7 @@ func BaselineUpdateHandler(c *gin.Context) {
 			return
 		}
 		if database.IsPgErrorCode(err, database.PgErrorDuplicateKey) {
-			LogAndRespBadRequest(c, err, "baseline name already exists")
+			LogAndRespBadRequest(c, err, DuplicateBaselineNameErr)
 			return
 		}
 		LogAndRespError(c, err, "Database error")

--- a/manager/controllers/baseline_update_test.go
+++ b/manager/controllers/baseline_update_test.go
@@ -191,7 +191,7 @@ func TestUpdateBaselineDuplicatedName(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	var errResp utils.ErrorResponse
 	ParseResponseBody(t, w.Body.Bytes(), &errResp)
-	assert.Equal(t, "baseline name already exists", errResp.Error)
+	assert.Equal(t, DuplicateBaselineNameErr, errResp.Error)
 }
 
 func TestUpdateBaselineSystems(t *testing.T) {


### PR DESCRIPTION
This rewords the duplicate baseline name error message from 'baseline name already exists' to 'patch template name already exists'. 


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
