### PR TITLE
SPM-1735: read yum_updates from s3

### DIFF
--- a/base/api/client.go
+++ b/base/api/client.go
@@ -23,20 +23,20 @@ func (o *Client) Request(ctx *context.Context, method, url string,
 	if requestPtr != nil {
 		err := json.NewEncoder(body).Encode(requestPtr)
 		if err != nil {
-			return nil, errors.Wrap(err, "UpdatesV3Request json encoding failed")
+			return nil, errors.Wrap(err, "JSON encoding failed")
 		}
 	}
 
 	httpReq, err := http.NewRequestWithContext(*ctx, method, url, body)
 	if err != nil {
-		return nil, errors.Wrap(err, "Updates request making failed")
+		return nil, errors.Wrap(err, "Request failed")
 	}
 	httpReq.Header.Add("Content-Type", "application/json")
 	addHeaders(httpReq, o.DefaultHeaders)
 
 	httpResp, err := utils.CallAPI(o.HTTPClient, httpReq, o.Debug)
 	if err != nil {
-		return nil, errors.Wrap(err, "Updates request making failed")
+		return nil, errors.Wrap(err, "Request failed")
 	}
 
 	bodyBytes, err := ioutil.ReadAll(httpResp.Body)

--- a/docs/admin/openapi.json
+++ b/docs/admin/openapi.json
@@ -8,7 +8,7 @@
             "name": "GPLv3",
             "url": "https://www.gnu.org/licenses/gpl-3.0.en.html"
         },
-        "version": "v2.3.1"
+        "version": "v2.3.7"
     },
     "servers": [
         {

--- a/listener/common_test.go
+++ b/listener/common_test.go
@@ -18,6 +18,8 @@ import (
 
 const id = "99c0ffee-0000-0000-0000-0000c0ffee99"
 
+var s3URL = "http://platform:9001/yum_updates"
+
 func TestInit(t *testing.T) {
 	utils.TestLoadEnv("conf/listener.env")
 }
@@ -94,7 +96,8 @@ func createTestUploadEvent(rhAccountID, orgID, inventoryID, reporter string, pac
 	if yum {
 		ev.PlatformMetadata = HostPlatformMetadata{
 			CustomMetadata: HostCustomMetadata{
-				YumUpdates: []byte(`{"kernel-0.3": {}}`),
+				YumUpdates:      []byte(`{"kernel-0.3": {}}`),
+				YumUpdatesS3URL: &s3URL,
 			},
 		}
 	}
@@ -136,7 +139,7 @@ func assertYumUpdatesInDB(t *testing.T, inventoryID string, yumUpdates []byte) {
 	var yumUpdatesParsed vmaas.UpdatesV2Response
 	err := json.Unmarshal(system.YumUpdates, &systemYumUpdatesParsed)
 	assert.Nil(t, err)
-	err = json.Unmarshal(yumUpdates, &systemYumUpdatesParsed)
+	err = json.Unmarshal(yumUpdates, &yumUpdatesParsed)
 	assert.Nil(t, err)
 	assert.Equal(t, systemYumUpdatesParsed, yumUpdatesParsed)
 }

--- a/listener/upload_test.go
+++ b/listener/upload_test.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"app/base/api"
 	"app/base/core"
 	"app/base/database"
 	"app/base/inventory"
@@ -12,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -274,8 +276,12 @@ func TestUpdateSystemPlatformYumUpdates(t *testing.T) {
 
 	accountID1 := getOrCreateTestAccount(t)
 
+	httpClient = &api.Client{
+		HTTPClient: &http.Client{},
+		Debug:      true,
+	}
 	hostEvent := createTestUploadEvent("1", "1", id, "puptoo", false, true)
-	yumUpdates, err := getYumUpdates(hostEvent)
+	yumUpdates, err := getYumUpdates(hostEvent, httpClient)
 	assert.Nil(t, err)
 
 	req := vmaas.UpdatesV3Request{}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -4,6 +4,7 @@ import (
 	"app/base"
 	"app/base/mqueue"
 	"app/base/utils"
+	"app/base/vmaas"
 	"app/manager/middlewares"
 	"encoding/json"
 	"fmt"
@@ -40,6 +41,7 @@ const uploadEvent = `{
     "platform_metadata": {
       "request_id": "ingress-service-5f79d54bf-q5jh6/iDl0gmf6Qw-071711",
       "custom_metadata": {
+		"yum_updates_s3_url": "http://platform:9001/yum_updates",
         "yum_updates": {
           "releasever": "8",
           "basearch": "x86_64",
@@ -93,6 +95,56 @@ const uploadEvent = `{
     }
 	}`
 
+var yumUpdates = `{
+	"releasever": "8",
+	"basearch": "x86_64",
+	"update_list": {
+		"bash-0:4.4.20-1.el8_4.x86_64": {
+			"available_updates": [
+			{
+				"package": "bash-0:4.4.20-3.el8.x86_64",
+				"repository": "rhel-8-for-x86_64-baseos-rpms",
+				"basearch": "x86_64",
+				"releasever": "8",
+				"erratum": "RHBA-2022:1993"
+			},
+			{
+				"package": "bash-0:4.4.20-3.el8.x86_64",
+				"repository": "ubi-8-baseos",
+				"basearch": "x86_64",
+				"releasever": "8",
+				"erratum": "RHBA-2022:1993"
+			},
+			{
+				"package": "bash-0:4.4.23-1.fc28.x86_64",
+				"repository": "local",
+				"basearch": "x86_64",
+				"releasever": "8"
+			}
+			]
+		},
+		"curl-0:7.61.1-18.el8_4.2.x86_64": {
+			"available_updates": [
+			{
+				"package": "curl-0:7.61.1-22.el8.x86_64",
+				"repository": "rhel-8-for-x86_64-baseos-rpms",
+				"basearch": "x86_64",
+				"releasever": "8",
+				"erratum": "RHSA-2021:4511"
+			},
+			{
+				"package": "curl-0:7.61.1-22.el8.x86_64",
+				"repository": "ubi-8-baseos",
+				"basearch": "x86_64",
+				"releasever": "8",
+				"erratum": "RHSA-2021:4511"
+			}
+			]
+		}
+	},
+	"metadata_time": "2022-05-30T14:00:25Z"
+}`
+
 func platformMock() {
 	utils.Log().Info("Platform mock starting")
 	app := gin.New()
@@ -105,6 +157,9 @@ func platformMock() {
 	app.POST("/control/upload", mockUploadHandler)
 	app.POST("/control/delete", mockDeleteHandler)
 	app.POST("/control/toggle_upload", mockToggleUpload)
+
+	// Mock yum_updates_s3
+	app.GET("/yum_updates", mockYumUpdatesS3)
 
 	err := utils.RunServer(base.Context, app, 9001)
 	if err != nil {
@@ -173,6 +228,16 @@ func mockDeleteHandler(c *gin.Context) {
 func mockToggleUpload(c *gin.Context) {
 	runUploadLoop = !runUploadLoop
 	c.JSON(http.StatusOK, fmt.Sprintf("%v", runUploadLoop))
+}
+
+func mockYumUpdatesS3(c *gin.Context) {
+	utils.Log().Info("Mocking S3 for providing yum updates")
+	updates := vmaas.UpdatesV2Response{}
+	if err := json.Unmarshal([]byte(yumUpdates), &updates); err != nil {
+		c.JSON(http.StatusInternalServerError, err.Error())
+		return
+	}
+	c.JSON(http.StatusOK, &updates)
 }
 
 func uploader() {


### PR DESCRIPTION
- primarily read yum_updates from yum_updates_s3_url
- if that does not exist read it from old yum_updates
- added `/yum_updates` endpoint to platform mock for tests
- added more generic logs to client

I haven't added retrying if yum_updates_s3_url is unavailable, should I?

TODO:
- [x] test in ephemeral whether it loads yum_updates form s3/minio
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
