### PR TITLE
Add ReadHeaderTimeout

### DIFF
--- a/base/utils/gin.go
+++ b/base/utils/gin.go
@@ -7,7 +7,11 @@ import (
 	"github.com/pkg/errors"
 	"net/http"
 	"strconv"
+	"time"
 )
+
+// ReadHeaderTimeout same as nginx default
+const ReadHeaderTimeout = 60 * time.Second
 
 func LoadParamInt(c *gin.Context, param string, defaultValue int, query bool) (int, error) {
 	var valueStr string
@@ -56,7 +60,7 @@ type ErrorResponse struct {
 
 func RunServer(ctx context.Context, handler http.Handler, port int) error {
 	addr := fmt.Sprintf(":%d", port)
-	srv := http.Server{Addr: addr, Handler: handler}
+	srv := http.Server{Addr: addr, Handler: handler, ReadHeaderTimeout: ReadHeaderTimeout}
 	go func() {
 		<-ctx.Done()
 		err := srv.Shutdown(context.Background())


### PR DESCRIPTION
```
base/utils/gin.go:59:9: G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (gosec)
        srv := http.Server{Addr: addr, Handler: handler}
```
I've set same value as is default in nginx

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
