### PR TITLE
SPM-1721: optimize advisory cache refresh

### DIFF
--- a/tasks/caches/refresh_advisory_caches.go
+++ b/tasks/caches/refresh_advisory_caches.go
@@ -1,10 +1,8 @@
 package caches
 
 import (
-	"app/base/database"
 	"app/base/utils"
 	"app/tasks"
-	"sync"
 
 	"gorm.io/gorm"
 )
@@ -13,33 +11,17 @@ func RefreshAdvisoryCaches() {
 	if !enableRefreshAdvisoryCaches {
 		return
 	}
-
-	var wg sync.WaitGroup
-	refreshAdvisoryCachesPerAccounts(&wg)
-	wg.Wait()
+	refreshAdvisoryCachesPerAccounts()
 }
 
-func refreshAdvisoryCachesPerAccounts(wg *sync.WaitGroup) {
-	var rhAccountIDs []int
-	err := database.Db.Table("rh_account").Pluck("id", &rhAccountIDs).Error
+func refreshAdvisoryCachesPerAccounts() {
+	utils.Log().Info("Refreshing advisory cache")
+	err := tasks.WithTx(func(tx *gorm.DB) error {
+		return tx.Exec("select refresh_advisory_caches(NULL, NULL)").Error
+	})
 	if err != nil {
-		utils.Log("err", err.Error()).Error("Unable to load rh_account table ids to refresh caches")
-		return
-	}
-
-	for _, rhAccountID := range rhAccountIDs {
-		wg.Add(1)
-		go func(rhAccountID int) {
-			defer wg.Done()
-			err = tasks.WithTx(func(tx *gorm.DB) error {
-				return tx.Exec("select refresh_advisory_caches(NULL, ?)", rhAccountID).Error
-			})
-			if err != nil {
-				utils.Log("err", err.Error(), "rh_account_id", rhAccountID).
-					Error("Refreshed account advisory caches")
-			} else {
-				utils.Log("rh_account_id", rhAccountID).Info("Refreshed account advisory caches")
-			}
-		}(rhAccountID)
+		utils.Log("err", err.Error()).Error("Refreshed account advisory caches")
+	} else {
+		utils.Log().Info("Refreshed account advisory caches")
 	}
 }

--- a/tasks/caches/refresh_advisory_caches_test.go
+++ b/tasks/caches/refresh_advisory_caches_test.go
@@ -5,7 +5,6 @@ import (
 	"app/base/database"
 	"app/base/models"
 	"app/base/utils"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,9 +23,7 @@ func TestRefreshAdvisoryCachesPerAccounts(t *testing.T) {
 	assert.Nil(t, database.Db.Model(&models.AdvisoryAccountData{}).
 		Where("advisory_id = 3 AND rh_account_id = 1").Update("systems_affected", 8).Error)
 
-	var wg sync.WaitGroup
-	refreshAdvisoryCachesPerAccounts(&wg)
-	wg.Wait()
+	refreshAdvisoryCachesPerAccounts()
 
 	assert.Equal(t, 2, database.PluckInt(database.Db.Table("advisory_account_data").
 		Where("advisory_id = 1 AND rh_account_id = 2"), "systems_affected"))


### PR DESCRIPTION
~~improvements:~~

~~- set max number of goroutines for refresh job, currently it runs as many as possible goroutines (for 80k accounts in prod) which results in locking all rows for accounts at the same moment~~
~~- query accounts which has inconsistencies in system counts and only refresh these accounts~~

~~the problem can be in the query which finds accounts, it works quite fast in stage but it timeouts in gabi in prod and it has quite high cost~~

~~Subquery Scan on sums  (cost=3722126.53..3723369.97 rows=199 width=4)"~~

~~any ideas how to improve it further?~~

After discussion with @MichaelMraka we've decided to refresh all caches at once by not supplying any account ids
```
refresh_advisory_caches(NULL, NULL)
```
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
