### PR TITLE
return 500 when app panics

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -39,6 +39,7 @@ func RunManager() {
 	app := gin.New()
 
 	// middlewares
+	app.Use(gin.Recovery())
 	middlewares.Prometheus().Use(app)
 	app.Use(middlewares.RequestResponseLogger())
 	app.Use(gzip.Gzip(gzip.DefaultCompression))


### PR DESCRIPTION
we need to return 500 when app panics, currently, the app will not respond to api call in case of panic
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
