### PR TITLE
SPM-1986: installable should be subset of applicable

### DIFF
--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -51,7 +51,7 @@ func CheckCachesValidRet() (bool, error) {
 
 	err = tx.Select("sp.rh_account_id, sa.advisory_id," +
 		"count(*) filter (where sa.status_id = 0) as systems_installable," +
-		"count(*) filter (where sa.status_id = 1) as systems_applicable").
+		"count(*) as systems_applicable").
 		Table("system_advisories sa").
 		Joins("JOIN system_platform sp ON sa.rh_account_id = sp.rh_account_id AND sa.system_id = sp.id").
 		Where("sp.stale = false AND sp.last_evaluation IS NOT NULL").
@@ -213,7 +213,9 @@ func CreateAdvisoryAccountData(t *testing.T, rhAccountID int, advisoryIDs []int6
 	systemsInstallable int) {
 	for _, advisoryID := range advisoryIDs {
 		err := Db.Create(&models.AdvisoryAccountData{
-			AdvisoryID: advisoryID, RhAccountID: rhAccountID, SystemsInstallable: systemsInstallable}).Error
+			AdvisoryID: advisoryID, RhAccountID: rhAccountID, SystemsInstallable: systemsInstallable,
+			// create same number of applicable and installable systems because installable is subset of applicable
+			SystemsApplicable: systemsInstallable}).Error
 		assert.Nil(t, err)
 	}
 	CheckAdvisoriesAccountData(t, rhAccountID, advisoryIDs, systemsInstallable)

--- a/database_admin/migrations/107_applicable_advisories.down.sql
+++ b/database_admin/migrations/107_applicable_advisories.down.sql
@@ -1,0 +1,167 @@
+CREATE OR REPLACE FUNCTION on_system_update()
+-- this trigger updates advisory_account_data when server changes its stale flag
+    RETURNS TRIGGER
+AS
+$system_update$
+DECLARE
+    was_counted  BOOLEAN;
+    should_count BOOLEAN;
+    change       INT;
+BEGIN
+    -- Ignore not yet evaluated systems
+    IF TG_OP != 'UPDATE' OR NEW.last_evaluation IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    was_counted := OLD.stale = FALSE;
+    should_count := NEW.stale = FALSE;
+
+    -- Determine what change we are performing
+    IF was_counted and NOT should_count THEN
+        change := -1;
+    ELSIF NOT was_counted AND should_count THEN
+        change := 1;
+    ELSE
+        -- No change
+        RETURN NEW;
+    END IF;
+
+    -- find advisories linked to the server and lock them
+    WITH to_update_advisories AS (
+        SELECT aad.advisory_id,
+               aad.rh_account_id,
+               -- Desired count depends on old count + change
+               aad.systems_installable + case when sa.status_id = 0 then change else 0 end as systems_installable_dst,
+               aad.systems_applicable + case when sa.status_id = 1 then change else 0 end as systems_applicable_dst
+          FROM advisory_account_data aad
+          JOIN system_advisories sa ON aad.advisory_id = sa.advisory_id
+          -- Filter advisory_account_data only for advisories affectign this system & belonging to system account
+         WHERE aad.rh_account_id =  NEW.rh_account_id
+           AND sa.system_id = NEW.id AND sa.rh_account_id = NEW.rh_account_id
+         ORDER BY aad.advisory_id FOR UPDATE OF aad),
+         -- Where count > 0, update existing rows
+         update AS (
+            UPDATE advisory_account_data aad
+               SET systems_installable = ta.systems_installable_dst,
+                   systems_applicable = ta.systems_applicable_dst
+              FROM to_update_advisories ta
+             WHERE aad.advisory_id = ta.advisory_id
+               AND aad.rh_account_id = NEW.rh_account_id
+               AND (ta.systems_installable_dst > 0 OR ta.systems_applicable_dst > 0)
+         ),
+         -- Where count = 0, delete existing rows
+         delete AS (
+            DELETE
+              FROM advisory_account_data aad
+             USING to_update_advisories ta
+             WHERE aad.rh_account_id = ta.rh_account_id
+               AND aad.advisory_id = ta.advisory_id
+               AND ta.systems_installable_dst <= 0
+               AND ta.systems_applicable_dst <= 0
+         )
+    -- If we have system affected && no exisiting advisory_account_data entry, we insert new rows
+    INSERT
+      INTO advisory_account_data (advisory_id, rh_account_id, systems_installable, systems_applicable)
+    SELECT sa.advisory_id, NEW.rh_account_id,
+           case when sa.status_id = 0 then 1 else 0 end as systems_installable,
+           case when sa.status_id = 1 then 1 else 0 end as systems_applicable
+    FROM system_advisories sa
+    WHERE sa.system_id = NEW.id AND sa.rh_account_id = NEW.rh_account_id
+      AND change > 0
+      -- create only rows which are not already in to_update_advisories
+      AND (NEW.rh_account_id, sa.advisory_id) NOT IN (
+            SELECT ta.rh_account_id, ta.advisory_id
+              FROM to_update_advisories ta
+    )
+    ON CONFLICT (advisory_id, rh_account_id) DO UPDATE
+        SET systems_installable = advisory_account_data.systems_installable + EXCLUDED.systems_installable,
+            systems_applicable = advisory_account_data.systems_applicable + EXCLUDED.systems_applicable;
+    RETURN NEW;
+END;
+$system_update$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION refresh_advisory_caches_multi(advisory_ids_in INTEGER[] DEFAULT NULL,
+                                                         rh_account_id_in INTEGER DEFAULT NULL)
+    RETURNS VOID AS
+$refresh_advisory$
+BEGIN
+    -- Lock rows
+    PERFORM aad.rh_account_id, aad.advisory_id
+    FROM advisory_account_data aad
+    WHERE (aad.advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+      AND (aad.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL)
+        FOR UPDATE OF aad;
+
+    WITH current_counts AS (
+        SELECT sa.advisory_id, sa.rh_account_id,
+               count(sa.*) filter (where sa.status_id = 0) as systems_installable,
+               count(sa.*) filter (where sa.status_id = 1) as systems_applicable
+          FROM system_advisories sa
+          JOIN system_platform sp
+            ON sa.rh_account_id = sp.rh_account_id AND sa.system_id = sp.id
+         WHERE sp.last_evaluation IS NOT NULL
+           AND sp.stale = FALSE
+           AND (sa.advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+           AND (sp.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL)
+         GROUP BY sa.advisory_id, sa.rh_account_id
+    ),
+        upserted AS (
+            INSERT INTO advisory_account_data (advisory_id, rh_account_id, systems_installable, systems_applicable)
+                 SELECT advisory_id, rh_account_id, systems_installable, systems_applicable
+                   FROM current_counts
+            ON CONFLICT (advisory_id, rh_account_id) DO UPDATE SET
+                     systems_installable = EXCLUDED.systems_installable,
+                     systems_applicable = EXCLUDED.systems_applicable
+         )
+    DELETE FROM advisory_account_data
+     WHERE (advisory_id, rh_account_id) NOT IN (SELECT advisory_id, rh_account_id FROM current_counts)
+       AND (advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+       AND (rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL);
+END;
+$refresh_advisory$ language plpgsql;
+
+CREATE OR REPLACE FUNCTION refresh_system_caches(system_id_in BIGINT DEFAULT NULL,
+                                                 rh_account_id_in INTEGER DEFAULT NULL)
+    RETURNS INTEGER AS
+$refresh_system$
+DECLARE
+    COUNT INTEGER;
+BEGIN
+    WITH system_advisories_count AS (
+        SELECT asp.rh_account_id, asp.id,
+               COUNT(advisory_id) FILTER (WHERE sa.status_id = 0) as installable_total,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 1 AND sa.status_id = 0) AS installable_enhancement,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 2 AND sa.status_id = 0) AS installable_bugfix,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 3 AND sa.status_id = 0) as installable_security,
+               COUNT(advisory_id) FILTER (WHERE sa.status_id = 1) as applicable_total,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 1 AND sa.status_id = 1) AS applicable_enhancement,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 2 AND sa.status_id = 1) AS applicable_bugfix,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 3 AND sa.status_id = 1) as applicable_security
+          FROM system_platform asp  -- this table ensures even systems without any system_advisories are in results
+          LEFT JOIN system_advisories sa
+            ON asp.rh_account_id = sa.rh_account_id AND asp.id = sa.system_id
+          LEFT JOIN advisory_metadata am
+            ON sa.advisory_id = am.id
+         WHERE (asp.id = system_id_in OR system_id_in IS NULL)
+           AND (asp.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL)
+         GROUP BY asp.rh_account_id, asp.id
+         ORDER BY asp.rh_account_id, asp.id
+    )
+        UPDATE system_platform sp
+           SET installable_advisory_count_cache = sc.installable_total,
+               installable_advisory_enh_count_cache = sc.installable_enhancement,
+               installable_advisory_bug_count_cache = sc.installable_bugfix,
+               installable_advisory_sec_count_cache = sc.installable_security,
+               applicable_advisory_count_cache = sc.applicable_total,
+               applicable_advisory_enh_count_cache = sc.applicable_enhancement,
+               applicable_advisory_bug_count_cache = sc.applicable_bugfix,
+               applicable_advisory_sec_count_cache = sc.applicable_security
+          FROM system_advisories_count sc
+         WHERE sp.rh_account_id = sc.rh_account_id AND sp.id = sc.id
+           AND (sp.id = system_id_in OR system_id_in IS NULL)
+           AND (sp.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL);
+
+    GET DIAGNOSTICS COUNT = ROW_COUNT;
+    RETURN COUNT;
+END;
+$refresh_system$ LANGUAGE plpgsql;

--- a/database_admin/migrations/107_applicable_advisories.up.sql
+++ b/database_admin/migrations/107_applicable_advisories.up.sql
@@ -1,0 +1,167 @@
+CREATE OR REPLACE FUNCTION on_system_update()
+-- this trigger updates advisory_account_data when server changes its stale flag
+    RETURNS TRIGGER
+AS
+$system_update$
+DECLARE
+    was_counted  BOOLEAN;
+    should_count BOOLEAN;
+    change       INT;
+BEGIN
+    -- Ignore not yet evaluated systems
+    IF TG_OP != 'UPDATE' OR NEW.last_evaluation IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    was_counted := OLD.stale = FALSE;
+    should_count := NEW.stale = FALSE;
+
+    -- Determine what change we are performing
+    IF was_counted and NOT should_count THEN
+        change := -1;
+    ELSIF NOT was_counted AND should_count THEN
+        change := 1;
+    ELSE
+        -- No change
+        RETURN NEW;
+    END IF;
+
+    -- find advisories linked to the server and lock them
+    WITH to_update_advisories AS (
+        SELECT aad.advisory_id,
+               aad.rh_account_id,
+               -- Desired count depends on old count + change
+               aad.systems_installable + case when sa.status_id = 0 then change else 0 end as systems_installable_dst,
+               aad.systems_applicable + change as systems_applicable_dst
+          FROM advisory_account_data aad
+          JOIN system_advisories sa ON aad.advisory_id = sa.advisory_id
+          -- Filter advisory_account_data only for advisories affectign this system & belonging to system account
+         WHERE aad.rh_account_id =  NEW.rh_account_id
+           AND sa.system_id = NEW.id AND sa.rh_account_id = NEW.rh_account_id
+         ORDER BY aad.advisory_id FOR UPDATE OF aad),
+         -- Where count > 0, update existing rows
+         update AS (
+            UPDATE advisory_account_data aad
+               SET systems_installable = ta.systems_installable_dst,
+                   systems_applicable = ta.systems_applicable_dst
+              FROM to_update_advisories ta
+             WHERE aad.advisory_id = ta.advisory_id
+               AND aad.rh_account_id = NEW.rh_account_id
+               AND (ta.systems_installable_dst > 0 OR ta.systems_applicable_dst > 0)
+         ),
+         -- Where count = 0, delete existing rows
+         delete AS (
+            DELETE
+              FROM advisory_account_data aad
+             USING to_update_advisories ta
+             WHERE aad.rh_account_id = ta.rh_account_id
+               AND aad.advisory_id = ta.advisory_id
+               AND ta.systems_installable_dst <= 0
+               AND ta.systems_applicable_dst <= 0
+         )
+    -- If we have system affected && no exisiting advisory_account_data entry, we insert new rows
+    INSERT
+      INTO advisory_account_data (advisory_id, rh_account_id, systems_installable, systems_applicable)
+    SELECT sa.advisory_id, NEW.rh_account_id,
+           case when sa.status_id = 0 then 1 else 0 end as systems_installable,
+           1 as systems_applicable
+    FROM system_advisories sa
+    WHERE sa.system_id = NEW.id AND sa.rh_account_id = NEW.rh_account_id
+      AND change > 0
+      -- create only rows which are not already in to_update_advisories
+      AND (NEW.rh_account_id, sa.advisory_id) NOT IN (
+            SELECT ta.rh_account_id, ta.advisory_id
+              FROM to_update_advisories ta
+    )
+    ON CONFLICT (advisory_id, rh_account_id) DO UPDATE
+        SET systems_installable = advisory_account_data.systems_installable + EXCLUDED.systems_installable,
+            systems_applicable = advisory_account_data.systems_applicable + EXCLUDED.systems_applicable;
+    RETURN NEW;
+END;
+$system_update$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION refresh_advisory_caches_multi(advisory_ids_in INTEGER[] DEFAULT NULL,
+                                                         rh_account_id_in INTEGER DEFAULT NULL)
+    RETURNS VOID AS
+$refresh_advisory$
+BEGIN
+    -- Lock rows
+    PERFORM aad.rh_account_id, aad.advisory_id
+    FROM advisory_account_data aad
+    WHERE (aad.advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+      AND (aad.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL)
+        FOR UPDATE OF aad;
+
+    WITH current_counts AS (
+        SELECT sa.advisory_id, sa.rh_account_id,
+               count(sa.*) filter (where sa.status_id = 0) as systems_installable,
+               count(sa.*) as systems_applicable
+          FROM system_advisories sa
+          JOIN system_platform sp
+            ON sa.rh_account_id = sp.rh_account_id AND sa.system_id = sp.id
+         WHERE sp.last_evaluation IS NOT NULL
+           AND sp.stale = FALSE
+           AND (sa.advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+           AND (sp.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL)
+         GROUP BY sa.advisory_id, sa.rh_account_id
+    ),
+        upserted AS (
+            INSERT INTO advisory_account_data (advisory_id, rh_account_id, systems_installable, systems_applicable)
+                 SELECT advisory_id, rh_account_id, systems_installable, systems_applicable
+                   FROM current_counts
+            ON CONFLICT (advisory_id, rh_account_id) DO UPDATE SET
+                     systems_installable = EXCLUDED.systems_installable,
+                     systems_applicable = EXCLUDED.systems_applicable
+         )
+    DELETE FROM advisory_account_data
+     WHERE (advisory_id, rh_account_id) NOT IN (SELECT advisory_id, rh_account_id FROM current_counts)
+       AND (advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+       AND (rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL);
+END;
+$refresh_advisory$ language plpgsql;
+
+CREATE OR REPLACE FUNCTION refresh_system_caches(system_id_in BIGINT DEFAULT NULL,
+                                                 rh_account_id_in INTEGER DEFAULT NULL)
+    RETURNS INTEGER AS
+$refresh_system$
+DECLARE
+    COUNT INTEGER;
+BEGIN
+    WITH system_advisories_count AS (
+        SELECT asp.rh_account_id, asp.id,
+               COUNT(advisory_id) FILTER (WHERE sa.status_id = 0) as installable_total,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 1 AND sa.status_id = 0) AS installable_enhancement,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 2 AND sa.status_id = 0) AS installable_bugfix,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 3 AND sa.status_id = 0) as installable_security,
+               COUNT(advisory_id) as applicable_total,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 1) AS applicable_enhancement,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 2) AS applicable_bugfix,
+               COUNT(advisory_id) FILTER (WHERE am.advisory_type_id = 3) as applicable_security
+          FROM system_platform asp  -- this table ensures even systems without any system_advisories are in results
+          LEFT JOIN system_advisories sa
+            ON asp.rh_account_id = sa.rh_account_id AND asp.id = sa.system_id
+          LEFT JOIN advisory_metadata am
+            ON sa.advisory_id = am.id
+         WHERE (asp.id = system_id_in OR system_id_in IS NULL)
+           AND (asp.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL)
+         GROUP BY asp.rh_account_id, asp.id
+         ORDER BY asp.rh_account_id, asp.id
+    )
+        UPDATE system_platform sp
+           SET installable_advisory_count_cache = sc.installable_total,
+               installable_advisory_enh_count_cache = sc.installable_enhancement,
+               installable_advisory_bug_count_cache = sc.installable_bugfix,
+               installable_advisory_sec_count_cache = sc.installable_security,
+               applicable_advisory_count_cache = sc.applicable_total,
+               applicable_advisory_enh_count_cache = sc.applicable_enhancement,
+               applicable_advisory_bug_count_cache = sc.applicable_bugfix,
+               applicable_advisory_sec_count_cache = sc.applicable_security
+          FROM system_advisories_count sc
+         WHERE sp.rh_account_id = sc.rh_account_id AND sp.id = sc.id
+           AND (sp.id = system_id_in OR system_id_in IS NULL)
+           AND (sp.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL);
+
+    GET DIAGNOSTICS COUNT = ROW_COUNT;
+    RETURN COUNT;
+END;
+$refresh_system$ LANGUAGE plpgsql;

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -440,8 +440,7 @@ func updateSystemPlatform(tx *gorm.DB, system *models.SystemPlatform,
 		applicableBugCount := 0
 		applicableSecCount := 0
 		for _, sa := range new {
-			switch sa.StatusID {
-			case INSTALLABLE:
+			if sa.StatusID == INSTALLABLE {
 				switch sa.Advisory.AdvisoryTypeID {
 				case 1:
 					installableEnhCount++
@@ -451,17 +450,16 @@ func updateSystemPlatform(tx *gorm.DB, system *models.SystemPlatform,
 					installableSecCount++
 				}
 				installableCount++
-			case APPLICABLE:
-				switch sa.Advisory.AdvisoryTypeID {
-				case 1:
-					applicableEnhCount++
-				case 2:
-					applicableBugCount++
-				case 3:
-					applicableSecCount++
-				}
-				applicableCount++
 			}
+			switch sa.Advisory.AdvisoryTypeID {
+			case 1:
+				applicableEnhCount++
+			case 2:
+				applicableBugCount++
+			case 3:
+				applicableSecCount++
+			}
+			applicableCount++
 		}
 
 		data["installable_advisory_count_cache"] = installableCount

--- a/manager/controllers/advisories.go
+++ b/manager/controllers/advisories.go
@@ -262,7 +262,7 @@ func buildAdvisoryAccountDataQuery(db *gorm.DB, account int) *gorm.DB {
 	query := database.SystemAdvisories(db, account).
 		Select(`sa.advisory_id, sp.rh_account_id as rh_account_id,
 		        count(sp.*) filter (where sa.status_id = 0) as systems_installable,
-		        count(sp.*) filter (where sa.status_id = 1) as systems_applicable`).
+		        count(sp.*) as systems_applicable`).
 		Where("sp.stale = false").
 		Group("sp.rh_account_id, sa.advisory_id")
 

--- a/manager/controllers/advisories_export_test.go
+++ b/manager/controllers/advisories_export_test.go
@@ -27,7 +27,7 @@ func TestAdvisoriesExportJSON(t *testing.T) {
 	assert.Equal(t, output[2].RebootRequired, false)
 	assert.Equal(t, output[2].ReleaseVersions, RelList{"7.0", "7Server"})
 	assert.Equal(t, output[2].InstallableSystems, 4)
-	assert.Equal(t, output[2].ApplicableSystems, 2)
+	assert.Equal(t, output[2].ApplicableSystems, 2+output[2].InstallableSystems)
 }
 
 func TestAdvisoriesExportCSV(t *testing.T) {
@@ -39,7 +39,7 @@ func TestAdvisoriesExportCSV(t *testing.T) {
 	lines := strings.Split(body, "\n")
 
 	assert.Equal(t, 14, len(lines))
-	assert.Equal(t, "RH-1,adv-1-des,2016-09-22T16:00:00Z,adv-1-syn,enhancement,,0,false,\"7.0,7Server\",4,2", lines[3])
+	assert.Equal(t, "RH-1,adv-1-des,2016-09-22T16:00:00Z,adv-1-syn,enhancement,,0,false,\"7.0,7Server\",4,6", lines[3])
 }
 
 func TestAdvisoriesExportWrongFormat(t *testing.T) {
@@ -61,7 +61,7 @@ func TestAdvisoriesExportCSVFilter(t *testing.T) {
 	lines := strings.Split(body, "\n")
 
 	assert.Equal(t, 3, len(lines))
-	assert.Equal(t, "RH-1,adv-1-des,2016-09-22T16:00:00Z,adv-1-syn,enhancement,,0,false,\"7.0,7Server\",4,2", lines[1])
+	assert.Equal(t, "RH-1,adv-1-des,2016-09-22T16:00:00Z,adv-1-syn,enhancement,,0,false,\"7.0,7Server\",4,6", lines[1])
 	assert.Equal(t, "", lines[2])
 }
 

--- a/manager/controllers/advisories_test.go
+++ b/manager/controllers/advisories_test.go
@@ -43,7 +43,7 @@ func TestAdvisoriesDefault(t *testing.T) {
 	assert.Equal(t, "adv-8-des", output.Data[3].Attributes.Description)
 	assert.Equal(t, "adv-8-syn", output.Data[3].Attributes.Synopsis)
 	assert.Equal(t, 1, output.Data[3].Attributes.InstallableSystems)
-	assert.Equal(t, 0, output.Data[3].Attributes.ApplicableSystems)
+	assert.Equal(t, 1, output.Data[3].Attributes.ApplicableSystems)
 	assert.Equal(t, false, output.Data[3].Attributes.RebootRequired)
 
 	// links
@@ -111,7 +111,7 @@ func TestAdvisoriesOrderDate(t *testing.T) {
 	assert.Equal(t, "adv-8-des", output.Data[3].Attributes.Description)
 	assert.Equal(t, "adv-8-syn", output.Data[3].Attributes.Synopsis)
 	assert.Equal(t, 1, output.Data[3].Attributes.InstallableSystems)
-	assert.Equal(t, 0, output.Data[3].Attributes.ApplicableSystems)
+	assert.Equal(t, 1, output.Data[3].Attributes.ApplicableSystems)
 }
 
 func TestAdvisoriesIDsOrderDate(t *testing.T) {
@@ -143,7 +143,7 @@ func TestAdvisoriesPatchedMissing(t *testing.T) {
 	assert.Equal(t, 12, len(output.Data))
 	assert.Equal(t, "RH-1", output.Data[2].ID)
 	assert.Equal(t, 4, output.Data[2].Attributes.InstallableSystems)
-	assert.Equal(t, 2, output.Data[2].Attributes.ApplicableSystems)
+	assert.Equal(t, 6, output.Data[2].Attributes.ApplicableSystems)
 }
 
 func TestAdvisoriesFilterTypeID1(t *testing.T) {
@@ -247,7 +247,7 @@ func TestAdvisoriesSearch(t *testing.T) {
 	assert.Equal(t, "adv-3-des", output.Data[0].Attributes.Description)
 	assert.Equal(t, "adv-3-syn", output.Data[0].Attributes.Synopsis)
 	assert.Equal(t, 1, output.Data[0].Attributes.InstallableSystems)
-	assert.Equal(t, 0, output.Data[0].Attributes.ApplicableSystems)
+	assert.Equal(t, 1, output.Data[0].Attributes.ApplicableSystems)
 
 	// links
 	assert.Equal(t, "/?offset=0&limit=20&sort=-public_date&search=h-3",
@@ -279,7 +279,7 @@ func TestAdvisoriesTags(t *testing.T) {
 	output := testAdvisories(t, "/?sort=id&tags=ns1/k2=val2")
 	assert.Equal(t, 8, len(output.Data))
 	assert.Equal(t, 1, output.Data[0].Attributes.InstallableSystems)
-	assert.Equal(t, 1, output.Data[0].Attributes.ApplicableSystems)
+	assert.Equal(t, 2, output.Data[0].Attributes.ApplicableSystems)
 	assert.Equal(t, "/?offset=0&limit=20&sort=id&tags=ns1/k2=val2", output.Links.First)
 }
 


### PR DESCRIPTION
- applicable advisory is any advisory which can be applied to a system
- installable advisory is an applicable advisory which can be installed on a system based on the current template `to_date` 
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
