### PR TITLE
SPM-1661: rework turnpike/admin api

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -16,13 +16,15 @@ jobs:
         METRICS_FILE=base/metrics/metrics.go
         DOC_FILE=docs/v2/openapi.json
         CLOWDER_FILE=deploy/clowdapp.yaml
+        TURNPIKE_FILE=turnpike/admin_api.go
         VERSION=$(awk '/^\/\/ @version/ {print $3}' $MANAGER_FILE)
         RELEASE_TYPE=$(git log -1 | tail -n1) # Check release type (/major, /minor, /patch (default))
         VERSION_NEXT=$(./scripts/increment_version.sh $VERSION $RELEASE_TYPE)
         sed -i "s|\(// @version \).*$|\1 $VERSION_NEXT|;" $MANAGER_FILE
+        sed -i "s|\(// @version \).*$|\1 $VERSION_NEXT|;" $TURNPIKE_FILE
         sed -i 's|\(ENGINEVERSION = "\)[^"]*\("\)$|'"\1$VERSION_NEXT\2|;" $METRICS_FILE
         sed -i 's|\("version": "\)[^"]*\("\)$|'"\1$VERSION_NEXT\2|;" $DOC_FILE
-        sed -i -E "s/\{name: IMAGE_TAG_(MANAGER|LISTENER|EVALUATOR_UPLOAD|EVALUATOR_RECALC|JOBS|DATABASE_ADMIN), value: .*\}/{name: IMAGE_TAG_\1, value: $VERSION_NEXT}/" $CLOWDER_FILE
+        sed -i -E "s/\{name: IMAGE_TAG_(MANAGER|LISTENER|EVALUATOR_UPLOAD|EVALUATOR_RECALC|JOBS|DATABASE_ADMIN|ADMIN), value: .*\}/{name: IMAGE_TAG_\1, value: $VERSION_NEXT}/" $CLOWDER_FILE
         git config --global user.name 'semantic-release'
         git config --global user.email ''
         git commit -am "${VERSION_NEXT}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ ADD --chown=insights:root database_admin/schema      /go/src/app/database_admin/
 ADD --chown=insights:root database_admin/migrations  /go/src/app/database_admin/migrations
 ADD --chown=insights:root docs/v1/openapi.json       /go/src/app/docs/v1/
 ADD --chown=insights:root docs/v2/openapi.json       /go/src/app/docs/v2/
+ADD --chown=insights:root docs/admin/openapi.json    /go/src/app/docs/admin/
 
 COPY --from=buildimg /go/src/app/main /go/src/app/
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -11,6 +11,50 @@ objects:
   spec:
     envName: ${ENV_NAME}
     deployments:
+    - name: admin
+      minReplicas: ${{REPLICAS_ADMIN}}
+      webServices:
+        public:
+          enabled: true
+          apiPath: patch
+        private:
+          enabled: false
+      podSpec:
+        image: ${IMAGE}:${IMAGE_TAG_ADMIN}
+        initContainers:
+          - name: check-for-db
+            image: ${IMAGE}:${IMAGE_TAG_DATABASE_ADMIN}
+            command:
+              - ./database_admin/check-upgraded.sh
+            env:
+            - {name: SCHEMA_MIGRATION, value: '${SCHEMA_MIGRATION}'}
+        command:
+          - ./scripts/entrypoint.sh
+          - admin
+        env:
+        - {name: GOMAXPROCS, value: '${GOMAXPROCS_ADMIN}'}
+        - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: DB_USER, value: vmaas_sync}
+        - {name: DB_PASSWD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
+                                                      key: vmaas-sync-database-password}}}
+        - {name: KAFKA_GROUP, value: patchman}
+        - {name: KAFKA_WRITER_MAX_ATTEMPTS, value: '${KAFKA_WRITER_MAX_ATTEMPTS}'}
+        - {name: EVAL_TOPIC, value: patchman.evaluator.recalc}
+        - {name: ENABLE_REPO_BASED_RE_EVALUATION, value: '${ENABLE_REPO_BASED_RE_EVALUATION}'}
+        - {name: ENABLE_RECALC_MESSAGES_SEND, value: '${ENABLE_RECALC_MESSAGES_SEND}'}
+        - {name: ENABLE_ADVISORIES_SYNC, value: '${ENABLE_ADVISORIES_SYNC}'}
+        - {name: ENABLE_PACKAGES_SYNC, value: '${ENABLE_PACKAGES_SYNC}'}
+        - {name: ENABLE_REPOS_SYNC, value: '${ENABLE_REPOS_SYNC}'}
+        - {name: ENABLE_MODIFIED_SINCE_SYNC, value: '${ENABLE_MODIFIED_SINCE_SYNC}'}
+        - {name: ERRATA_PAGE_SIZE, value: '${ERRATA_PAGE_SIZE}'}
+        - {name: PACKAGES_PAGE_SIZE, value: '${PACKAGES_PAGE_SIZE}'}
+        - {name: MSG_BATCH_SIZE, value: '${MSG_BATCH_SIZE}'}
+        - {name: ENABLE_TURNPIKE_AUTH, value: '${ENABLE_TURNPIKE_AUTH}'}
+
+        resources:
+          limits: {cpu: '${RES_LIMIT_CPU_ADMIN}', memory: '${RES_LIMIT_MEM_ADMIN}'}
+          requests: {cpu: '${RES_REQUEST_CPU_ADMIN}', memory: '${RES_REQUEST_MEM_ADMIN}'}
+
     - name: manager
       minReplicas: ${{REPLICAS_MANAGER}}
       webServices:
@@ -73,7 +117,6 @@ objects:
         - {name: KAFKA_GROUP, value: patchman}
         - {name: KAFKA_WRITER_MAX_ATTEMPTS, value: '${KAFKA_WRITER_MAX_ATTEMPTS}'}
         - {name: EVAL_TOPIC, value: '${EVAL_TOPIC_MANAGER}'}
-        - {name: ENABLE_TURNPIKE_AUTH, value: '${ENABLE_TURNPIKE_AUTH}'}
 
         resources:
           limits: {cpu: '${RES_LIMIT_CPU_MANAGER}', memory: '${RES_LIMIT_MEM_MANAGER}'}
@@ -289,8 +332,6 @@ objects:
         - {name: ERRATA_PAGE_SIZE, value: '${ERRATA_PAGE_SIZE}'}
         - {name: PACKAGES_PAGE_SIZE, value: '${PACKAGES_PAGE_SIZE}'}
         - {name: ENABLE_CYNDI_METRICS, value: '${ENABLE_CYNDI_METRICS}'}
-        - {name: ENABLE_ADVISORIES_COUNT_CHECK, value: '${ENABLE_ADVISORIES_COUNT_CHECK}'}
-        - {name: ENABLE_PACKAGES_COUNT_CHECK, value: '${ENABLE_PACKAGES_COUNT_CHECK}'}
         - {name: MSG_BATCH_SIZE, value: '${MSG_BATCH_SIZE}'}
         - {name: PROMETHEUS_PUSHGATEWAY,value: '${PROMETHEUS_PUSHGATEWAY}'}
         - {name: FULL_SYNC_CADENCE,value: '${FULL_SYNC_CADENCE}'}
@@ -579,8 +620,6 @@ parameters:
 - {name: ERRATA_PAGE_SIZE, value: '500'} # Requested Vmaas response page size for advisories sync
 - {name: PACKAGES_PAGE_SIZE, value: '5'} # Requested Vmaas response page size for packages sync
 - {name: ENABLE_CYNDI_METRICS, value: 'true'} # Calculate and expose metrics about Cyndi data
-- {name: ENABLE_ADVISORIES_COUNT_CHECK, value: 'true'} # Check all advisories count after sync, re-sync all if needed
-- {name: ENABLE_PACKAGES_COUNT_CHECK, value: 'true'} # Check all packages count after sync, re-sync all if needed
 - {name: RES_LIMIT_CPU_VMAAS_SYNC, value: 500m}
 - {name: RES_LIMIT_MEM_VMAAS_SYNC, value: 384Mi}
 - {name: RES_REQUEST_CPU_VMAAS_SYNC, value: 500m}
@@ -634,8 +673,15 @@ parameters:
 - {name: VMAAS_CALL_USE_OPTIMISTIC_UPDATES, value: 'true'} # Always use "optimistic_updates" in vmaas request (not only for third party usage).
 - {name: MSG_BATCH_SIZE, value: '4000'} # BatchSize for PlatformEvent message
 - {name: ENABLE_PAYLOAD_TRACKER, value: 'true'} # Send status messages to payload tracker
+
 # Turnpike
-- {name: ENABLE_TURNPIKE_AUTH, value: 'false'} # Enable Turnpike authentication for internal API (manual sync, re-calc)
+- {name: IMAGE_TAG_ADMIN, value: v2.3.1}
+- {name: ENABLE_TURNPIKE_AUTH, value: 'true'} # Enable Turnpike authentication for internal API (manual sync, re-calc)
+- {name: REPLICAS_ADMIN, value: '1'}
+- {name: RES_LIMIT_CPU_ADMIN, value: 100m}
+- {name: RES_LIMIT_MEM_ADMIN, value: 256Mi}
+- {name: RES_REQUEST_CPU_ADMIN, value: 50m}
+- {name: RES_REQUEST_MEM_ADMIN, value: 128Mi}
 
 # Floorist parameters
 - {name: FLOORIST_SUSPEND, value: 'true', required: true} # Disable Floorist cronjob execution

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -213,5 +213,26 @@ services:
     security_opt:
       - label=disable
 
+  admin:
+    container_name: admin
+    image: patchman-engine-app
+    env_file:
+      - ./conf/common.env
+      - ./conf/vmaas_sync.env
+    command: ./scripts/entrypoint.sh admin
+    ports:
+      - 8085:8083
+    depends_on:
+      - db
+      - kafka
+      - platform
+      - patchimg
+    volumes:
+      - ./dev:/go/src/app/dev
+      - ./dev/database/secrets:/opt/postgresql
+      - ./dev/kafka/secrets:/opt/kafka
+    security_opt:
+      - label=disable
+
 volumes:
   db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,5 +207,25 @@ services:
     security_opt:
       - label=disable
 
+  admin:
+    container_name: admin
+    image: patchman-engine-app
+    env_file:
+      - ./conf/common.env
+      - ./conf/vmaas_sync.env
+      - ./conf/gorun.env
+    command: ./scripts/entrypoint.sh admin
+    ports:
+      - 8085:8083
+    depends_on:
+      - db
+      - kafka
+      - platform
+      - patchimg
+    volumes:
+      - ./:/go/src/app
+    security_opt:
+      - label=disable
+
 volumes:
   db-data:

--- a/docs/admin/openapi.json
+++ b/docs/admin/openapi.json
@@ -1,0 +1,150 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Patch Admin API",
+        "description": "Admin API of the Patch application on [internal.console.redhat.com](https://internal.console.redhat.com)",
+        "contact": {},
+        "license": {
+            "name": "GPLv3",
+            "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
+        },
+        "version": "v2.3.1"
+    },
+    "servers": [
+        {
+            "url": "/api/patch/admin"
+        }
+    ],
+    "paths": {
+        "/check-caches": {
+            "get": {
+                "summary": "Check cached counts",
+                "description": "Check cached counts",
+                "operationId": "checkCaches",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/re-calc": {
+            "get": {
+                "summary": "Re-evaluate systems",
+                "description": "Re-evaluate systems",
+                "operationId": "recalc",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
+        "/sync": {
+            "get": {
+                "summary": "Sync data from VMaaS",
+                "description": "Sync data from VMaaS",
+                "operationId": "sync",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "RhIdentity": {
+                "type": "apiKey",
+                "name": "x-rh-identity",
+                "in": "header"
+            }
+        }
+    }
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -11,6 +11,7 @@ import (
 
 const exposedOpenapiPathV1 = "/tmp/openapi.v1.json"
 const exposedOpenapiPathV2 = "/tmp/openapi.v2.json"
+const exposedOpenapiPathAdmin = "/tmp/openapi.admin.json"
 
 var appVersions = map[string]openapiData{
 	"v1": {
@@ -21,6 +22,10 @@ var appVersions = map[string]openapiData{
 		in: "./docs/v2/openapi.json", out: exposedOpenapiPathV2,
 		url: "/api/patch/v2/openapi.json", handler: handleOpenapiV2Spec,
 	},
+}
+var adminAPI = openapiData{
+	in: "./docs/admin/openapi.json", out: exposedOpenapiPathAdmin,
+	url: "/api/patch/admin/openapi.json", handler: handleOpenapiAdminSpec,
 }
 
 type openapiData struct {
@@ -46,6 +51,14 @@ func Init(app *gin.Engine, config EndpointsConfig) string {
 	return data.url
 }
 
+func InitAdminAPI(app *gin.Engine) string {
+	cfg := EndpointsConfig{}
+	// used to create file with openapi.json
+	filterOpenAPI(cfg, adminAPI.in, adminAPI.out)
+	app.GET(adminAPI.url, adminAPI.handler)
+	return adminAPI.url
+}
+
 func handleOpenapiV1Spec(c *gin.Context) {
 	c.Status(200)
 	c.Header("Content-Type", "application/json; charset=utf-8")
@@ -56,6 +69,12 @@ func handleOpenapiV2Spec(c *gin.Context) {
 	c.Status(200)
 	c.Header("Content-Type", "application/json; charset=utf-8")
 	c.File(exposedOpenapiPathV2)
+}
+
+func handleOpenapiAdminSpec(c *gin.Context) {
+	c.Status(200)
+	c.Header("Content-Type", "application/json; charset=utf-8")
+	c.File(exposedOpenapiPathAdmin)
 }
 
 func filterOpenAPI(config EndpointsConfig, inputOpenapiPath, outputOpenapiPath string) (removedPaths int) {

--- a/main.go
+++ b/main.go
@@ -12,17 +12,21 @@ import (
 	"app/tasks/cleaning"
 	"app/tasks/system_culling"
 	"app/tasks/vmaas_sync"
+	"app/turnpike"
 	"log"
 	"os"
 )
 
-//nolint: funlen
+// nolint: funlen
 func main() {
 	base.HandleSignals()
 
 	defer utils.LogPanics(true)
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
+		case "admin":
+			turnpike.RunAdminAPI()
+			return
 		case "manager":
 			manager.RunManager()
 			return

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -9,7 +9,6 @@ import (
 	"app/manager/kafka"
 	"app/manager/middlewares"
 	"app/manager/routes"
-	"app/turnpike"
 
 	"github.com/gin-contrib/gzip"
 	"github.com/gin-gonic/gin"
@@ -57,8 +56,6 @@ func RunManager() {
 	go base.TryExposeOnMetricsPort(app)
 
 	kafka.TryStartEvalQueue(mqueue.NewKafkaWriterFromEnv)
-
-	go turnpike.RunAdminAPI()
 
 	port := utils.Cfg.PublicPort
 	err := utils.RunServer(base.Context, app, port)

--- a/manager/middlewares/swagger.go
+++ b/manager/middlewares/swagger.go
@@ -17,3 +17,11 @@ func SetSwagger(app *gin.Engine, config docs.EndpointsConfig) {
 	url := ginSwagger.URL(openapiURL)
 	app.GET("/openapi/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
 }
+
+func SetAdminSwagger(app *gin.Engine) {
+	oaURL := docs.InitAdminAPI((app))
+
+	url := ginSwagger.URL(oaURL)
+	api := app.Group("/api/patch/admin")
+	api.GET("/openapi/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
+}

--- a/manager/routes/routes.go
+++ b/manager/routes/routes.go
@@ -1,9 +1,11 @@
 package routes
 
 import (
+	"app/base/utils"
 	"app/docs"
 	"app/manager/controllers"
 	"app/manager/middlewares"
+	admin "app/turnpike/controllers"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -73,9 +75,17 @@ func InitAPI(api *gin.RouterGroup, config docs.EndpointsConfig) { // nolint: fun
 	ids.GET("/systems/:inventory_id/advisories", controllers.SystemAdvisoriesIDsHandler)
 
 	api.GET("/status", controllers.Status)
-	initAdmin(api.Group("/admin"))
 }
 
-func initAdmin(group *gin.RouterGroup) {
+func InitAdmin(app *gin.Engine) {
+	enableTurnpikeAuth := utils.GetBoolEnvOrDefault("ENABLE_TURNPIKE_AUTH", false)
 
+	api := app.Group("/api/patch/admin")
+	if enableTurnpikeAuth {
+		api.Use(middlewares.TurnpikeAuthenticator())
+	}
+
+	api.GET("/sync", admin.Syncapi)
+	api.GET("/re-calc", admin.Recalc)
+	api.GET("/check-caches", admin.CheckCaches)
 }

--- a/scripts/check-dockercomposes.sh
+++ b/scripts/check-dockercomposes.sh
@@ -9,7 +9,7 @@ sed \
     -e "s|INSTALL_TOOLS=yes|INSTALL_TOOLS=no|" \
     -e "s|target: buildimg|target: runtimeimg|" \
     -e "/ - \.\/conf\/gorun.env/ d" \
-    -e "/  \(db_admin\|db_feed\|manager\|listener\|evaluator_recalc\|evaluator_upload\|vmaas_sync\):/,/^$/ {
+    -e "/  \(db_admin\|db_feed\|manager\|listener\|evaluator_recalc\|evaluator_upload\|vmaas_sync\|admin\):/,/^$/ {
       s/- \.\/:\/go\/src\/app/- \.\/dev:\/go\/src\/app\/dev\n\
       - .\/dev\/database\/secrets:\/opt\/postgresql\n\
       - \.\/dev\/kafka\/secrets:\/opt\/kafka/

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -7,10 +7,17 @@ DOCS_TMP_DIR=/tmp
 CONVERT_URL="https://converter.swagger.io/api/convert"
 
 # Create temporary swagger 2.0 definition
-swag init --output $DOCS_TMP_DIR --generalInfo manager/manager.go
+swag init --output $DOCS_TMP_DIR --exclude turnpike --generalInfo manager/manager.go
+swag init --output $DOCS_TMP_DIR/admin --dir turnpike --generalInfo admin_api.go
 
 # Perform conversion
 curl -X "POST" -H "accept: application/json" -H  "Content-Type: application/json" \
   -d @$DOCS_TMP_DIR/swagger.json $CONVERT_URL \
   | python3 -m json.tool \
   > docs/v2/openapi.json
+
+# Convert admin spec
+curl -X "POST" -H "accept: application/json" -H  "Content-Type: application/json" \
+  -d @$DOCS_TMP_DIR/admin/swagger.json $CONVERT_URL \
+  | python3 -m json.tool \
+  > docs/admin/openapi.json

--- a/turnpike/admin_api.go
+++ b/turnpike/admin_api.go
@@ -2,77 +2,43 @@ package turnpike
 
 import (
 	"app/base"
-	"app/base/database"
+	"app/base/core"
 	"app/base/utils"
 	"app/manager/middlewares"
-	sync "app/tasks/vmaas_sync"
-	"net/http"
+	"app/manager/routes"
 
 	"github.com/gin-gonic/gin"
 )
 
-var enableTurnpikeAuth bool
+// nolint: lll
+// @title Patch Admin API
+// DO NOT EDIT version MANUALLY - this variable is modified by generate_docs.sh
+// @version  v2.3.1
+// @description Admin API of the Patch application on [internal.console.redhat.com](https://internal.console.redhat.com)
 
-func init() {
-	enableTurnpikeAuth = utils.GetBoolEnvOrDefault("ENABLE_TURNPIKE_AUTH", false)
-}
+// @license.name GPLv3
+// @license.url https://www.gnu.org/licenses/gpl-3.0.en.html
 
+// @query.collection.format multi
+// @securityDefinitions.apikey RhIdentity
+// @in header
+// @name x-rh-identity
+
+// @BasePath /api/patch/admin
 func RunAdminAPI() {
+	core.ConfigureApp()
+
+	utils.Log("port", utils.Cfg.PublicPort).Info("Manager-admin starting")
 	app := gin.New()
+	app.Use(middlewares.RequestResponseLogger())
+	middlewares.SetAdminSwagger(app)
 
-	if enableTurnpikeAuth {
-		app.Use(middlewares.TurnpikeAuthenticator())
-	}
+	core.InitProbes(app)
+	routes.InitAdmin(app)
 
-	app.GET("/sync", syncapi)
-	app.GET("/re-calc", recalc)
-	app.GET("/check-caches", checkCaches)
-
-	err := utils.RunServer(base.Context, app, utils.Cfg.PrivatePort)
-
+	err := utils.RunServer(base.Context, app, utils.Cfg.PublicPort)
 	if err != nil {
 		utils.Log("err", err.Error()).Error()
 		panic(err)
 	}
-}
-
-func syncapi(c *gin.Context) {
-	utils.Log().Info("manual syncing called...")
-	err := sync.SyncData(nil, nil)
-	if err != nil {
-		utils.Log("err", err.Error()).Error("manual called syncing failed")
-		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
-		return
-	}
-	utils.Log().Info("manual syncing finished successfully")
-	c.JSON(http.StatusOK, "OK")
-}
-
-func recalc(c *gin.Context) {
-	utils.Log().Info("manual re-calc messages sending called...")
-	err := sync.SendReevaluationMessages()
-	if err != nil {
-		utils.Log("err", err.Error()).Error("manual re-calc msgs sending failed")
-		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
-		return
-	}
-	utils.Log().Info("manual re-calc messages sent successfully")
-	c.JSON(http.StatusOK, "OK")
-}
-
-func checkCaches(c *gin.Context) {
-	valid, err := database.CheckCachesValidRet()
-	if err != nil {
-		utils.Log("error", err).Error("Could not check validity of caches")
-		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
-		return
-	}
-
-	if !valid {
-		utils.Log().Error("Cache mismatch found")
-		c.JSON(http.StatusConflict, "conflict")
-		return
-	}
-
-	c.JSON(http.StatusOK, "caches counts OK")
 }

--- a/turnpike/controllers/admin.go
+++ b/turnpike/controllers/admin.go
@@ -1,0 +1,79 @@
+package controllers
+
+import (
+	"app/base/database"
+	"app/base/utils"
+	sync "app/tasks/vmaas_sync"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// @Summary Sync data from VMaaS
+// @Description Sync data from VMaaS
+// @ID sync
+// @Security RhIdentity
+// @Accept   json
+// @Produce  json
+// @Success 200 {object} string
+// @Failure 500 {object} map[string]interface{}
+// @Router /sync [get]
+func Syncapi(c *gin.Context) {
+	utils.Log().Info("manual syncing called...")
+	err := sync.SyncData(nil, nil)
+	if err != nil {
+		utils.Log("err", err.Error()).Error("manual called syncing failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
+		return
+	}
+	utils.Log().Info("manual syncing finished successfully")
+	c.JSON(http.StatusOK, "OK")
+}
+
+// @Summary Re-evaluate systems
+// @Description Re-evaluate systems
+// @ID recalc
+// @Security RhIdentity
+// @Accept   json
+// @Produce  json
+// @Success 200 {object} string
+// @Failure 500 {object} map[string]interface{}
+// @Router /re-calc [get]
+func Recalc(c *gin.Context) {
+	utils.Log().Info("manual re-calc messages sending called...")
+	err := sync.SendReevaluationMessages()
+	if err != nil {
+		utils.Log("err", err.Error()).Error("manual re-calc msgs sending failed")
+		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
+		return
+	}
+	utils.Log().Info("manual re-calc messages sent successfully")
+	c.JSON(http.StatusOK, "OK")
+}
+
+// @Summary Check cached counts
+// @Description Check cached counts
+// @ID checkCaches
+// @Security RhIdentity
+// @Accept   json
+// @Produce  json
+// @Success 200 {object} string
+// @Failure 409 {object} string
+// @Failure 500 {object} map[string]interface{}
+// @Router /check-caches [get]
+func CheckCaches(c *gin.Context) {
+	valid, err := database.CheckCachesValidRet()
+	if err != nil {
+		utils.Log("error", err).Error("Could not check validity of caches")
+		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
+		return
+	}
+
+	if !valid {
+		utils.Log().Error("Cache mismatch found")
+		c.JSON(http.StatusConflict, "conflict")
+		return
+	}
+
+	c.JSON(http.StatusOK, "caches counts OK")
+}


### PR DESCRIPTION
- move admin api to its own pod
- generate openapi for admin api
- api is exposed on `/api/patch/admin`
- openapi UI is on `/api/patch/admin/openapi/index.html` on `PublicPort` or `8085` if ran locally
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
