### PR TITLE
SPM-1737: introduce tags REST API

### DIFF
--- a/docs/v2/openapi.json
+++ b/docs/v2/openapi.json
@@ -4861,6 +4861,50 @@
                 ]
             }
         },
+        "/tags": {
+            "get": {
+                "summary": "Show me systems tags applicable to this application",
+                "description": "Show me systems tags applicable to this application",
+                "operationId": "listSystemTags",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/controllers.SystemTagsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/utils.ErrorResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "RhIdentity": []
+                    }
+                ]
+            }
+        },
         "/views/advisories/systems": {
             "post": {
                 "summary": "View advisory-system pairs for selected systems and advisories",
@@ -6025,6 +6069,34 @@
                     },
                     "value": {
                         "type": "string"
+                    }
+                }
+            },
+            "controllers.SystemTagItem": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer"
+                    },
+                    "tag": {
+                        "$ref": "#/components/schemas/controllers.SystemTag"
+                    }
+                }
+            },
+            "controllers.SystemTagsResponse": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.SystemTagItem"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/controllers.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/controllers.ListMeta"
                     }
                 }
             },

--- a/docs/v2/openapi.json
+++ b/docs/v2/openapi.json
@@ -4866,6 +4866,36 @@
                 "summary": "Show me systems tags applicable to this application",
                 "description": "Show me systems tags applicable to this application",
                 "operationId": "listSystemTags",
+                "parameters": [
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sort field",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "tag",
+                                "count"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Limit for paging, set -1 to return all",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Offset for paging",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/manager/controllers/systems.go
+++ b/manager/controllers/systems.go
@@ -98,12 +98,6 @@ type SystemSums struct {
 	Stale     int64 `query:"count(*) filter (where sp.stale = true)" gorm:"column:stale"`
 }
 
-type SystemTag struct {
-	Key       string `json:"key"`
-	Namespace string `json:"namespace"`
-	Value     string `json:"value"`
-}
-
 type SystemItem struct {
 	Attributes SystemItemAttributes `json:"attributes"`
 	ID         string               `json:"id"`

--- a/manager/controllers/systemtags.go
+++ b/manager/controllers/systemtags.go
@@ -1,7 +1,63 @@
 package controllers
 
+import (
+	"app/base/database"
+	"net/http"
+
+	"app/manager/middlewares"
+
+	"github.com/gin-gonic/gin"
+)
+
 type SystemTag struct {
 	Key       string `json:"key"`
 	Namespace string `json:"namespace"`
 	Value     string `json:"value"`
+}
+
+type SystemTagItem struct {
+	Count int       `json:"count"`
+	Tag   SystemTag `json:"tag" gorm:"serializer:json"`
+}
+
+type SystemTagsResponse struct {
+	Data  []SystemTagItem `json:"data"`
+	Links Links           `json:"links"`
+	Meta  ListMeta        `json:"meta"`
+}
+
+// @Summary Show me systems tags applicable to this application
+// @Description Show me systems tags applicable to this application
+// @ID listSystemTags
+// @Security RhIdentity
+// @Produce  json
+// @Success 200 {object} SystemTagsResponse
+// @Failure 400 {object} utils.ErrorResponse
+// @Failure 500 {object} utils.ErrorResponse
+// @Router /tags [get]
+func SystemTagListHandler(c *gin.Context) {
+	account := c.GetInt(middlewares.KeyAccount)
+
+	// https://stackoverflow.com/questions/33474778/how-to-group-result-by-array-column-in-postgres
+	sq := database.Systems(database.Db, account).
+		Joins("JOIN inventory.hosts ih ON ih.id = sp.inventory_id").
+		Select("jsonb_array_elements(ih.tags) AS tag")
+
+	var tagsWithCount []SystemTagItem
+	tx := database.Db.Table("(?) AS sq", sq).
+		Select("COUNT(sq.tag) AS count, sq.tag AS tag").
+		Group("sq.tag").
+		Order("sq.tag").
+		Scan(&tagsWithCount)
+
+	if tx.Error != nil {
+		LogAndRespError(c, tx.Error, "unable to get tags")
+		return
+	}
+
+	resp := SystemTagsResponse{
+		Data: tagsWithCount,
+	}
+
+	c.JSON(http.StatusOK, &resp)
 }

--- a/manager/controllers/systemtags.go
+++ b/manager/controllers/systemtags.go
@@ -2,11 +2,13 @@ package controllers
 
 import (
 	"app/base/database"
+	"errors"
 	"net/http"
 
 	"app/manager/middlewares"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 type SystemTag struct {
@@ -26,16 +28,40 @@ type SystemTagsResponse struct {
 	Meta  ListMeta        `json:"meta"`
 }
 
+var SystemTagsOpts = ListOpts{
+	Fields: database.AttrMap{
+		"tag": {
+			OrderQuery: "sq.tag",
+		},
+		"count": {
+			OrderQuery: "COUNT(sq.tag)",
+		},
+	},
+	StableSort:  "tag",
+	DefaultSort: "tag",
+	TotalFunc:   systemTagsSubtotals,
+}
+
+func systemTagsSubtotals(tx *gorm.DB) (total int, subTotals map[string]int, err error) {
+	// Use direct COUNT() to avoid ORM magic
+	err = tx.Select("COUNT(*)").Scan(&total).Error
+	return
+}
+
 // @Summary Show me systems tags applicable to this application
 // @Description Show me systems tags applicable to this application
 // @ID listSystemTags
 // @Security RhIdentity
 // @Produce  json
+// @Param	sort	query	string	false	"Sort field" Enums(tag, count)
+// @Param	limit	query	int		fals	"Limit for paging, set -1 to return all"
+// @Param 	offset	query	int		false	"Offset for paging"
 // @Success 200 {object} SystemTagsResponse
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
 // @Router /tags [get]
 func SystemTagListHandler(c *gin.Context) {
+	var err error
 	account := c.GetInt(middlewares.KeyAccount)
 
 	// https://stackoverflow.com/questions/33474778/how-to-group-result-by-array-column-in-postgres
@@ -43,21 +69,43 @@ func SystemTagListHandler(c *gin.Context) {
 		Joins("JOIN inventory.hosts ih ON ih.id = sp.inventory_id").
 		Select("jsonb_array_elements(ih.tags) AS tag")
 
-	var tagsWithCount []SystemTagItem
-	tx := database.Db.Table("(?) AS sq", sq).
+	query := database.Db.Table("(?) AS sq", sq.Debug()).
 		Select("COUNT(sq.tag) AS count, sq.tag AS tag").
-		Group("sq.tag").
-		Order("sq.tag").
-		Scan(&tagsWithCount)
+		Group("sq.tag")
 
+	tx, meta, links, err := ListCommon(query, c, nil, SystemTagsOpts)
+	if !checkSortMeta(meta.Sort) {
+		LogAndRespBadRequest(c, errors.New("invalid sort field(s)"), "invalid sort")
+		return
+	}
+	if err != nil {
+		// error handling is done within ListCommon
+		return
+	}
+
+	var tagsWithCount []SystemTagItem
+	tx = tx.Scan(&tagsWithCount)
 	if tx.Error != nil {
 		LogAndRespError(c, tx.Error, "unable to get tags")
 		return
 	}
 
 	resp := SystemTagsResponse{
-		Data: tagsWithCount,
+		Data:  tagsWithCount,
+		Meta:  *meta,
+		Links: *links,
 	}
 
 	c.JSON(http.StatusOK, &resp)
+}
+
+// check for sort fields and disallow special case of hardcoded sort by "id",
+// as it is unavailable for aggregated SQLs
+func checkSortMeta(sort []string) bool {
+	for _, sortField := range sort {
+		if sortField == "id" {
+			return false
+		}
+	}
+	return true
 }

--- a/manager/controllers/systemtags.go
+++ b/manager/controllers/systemtags.go
@@ -1,0 +1,7 @@
+package controllers
+
+type SystemTag struct {
+	Key       string `json:"key"`
+	Namespace string `json:"namespace"`
+	Value     string `json:"value"`
+}

--- a/manager/controllers/systemtags_test.go
+++ b/manager/controllers/systemtags_test.go
@@ -1,0 +1,26 @@
+package controllers
+
+import (
+	"app/base/core"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// test System Tags List
+func TestSystemTagsListDefault(t *testing.T) {
+	core.SetupTest(t)
+
+	w := CreateRequestRouterWithAccount("GET", "/", nil, "", SystemTagListHandler, "/", 1)
+
+	var output SystemTagsResponse
+	CheckResponse(t, w, 200, &output)
+	if !assert.Equal(t, 4, len(output.Data)) {
+		return
+	}
+
+	assert.Equal(t, 7, output.Data[0].Count)
+	assert.Equal(t, "k1", output.Data[0].Tag.Key)
+	assert.Equal(t, "ns1", output.Data[0].Tag.Namespace)
+	assert.Equal(t, "val1", output.Data[0].Tag.Value)
+}

--- a/manager/controllers/systemtags_test.go
+++ b/manager/controllers/systemtags_test.go
@@ -24,3 +24,44 @@ func TestSystemTagsListDefault(t *testing.T) {
 	assert.Equal(t, "ns1", output.Data[0].Tag.Namespace)
 	assert.Equal(t, "val1", output.Data[0].Tag.Value)
 }
+
+func TestSystemTagsListPagination(t *testing.T) {
+	core.SetupTest(t)
+
+	w := CreateRequestRouterWithAccount("GET", "/?offset=1&limit=1", nil, "", SystemTagListHandler, "/", 1)
+
+	var output SystemTagsResponse
+	CheckResponse(t, w, 200, &output)
+	if !assert.Equal(t, 1, len(output.Data)) {
+		return
+	}
+
+	assert.Equal(t, 2, output.Data[0].Count)
+	assert.Equal(t, "k2", output.Data[0].Tag.Key)
+	assert.Equal(t, "ns1", output.Data[0].Tag.Namespace)
+	assert.Equal(t, "val2", output.Data[0].Tag.Value)
+}
+
+func TestSystemTagsListSort(t *testing.T) {
+	core.SetupTest(t)
+
+	w := CreateRequestRouterWithAccount("GET", "/?sort=count", nil, "", SystemTagListHandler, "/", 1)
+
+	var output SystemTagsResponse
+	CheckResponse(t, w, 200, &output)
+	if !assert.Equal(t, 4, len(output.Data)) {
+		return
+	}
+
+	assert.Equal(t, 1, output.Data[0].Count)
+	assert.Equal(t, "k3", output.Data[0].Tag.Key)
+	assert.Equal(t, "ns1", output.Data[0].Tag.Namespace)
+	assert.Equal(t, "val3", output.Data[0].Tag.Value)
+}
+
+func TestSystemTagsListBadRequestOnIdtSort(t *testing.T) {
+	core.SetupTest(t)
+
+	w := CreateRequestRouterWithAccount("GET", "/?sort=id", nil, "", SystemTagListHandler, "/", 1)
+	assert.Equal(t, 400, w.Code)
+}

--- a/manager/controllers/utils.go
+++ b/manager/controllers/utils.go
@@ -334,7 +334,7 @@ func (t *Tag) ApplyTag(tx *gorm.DB) *gorm.DB {
 	}
 
 	query := fmt.Sprintf(`[{%s "key": "%s" %s}]`, ns, t.Key, v)
-	return tx.Where("h.tags @> ?::jsonb", query)
+	return tx.Where("ih.tags @> ?::jsonb", query)
 }
 
 func ParseTagsFilters(c *gin.Context) (map[string]FilterData, error) {
@@ -427,8 +427,8 @@ func ApplyTagsFilter(filters map[string]FilterData, tx *gorm.DB, systemIDExpr st
 	}
 
 	subq := database.Db.
-		Table("inventory.hosts h").
-		Select("h.id")
+		Table("inventory.hosts ih").
+		Select("ih.id")
 
 	for key, val := range filters {
 		if strings.Contains(key, "/") {
@@ -468,7 +468,7 @@ func ApplyTagsFilter(filters map[string]FilterData, tx *gorm.DB, systemIDExpr st
 // Builds system_profile sub query in generic way.
 // Example:
 // buildQuery("mssql->version", "1.0")
-// returns "(h.system_profile -> 'mssql' ->> 'version')::text = 1.0"
+// returns "(ih.system_profile -> 'mssql' ->> 'version')::text = 1.0"
 func buildQuery(key string, val string) string {
 	var cmp string
 
@@ -483,7 +483,7 @@ func buildQuery(key string, val string) string {
 		cmp = " is not null"
 	}
 
-	subq := "(h.system_profile"
+	subq := "(ih.system_profile"
 	sbkeys := strings.Split(key, "->")
 	for i, sbkey := range sbkeys {
 		sbkey = fmt.Sprintf("'%s'", sbkey)

--- a/manager/routes/routes.go
+++ b/manager/routes/routes.go
@@ -46,6 +46,8 @@ func InitAPI(api *gin.RouterGroup, config docs.EndpointsConfig) { // nolint: fun
 	systems.GET("/:inventory_id/packages", controllers.SystemPackagesHandler)
 	systems.DELETE("/:inventory_id", controllers.SystemDeleteHandler)
 
+	api.GET("/tags", controllers.SystemTagListHandler)
+
 	packages := api.Group("/packages")
 	packages.GET("/", controllers.PackagesListHandler)
 	packages.GET("/:package_name/systems", controllers.PackageSystemsListHandler)


### PR DESCRIPTION
Introduces `/tags` which returns tags with host counts effective for this service.

Along the way it refactors following:
* moves `SystemTag` type
* use of common `ih` alias for `inventory.hosts` table within tags filter
* filter tags where clause split

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
