### PR TITLE
SPM-2013: run advisory_refresh for individual accounts in 4 goroutines

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -434,6 +434,7 @@ objects:
         - {name: DB_PASSWD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
                                                       key: vmaas-sync-database-password}}}
         - {name: ENABLE_REFRESH_ADVISORY_CACHES, value: '${ENABLE_REFRESH_ADVISORY_CACHES}'}
+        - {name: SKIP_N_ACCOUNTS_REFRESH, value: '${SKIP_N_ACCOUNTS_REFRESH}'}
 
     - name: delete-unused
       activeDeadlineSeconds: ${{JOBS_TIMEOUT}}
@@ -672,6 +673,7 @@ parameters:
 - {name: ADVISORY_REFRESH_SCHEDULE, value: '*/15 * * * *'} # Cronjob schedule definition
 - {name: ADVISORY_REFRESH_SUSPEND, value: 'false'} # Disable cronjob execution
 - {name: ENABLE_REFRESH_ADVISORY_CACHES, value: 'true'} # Enable periodic refresh of account advisory caches
+- {name: SKIP_N_ACCOUNTS_REFRESH, value: '0'} # Skip advisory cache refresh for N first accounts in case the previous refresh didn't finish
 
 # Database admin
 - {name: GOMAXPROCS_ADMIN, value: '8'}

--- a/tasks/caches/caches.go
+++ b/tasks/caches/caches.go
@@ -8,11 +8,13 @@ import (
 
 var (
 	enableRefreshAdvisoryCaches bool
+	skipNAccountsRefresh        int
 )
 
 func configure() {
 	core.ConfigureApp()
 	enableRefreshAdvisoryCaches = utils.GetBoolEnvOrDefault("ENABLE_REFRESH_ADVISORY_CACHES", false)
+	skipNAccountsRefresh = utils.GetIntEnvOrDefault("SKIP_N_ACCOUNTS_REFRESH", 0)
 }
 
 func RunAdvisoryRefresh() {

--- a/tasks/caches/refresh_advisory_caches.go
+++ b/tasks/caches/refresh_advisory_caches.go
@@ -1,8 +1,10 @@
 package caches
 
 import (
+	"app/base/database"
 	"app/base/utils"
 	"app/tasks"
+	"sync"
 
 	"gorm.io/gorm"
 )
@@ -11,16 +13,47 @@ func RefreshAdvisoryCaches() {
 	if !enableRefreshAdvisoryCaches {
 		return
 	}
-	refreshAdvisoryCachesPerAccounts()
+
+	var wg sync.WaitGroup
+	refreshAdvisoryCachesPerAccounts(&wg)
+	wg.Wait()
 }
 
-func refreshAdvisoryCachesPerAccounts() {
-	err := tasks.WithTx(func(tx *gorm.DB) error {
-		return tx.Exec("select refresh_advisory_caches(NULL, NULL)").Error
-	})
+func refreshAdvisoryCachesPerAccounts(wg *sync.WaitGroup) {
+	var rhAccountIDs []int
+	err := database.Db.Table("rh_account").Order("id").Pluck("id", &rhAccountIDs).Error
+	if skipNAccountsRefresh > 0 {
+		utils.LogInfo("n", skipNAccountsRefresh, "Skipping refresh of first N accounts")
+		rhAccountIDs = rhAccountIDs[skipNAccountsRefresh:]
+	}
+	utils.LogInfo("accounts", len(rhAccountIDs), "Starting advisory cache refresh for accounts")
 	if err != nil {
-		utils.LogError("err", err.Error(), "Refreshed account advisory caches")
-	} else {
-		utils.LogInfo("Refreshed account advisory caches")
+		utils.LogError("err", err.Error(), "Unable to load rh_account table ids to refresh caches")
+		return
+	}
+
+	// use max 4 goroutines for cache refresh
+	guard := make(chan struct{}, 4)
+
+	for i, rhAccountID := range rhAccountIDs {
+		guard <- struct{}{}
+		wg.Add(1)
+		go func(i, rhAccountID int) {
+			defer func() {
+				<-guard
+				wg.Done()
+			}()
+
+			err = tasks.WithTx(func(tx *gorm.DB) error {
+				utils.LogInfo("i", i, "rh_account_id", rhAccountID, "Refreshing account advisory cache")
+				return tx.Exec("select refresh_advisory_caches(NULL, ?)", rhAccountID).Error
+			})
+			if err != nil {
+				utils.LogError("err", err.Error(), "rh_account_id", rhAccountID,
+					"Refreshed account advisory caches")
+				return
+			}
+			utils.LogInfo("i", i, "rh_account_id", rhAccountID, "Refreshed account advisory cache")
+		}(i, rhAccountID)
 	}
 }

--- a/tasks/caches/refresh_advisory_caches_test.go
+++ b/tasks/caches/refresh_advisory_caches_test.go
@@ -5,6 +5,7 @@ import (
 	"app/base/database"
 	"app/base/models"
 	"app/base/utils"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,7 +24,9 @@ func TestRefreshAdvisoryCachesPerAccounts(t *testing.T) {
 	assert.Nil(t, database.Db.Model(&models.AdvisoryAccountData{}).
 		Where("advisory_id = 3 AND rh_account_id = 1").Update("systems_installable", 8).Error)
 
-	refreshAdvisoryCachesPerAccounts()
+	var wg sync.WaitGroup
+	refreshAdvisoryCachesPerAccounts(&wg)
+	wg.Wait()
 
 	assert.Equal(t, 1, database.PluckInt(database.Db.Table("advisory_account_data").
 		Where("advisory_id = 1 AND rh_account_id = 2"), "systems_installable"))


### PR DESCRIPTION
- run refresh for single account at a time
- run in 4 goroutines so we don't need to wait for refresh of bigger accounts
- add `SKIP_N_ACCOUNTS_REFRESH` to skip accounts refresh if something goes wrong and we want to continue with refresh

previous solution didn't finish in prod even after 6 hours with evaluator, listener, and all other jobs disabled
this finished in 9 minutes with evaluator, listener and jobs disabled

it is already pushed to prod using hotfix branch
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
