### PR TITLE
RHINENG-1162: add missing read replica envs for package refresh job

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -681,7 +681,7 @@ parameters:
 - {name: ENABLE_CULLED_SYSTEM_DELETE, value: 'true'} # Enable deleting part of culling method
 - {name: ENABLE_SYSTEM_STALING, value: 'true'} # Enable marking systems stale of culling method
 # Cache refresh
-- {name: PKG_REFRESH_SCHEDULE, value: '5 11-22 * * *'} # Cronjob schedule definition
+- {name: PKG_REFRESH_SCHEDULE, value: '5 11-20/2 * * *'} # Cronjob schedule definition
 - {name: PKG_REFRESH_SUSPEND, value: 'false'} # Disable cronjob execution
 - {name: ADVISORY_REFRESH_SCHEDULE, value: '*/15 * * * *'} # Cronjob schedule definition
 - {name: ADVISORY_REFRESH_SUSPEND, value: 'false'} # Disable cronjob execution

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -411,6 +411,11 @@ objects:
         - {name: DB_USER, value: vmaas_sync}
         - {name: DB_PASSWD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
                                                       key: vmaas-sync-database-password}}}
+        - {name: DB_HOST_READ_REPLICA, valueFrom: {secretKeyRef: {key: db.host,
+                                                                  name: patchman-db-readonly}}}
+        - {name: DB_PORT_READ_REPLICA, valueFrom: {secretKeyRef: {key: db.port,
+                                                                  name: patchman-db-readonly}}}
+        - {name: DB_READ_REPLICA_ENABLED, value: '${DB_READ_REPLICA_ENABLED_JOBS}'}
         - {name: PROMETHEUS_PUSHGATEWAY,value: '${PROMETHEUS_PUSHGATEWAY}'}
 
     - name: advisory-refresh
@@ -644,6 +649,7 @@ parameters:
 - {name: DB_DEBUG_JOBS, value: 'false'}
 - {name: JOBS_TIMEOUT, value: '1800'}  # 30 min timeout for jobs
 - {name: PROMETHEUS_PUSHGATEWAY, required: true, value: "pushgateway"}
+- {name: DB_READ_REPLICA_ENABLED_JOBS, value: 'TRUE'}
 
 # VMaaS sync
 - {name: VMAAS_SYNC_SCHEDULE, value: '*/5 * * * *'} # Cronjob schedule definition


### PR DESCRIPTION
also change job schedule, some jobs take more than 1 hour which results in the next job to be scheduled just after the first on finishes. It causes jobs to start after 22:00 and interfere with upload evaluation
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
