### PR TITLE
SPM-1564 add metrics for request durations per API endpoint

### DIFF
--- a/manager/middlewares/logger.go
+++ b/manager/middlewares/logger.go
@@ -36,5 +36,7 @@ func RequestResponseLogger() gin.HandlerFunc {
 		} else {
 			utils.Log(fields...).Error("request")
 		}
+
+		utils.ObserveSecondsSince(tStart, requestDurations.WithLabelValues(c.Request.Method+c.Request.URL.String()))
 	}
 }

--- a/manager/middlewares/prometheus.go
+++ b/manager/middlewares/prometheus.go
@@ -15,9 +15,17 @@ var serviceErrorCnt = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Name:      "dependency_call",
 }, []string{"name", "status"})
 
+var requestDurations = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Help:      "Request Durations",
+	Namespace: "patchman_engine",
+	Subsystem: "manager",
+	Name:      "request_durations",
+	Buckets:   []float64{1, 1.5, 1.75, 2, 2.5, 3, 3.5, 4},
+}, []string{"endpoint"})
+
 // Create and configure Prometheus middleware to expose metrics
 func Prometheus() *ginprometheus.Prometheus {
-	prometheus.MustRegister(serviceErrorCnt)
+	prometheus.MustRegister(serviceErrorCnt, requestDurations)
 
 	p := ginprometheus.NewPrometheus("patchman_engine")
 	p.MetricsPath = utils.Cfg.MetricsPath


### PR DESCRIPTION
Example:
```
patchman_engine_manager_request_durations_bucket{endpoint="GET/api/patch/v2/advisories/",le="1"} 10
patchman_engine_manager_request_durations_bucket{endpoint="GET/api/patch/v2/advisories/",le="1.5"} 10
patchman_engine_manager_request_durations_bucket{endpoint="GET/api/patch/v2/advisories/",le="1.75"} 10
patchman_engine_manager_request_durations_bucket{endpoint="GET/api/patch/v2/advisories/",le="2"} 10
patchman_engine_manager_request_durations_bucket{endpoint="GET/api/patch/v2/advisories/",le="2.5"} 10
patchman_engine_manager_request_durations_bucket{endpoint="GET/api/patch/v2/advisories/",le="3"} 10
patchman_engine_manager_request_durations_bucket{endpoint="GET/api/patch/v2/advisories/",le="3.5"} 10
patchman_engine_manager_request_durations_bucket{endpoint="GET/api/patch/v2/advisories/",le="4"} 10
patchman_engine_manager_request_durations_bucket{endpoint="GET/api/patch/v2/advisories/",le="+Inf"} 10
patchman_engine_manager_request_durations_sum{endpoint="GET/api/patch/v2/advisories/"} 0.021635808
patchman_engine_manager_request_durations_count{endpoint="GET/api/patch/v2/advisories/"} 10
```
Buckets are same as in Vulnerability in order to help us discover API endpoints which are close to 2s (latency target).
Tested with 0.005 bucket to see it works.