### PR TITLE
fix(listener): use releasever in vmaas_req

### DIFF
--- a/base/inventory/inventory.go
+++ b/base/inventory/inventory.go
@@ -8,6 +8,7 @@ type SystemProfile struct {
 	DnfModules        *[]DnfModule    `json:"dnf_modules,omitempty"`
 	OperatingSystem   OperatingSystem `json:"operating_system,omitempty"`
 	Rhsm              Rhsm            `json:"rhsm,omitempty"`
+	Releasever        *string         `json:"releasever,omitempty"`
 }
 
 func (t *SystemProfile) GetInstalledPackages() []string {

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -555,6 +555,9 @@ func processUpload(host *Host, yumUpdates []byte) (*models.SystemPlatform, error
 
 	// use rhsm version if set
 	releasever := systemProfile.Rhsm.Version
+	if releasever == "" && systemProfile.Releasever != nil {
+		releasever = *systemProfile.Releasever
+	}
 	if len(releasever) > 0 {
 		updatesReq.SetReleasever(releasever)
 	}


### PR DESCRIPTION
Utilize relelasever from a system profile if RHSM version isn't set. This should improve reporting from RHUI systems.

SPM-2137

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
