### PR TITLE
SPM-1921: fix tags 500 by trimming quotes

### DIFF
--- a/manager/controllers/utils.go
+++ b/manager/controllers/utils.go
@@ -295,8 +295,19 @@ func HasTags(c *gin.Context) bool {
 	return hasTags
 }
 
+func trimQuotes(s string) string {
+	if len(s) >= 2 && s[0] == s[len(s)-1] && (s[0] == '"' || s[0] == '\'') {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
 func ParseTag(tag string) (*Tag, error) {
-	matches := tagRegex.FindStringSubmatch(tag)
+	// trim leading and trailing quote, otherwise we can end up with
+	// e.g. namespace='"insights-client", key="key", val="val'"
+	// when query is tags='insights-client/key=val' which is invalid
+	trimmed := trimQuotes(tag)
+	matches := tagRegex.FindStringSubmatch(trimmed)
 	if len(matches) < 5 {
 		// We received an invalid tag
 		err := errors.Errorf(InvalidTagMsg, tag)


### PR DESCRIPTION
example of another query which caused 500 on tags filter
```sh
# tags='insights-client/demo="{{slug}}"'
tags=%27insights-client%2Fdemo%3D%22%7B%7Bslug%7D%7D%22%27
```
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
