### PR TITLE
SPM-1326: fix missing thirdparty package in system/packages

### DIFF
--- a/manager/controllers/system_packages.go
+++ b/manager/controllers/system_packages.go
@@ -50,8 +50,8 @@ type SystemPackageDBLoad struct {
 
 func systemPackageQuery(account int, inventoryID string) *gorm.DB {
 	query := database.SystemPackages(database.Db, account).
-		Joins("JOIN strings AS descr ON p.description_hash = descr.id").
-		Joins("JOIN strings AS sum ON p.summary_hash = sum.id").
+		Joins("LEFT JOIN strings AS descr ON p.description_hash = descr.id").
+		Joins("LEFT JOIN strings AS sum ON p.summary_hash = sum.id").
 		Select(SystemPackagesSelect).
 		Where("sp.inventory_id = ?::uuid", inventoryID)
 


### PR DESCRIPTION
Basically the same thing as for https://github.com/RedHatInsights/patchman-engine/pull/1026, there is `""` vs null issue in DB, so we might want to use left join

with `JOIN`
```
-d "{\"query\": \"select pn.name from system_package sp JOIN package p ON sp.package_id = p.id JOIN strings sum ON p.summary_hash = sum.id JOIN package_name pn ON pn.id = sp.name_id where sp.system_id = '1422060' and sp.name_id = '660016426'\"}" -s | jq
{
  "result": [
    [
      "name"
    ]
  ],
  "error": ""
}
```

with LEFT JOIN
```
-d "{\"query\": \"select pn.name from system_package sp JOIN package p ON sp.package_id = p.id LEFT JOIN strings sum ON p.summary_hash = sum.id JOIN package_name pn ON pn.id = sp.name_id where sp.system_id = '1422060' and sp.name_id = '660016426'\"}" -s | jq
{
  "result": [
    [
      "name"
    ],
    [
      "thirdparty"
    ]
  ],
  "error": ""
}
```
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
