### PR TITLE
SPM-1955, SPM-1831 - fix sorting

### DIFF
--- a/database_admin/migrations/106_alphanumeric_collation.down.sql
+++ b/database_admin/migrations/106_alphanumeric_collation.down.sql
@@ -1,0 +1,1 @@
+DROP COLLATION "numeric";

--- a/database_admin/migrations/106_alphanumeric_collation.up.sql
+++ b/database_admin/migrations/106_alphanumeric_collation.up.sql
@@ -1,0 +1,1 @@
+CREATE COLLATION IF NOT EXISTS numeric (provider = icu, locale = 'en-u-kn-true');

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,13 +7,15 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (105, false);
+VALUES (106, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
 -- ---------------------------------------------------------------------------
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE COLLATION IF NOT EXISTS numeric (provider = icu, locale = 'en-u-kn-true');
 
 -- empty
 CREATE OR REPLACE FUNCTION empty(t TEXT)

--- a/manager/controllers/common_attributes.go
+++ b/manager/controllers/common_attributes.go
@@ -15,7 +15,7 @@ type MetaTotalHelper struct {
 }
 
 type OSAttributes struct {
-	OS   string `json:"os" csv:"os" query:"ih.system_profile->'operating_system'->>'name' || ' ' || coalesce(ih.system_profile->'operating_system'->>'major' || '.' || (ih.system_profile->'operating_system'->>'minor'), '')" order_query:"ih.system_profile->'operating_system'->>'name',cast(substring(ih.system_profile->'operating_system'->>'major','^\\d+') as int),cast(substring(ih.system_profile->'operating_system'->>'minor','^\\d+') as int)" gorm:"column:os"`
+	OS   string `json:"os" csv:"os" query:"ih.system_profile->'operating_system'->>'name' || ' ' || coalesce(ih.system_profile->'operating_system'->>'major' || '.' || (ih.system_profile->'operating_system'->>'minor'), '')" order_query:"ih.system_profile->'operating_system'->>'name' || ' ' || coalesce(ih.system_profile->'operating_system'->>'major' || '.' || (ih.system_profile->'operating_system'->>'minor'), '') collate numeric" gorm:"column:os"`
 	Rhsm string `json:"rhsm" csv:"rhsm" query:"ih.system_profile->'rhsm'->>'version'" gorm:"column:rhsm"`
 }
 

--- a/manager/controllers/systems_test.go
+++ b/manager/controllers/systems_test.go
@@ -210,13 +210,13 @@ func TestSystemsFilterInvalidSyntax(t *testing.T) {
 func TestSystemsOrderOS(t *testing.T) {
 	output := testSystems(t, `/?sort=os`, 1)
 	assert.Equal(t, "RHEL 7.3", output.Data[0].Attributes.OS)
-	assert.Equal(t, "RHEL 8.x", output.Data[1].Attributes.OS) // yes, we should be robust against this
+	assert.Equal(t, "RHEL 8.1", output.Data[1].Attributes.OS)
 	assert.Equal(t, "RHEL 8.1", output.Data[2].Attributes.OS)
-	assert.Equal(t, "RHEL 8.1", output.Data[3].Attributes.OS)
-	assert.Equal(t, "RHEL 8.2", output.Data[4].Attributes.OS)
+	assert.Equal(t, "RHEL 8.2", output.Data[3].Attributes.OS)
+	assert.Equal(t, "RHEL 8.3", output.Data[4].Attributes.OS)
 	assert.Equal(t, "RHEL 8.3", output.Data[5].Attributes.OS)
-	assert.Equal(t, "RHEL 8.3", output.Data[6].Attributes.OS)
-	assert.Equal(t, "RHEL 8.10", output.Data[7].Attributes.OS)
+	assert.Equal(t, "RHEL 8.10", output.Data[6].Attributes.OS)
+	assert.Equal(t, "RHEL 8.x", output.Data[7].Attributes.OS) // yes, we should be robust against this
 }
 
 func testSystems(t *testing.T, url string, account int) SystemsResponse {

--- a/manager/controllers/utils.go
+++ b/manager/controllers/utils.go
@@ -81,7 +81,7 @@ func ApplySort(c *gin.Context, tx *gorm.DB, fieldExprs database.AttrMap,
 		if strings.HasPrefix(enteredField, "-") && allowedFieldSet[enteredField[1:]] { //nolint:gocritic
 			tx = tx.Order(fmt.Sprintf("%s DESC NULLS LAST", fieldExprs[enteredField[1:]].OrderQuery))
 		} else if allowedFieldSet[enteredField] {
-			tx = tx.Order(fmt.Sprintf("%s ASC NULLS FIRST", fieldExprs[enteredField].OrderQuery))
+			tx = tx.Order(fmt.Sprintf("%s ASC NULLS LAST", fieldExprs[enteredField].OrderQuery))
 		} else {
 			// We have not found any matches in allowed fields, return an error
 			return nil, nil, errors.Errorf("Invalid sort field: %v", enteredField)


### PR DESCRIPTION
- use collation to use natural sort for alphanumerical strings (OS) - see commit message
- make nulls last when sorting, based on SPM-1831 it is the common way of sorting by all apps
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
