### PR TITLE
store vmaas response value not pointer in cache

### DIFF
--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -267,9 +267,9 @@ func getUpdatesData(ctx context.Context, tx *gorm.DB, system *models.SystemPlatf
 func getVmaasUpdates(ctx context.Context, tx *gorm.DB,
 	system *models.SystemPlatform) (*vmaas.UpdatesV2Response, error) {
 	// first check if we have data in cache
-	vmaasData, ok := memoryVmaasCache.Get(system.JSONChecksum)
+	vmaasDataCache, ok := memoryVmaasCache.Get(system.JSONChecksum)
 	if ok {
-		return vmaasData, nil
+		return &vmaasDataCache, nil
 	}
 	updatesReq, err := tryGetVmaasRequest(system)
 	if err != nil {
@@ -289,13 +289,13 @@ func getVmaasUpdates(ctx context.Context, tx *gorm.DB,
 	useOptimisticUpdates := thirdParty || vmaasCallUseOptimisticUpdates
 	updatesReq.OptimisticUpdates = utils.PtrBool(useOptimisticUpdates)
 
-	vmaasData, err = callVMaas(ctx, updatesReq)
+	vmaasData, err := callVMaas(ctx, updatesReq)
 	if err != nil {
 		evaluationCnt.WithLabelValues("error-call-vmaas-updates").Inc()
 		return nil, errors.Wrap(err, "vmaas API call failed")
 	}
 
-	memoryVmaasCache.Add(system.JSONChecksum, vmaasData)
+	memoryVmaasCache.Add(system.JSONChecksum, *vmaasData)
 	return vmaasData, nil
 }
 

--- a/evaluator/vmaas_cache.go
+++ b/evaluator/vmaas_cache.go
@@ -17,7 +17,7 @@ type VmaasCache struct {
 	size          int
 	validity      *types.Rfc3339TimestampWithZ
 	checkDuration time.Duration
-	data          *lru.TwoQueueCache[string, *vmaas.UpdatesV2Response]
+	data          *lru.TwoQueueCache[string, vmaas.UpdatesV2Response]
 	currentSize   int
 }
 
@@ -33,7 +33,7 @@ func NewVmaasPackageCache(enabled bool, size int, checkDuration time.Duration) *
 
 	if c.enabled {
 		var err error
-		c.data, err = lru.New2Q[string, *vmaas.UpdatesV2Response](c.size)
+		c.data, err = lru.New2Q[string, vmaas.UpdatesV2Response](c.size)
 		if err != nil {
 			panic(err)
 		}
@@ -42,7 +42,7 @@ func NewVmaasPackageCache(enabled bool, size int, checkDuration time.Duration) *
 	return c
 }
 
-func (c *VmaasCache) Get(checksum *string) (*vmaas.UpdatesV2Response, bool) {
+func (c *VmaasCache) Get(checksum *string) (vmaas.UpdatesV2Response, bool) {
 	if c.enabled && checksum != nil {
 		val, ok := c.data.Get(*checksum)
 		if ok {
@@ -52,10 +52,10 @@ func (c *VmaasCache) Get(checksum *string) (*vmaas.UpdatesV2Response, bool) {
 		}
 	}
 	vmaasCacheCnt.WithLabelValues("miss").Inc()
-	return nil, false
+	return vmaas.UpdatesV2Response{}, false
 }
 
-func (c *VmaasCache) Add(checksum *string, response *vmaas.UpdatesV2Response) {
+func (c *VmaasCache) Add(checksum *string, response vmaas.UpdatesV2Response) {
 	if c.enabled && checksum != nil {
 		if c.currentSize < c.size {
 			c.currentSize++


### PR DESCRIPTION
It looks like that storing pointers is preventing GC from releasing memory

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
