### PR TITLE
POC: package systems

### DIFF
--- a/base/database/utils.go
+++ b/base/database/utils.go
@@ -39,6 +39,13 @@ func SystemPackages(tx *gorm.DB, accountID int, groups map[string]string) *gorm.
 		Joins("JOIN package_name pn on pn.id = spkg.name_id")
 }
 
+func SystemPackages2(tx *gorm.DB, accountID int, groups map[string]string) *gorm.DB {
+	return Systems(tx, accountID, groups).
+		Joins("JOIN system_package2 spkg on spkg.system_id = sp.id AND spkg.rh_account_id = ?", accountID).
+		Joins("JOIN package p on p.id = spkg.package_id").
+		Joins("JOIN package_name pn on pn.id = spkg.name_id")
+}
+
 func Packages(tx *gorm.DB) *gorm.DB {
 	return tx.Table("package p").
 		Joins("JOIN package_name pn on p.name_id = pn.id").

--- a/dev/test_data.sql
+++ b/dev/test_data.sql
@@ -151,7 +151,8 @@ INSERT INTO package(id, name_id, evra, description_hash, summary_hash, advisory_
 (9, 109, '2.21-10.el8.x86_64', '99', '9', 9, true), -- which
 (10, 110, '0.80-2.el8.x86_64', '1010', '10', 9, true), -- passwd
 (11, 101, '5.6.13-201.fc31.x86_64', '11', '1', 7, true), -- kernel
-(12, 102, '76.0.1-2.fc31.x86_64', '22', '2', null, true); -- firefox
+(12, 102, '76.0.1-2.fc31.x86_64', '22', '2', null, true), -- firefox
+(13, 102, '77.0.1-1.fc31.x86_64', '22', '2', null, true); -- firefox
 
 INSERT INTO system_package (rh_account_id, system_id, package_id, name_id, update_data) VALUES
 (3, 12, 1, 101, '[{"evra": "5.10.13-201.fc31.x86_64", "advisory": "RH-100", "status": "Installable"}]'),
@@ -161,6 +162,15 @@ INSERT INTO system_package (rh_account_id, system_id, package_id, name_id, updat
 (3, 13, 3, 103, null),
 (3, 13, 4, 104, null),
 (3, 16, 1, 101, '[{"evra": "5.10.13-201.fc31.x86_64", "advisory": "RH-100", "status": "Installable"}]');
+
+INSERT INTO system_package2 (rh_account_id, system_id, name_id, package_id, installable_id, applicable_id) VALUES
+(3, 12, 101, 1, 11, null),
+(3, 12, 102, 2, 12, null),
+(3, 13, 101, 1, null, null),
+(3, 13, 102, 2, 12, 13),
+(3, 13, 103, 3, null, null),
+(3, 13, 104, 4, null, null),
+(3, 16, 101, 1, 11, 11);
 
 INSERT INTO timestamp_kv (name, value) VALUES
 ('last_eval_repo_based', '2018-04-05T01:23:45+02:00');

--- a/evaluator/package_cache_test.go
+++ b/evaluator/package_cache_test.go
@@ -17,8 +17,8 @@ func TestGetPackageCache(t *testing.T) {
 	pc.Load()
 	assert.Equal(t, 11, pc.byID.Len())
 	assert.Equal(t, 11, pc.byNevra.Len())
-	assert.Equal(t, 11, pc.latestByName.Len())
-	assert.Equal(t, 11, pc.nameByID.Len())
+	assert.Equal(t, 10, pc.latestByName.Len())
+	assert.Equal(t, 10, pc.nameByID.Len())
 	// ask for a package not in cache
 	val, ok := pc.GetByID(1)
 	assert.True(t, ok)
@@ -78,8 +78,8 @@ func TestAddPackageCache(t *testing.T) {
 	pc := NewPackageCache(true, true, 100, 100)
 	assert.NotNil(t, pc)
 	pc.Load()
-	assert.Equal(t, 13, pc.byID.Len())
-	assert.Equal(t, 13, pc.byNevra.Len())
+	assert.Equal(t, 14, pc.byID.Len())
+	assert.Equal(t, 14, pc.byNevra.Len())
 	assert.Equal(t, 11, pc.latestByName.Len())
 	assert.Equal(t, 11, pc.nameByID.Len())
 
@@ -92,8 +92,8 @@ func TestAddPackageCache(t *testing.T) {
 		SummaryHash:     []byte("4"),
 	}
 	pc.Add(&pkg)
-	assert.Equal(t, 14, pc.byID.Len())
-	assert.Equal(t, 14, pc.byNevra.Len())
+	assert.Equal(t, 15, pc.byID.Len())
+	assert.Equal(t, 15, pc.byNevra.Len())
 	assert.Equal(t, 11, pc.latestByName.Len())
 	assert.Equal(t, 11, pc.nameByID.Len())
 

--- a/manager/controllers/package_systems.go
+++ b/manager/controllers/package_systems.go
@@ -27,10 +27,15 @@ type PackageSystemItemCommon struct {
 	SystemIDAttribute
 	SystemDisplayName
 	InstalledEVRA string         `json:"installed_evra" csv:"installed_evra" query:"p.evra" gorm:"column:installed_evra"`
-	AvailableEVRA string         `json:"available_evra" csv:"available_evra" query:"spkg.latest_evra" gorm:"column:available_evra"`
-	Updatable     bool           `json:"updatable" csv:"updatable" query:"(update_status(spkg.update_data) = 'Installable')" gorm:"column:updatable"`
+	AvailableEVRA string         `json:"available_evra" csv:"available_evra" query:"null" gorm:"-"`
+	Updatable     bool           `json:"updatable" csv:"updatable" query:"(spkg.installable_id IS NOT NULL)" gorm:"column:updatable"`
 	Tags          SystemTagsList `json:"tags" csv:"tags" query:"null" gorm:"-"`
 	BaselineAttributes
+	// helper to get AvailableEVRA (latest_evra)
+	InstallableID   int64  `json:"-" csv:"-" query:"spkg.installable_id" gorm:"column:installable_id"`
+	ApplicableID    int64  `json:"-" csv:"-" query:"spkg.applicable_id" gorm:"column:applicable_id"`
+	InstallableEVRA string `json:"-" csv:"-" query:"pi.evra" gorm:"column:installable_evra"`
+	ApplicableEVRA  string `json:"-" csv:"-" query:"pa.evra" gorm:"column:applicable_evra"`
 }
 
 type PackageSystemItemV2 struct {
@@ -42,7 +47,7 @@ type PackageSystemItemV3 struct {
 	PackageSystemItemCommon
 	BaselineIDAttr
 	OSAttributes
-	UpdateStatus string `json:"update_status" csv:"update_status" query:"update_status(spkg.update_data)" gorm:"column:update_status"`
+	UpdateStatus string `json:"update_status" csv:"update_status" query:"CASE WHEN spkg.installable_id is not null THEN 'Installable' WHEN spkg.applicable_id is not null THEN 'Applicable' ELSE 'None' END" gorm:"column:update_status"`
 	SystemGroups
 }
 
@@ -72,13 +77,14 @@ func packagesByNameQuery(db *gorm.DB, pkgName string) *gorm.DB {
 
 func packageSystemsQuery(db *gorm.DB, acc int, groups map[string]string, packageName string, packageIDs []int,
 ) *gorm.DB {
-	query := database.SystemPackages(db, acc, groups).
+	query := database.SystemPackages2(db, acc, groups).
 		Select(PackageSystemsSelect).
+		Joins("LEFT JOIN package pi ON pi.id = spkg.installable_id").
+		Joins("LEFT JOIN package pa ON pa.id = spkg.applicable_id").
 		Joins("LEFT JOIN baseline bl ON sp.baseline_id = bl.id AND sp.rh_account_id = bl.rh_account_id").
 		Where("sp.stale = false").
 		Where("pn.name = ?", packageName).
 		Where("spkg.package_id in (?)", packageIDs)
-
 	return query
 }
 
@@ -243,6 +249,10 @@ func packageSystemDBLookups2PackageSystemItemsV3(systems []PackageSystemDBLookup
 			utils.LogDebug("err", err.Error(), "inventory_id", system.ID, "system groups parsing failed")
 		}
 		data[i] = system.PackageSystemItemV3
+		data[i].AvailableEVRA = data[i].InstallableEVRA
+		if len(data[i].ApplicableEVRA) > 0 {
+			data[i].AvailableEVRA = data[i].ApplicableEVRA
+		}
 	}
 	return data, total
 }

--- a/manager/controllers/package_systems_export_test.go
+++ b/manager/controllers/package_systems_export_test.go
@@ -20,7 +20,7 @@ func TestPackageSystemsExportHandlerJSON(t *testing.T) {
 	assert.Equal(t, 3, len(output))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000012", output[0].ID)
 	assert.Equal(t, "5.6.13-200.fc31.x86_64", output[0].InstalledEVRA)
-	assert.Equal(t, "5.10.13-200.fc31.x86_64", output[0].AvailableEVRA)
+	assert.Equal(t, "5.6.13-201.fc31.x86_64", output[0].AvailableEVRA)
 	assert.Equal(t, SystemTagsList{{"k1", "ns1", "val1"}}, output[0].Tags)
 	assert.Equal(t, "", output[0].BaselineName)
 	assert.Equal(t, utils.PtrBoolNil(), output[0].BaselineUpToDate)
@@ -39,7 +39,7 @@ func TestPackageSystemsExportHandlerCSV(t *testing.T) {
 	assert.Equal(t, "id,display_name,installed_evra,available_evra,updatable,tags,"+
 		"baseline_name,baseline_uptodate,baseline_id,os,rhsm,update_status,groups", lines[0])
 	assert.Equal(t, "00000000-0000-0000-0000-000000000012,00000000-0000-0000-0000-000000000012,"+
-		"5.6.13-200.fc31.x86_64,5.10.13-200.fc31.x86_64,true,"+
+		"5.6.13-200.fc31.x86_64,5.6.13-201.fc31.x86_64,true,"+
 		"\"[{'key':'k1','namespace':'ns1','value':'val1'}]\",,,0,RHEL 8.1,8.1,Installable,[]",
 		lines[1])
 	assert.Equal(t, "00000000-0000-0000-0000-000000000013,00000000-0000-0000-0000-000000000013,"+

--- a/manager/controllers/package_systems_test.go
+++ b/manager/controllers/package_systems_test.go
@@ -16,7 +16,7 @@ func TestPackageSystems(t *testing.T) {
 	assert.Equal(t, "00000000-0000-0000-0000-000000000012", output.Data[0].ID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000012", output.Data[0].DisplayName)
 	assert.Equal(t, "5.6.13-200.fc31.x86_64", output.Data[0].InstalledEVRA)
-	assert.Equal(t, "5.10.13-200.fc31.x86_64", output.Data[0].AvailableEVRA)
+	assert.Equal(t, "5.6.13-201.fc31.x86_64", output.Data[0].AvailableEVRA)
 	assert.Equal(t, SystemTagsList{{"k1", "ns1", "val1"}}, output.Data[0].Tags)
 	assert.Equal(t, "", output.Data[0].BaselineName)
 	assert.Equal(t, utils.PtrBoolNil(), output.Data[0].BaselineUpToDate)

--- a/tasks/vmaas_sync/metrics_test.go
+++ b/tasks/vmaas_sync/metrics_test.go
@@ -56,7 +56,7 @@ func TestPackageCounts(t *testing.T) {
 
 	count, err := getPackageCounts()
 	assert.Nil(t, err)
-	assert.Equal(t, int64(12), count)
+	assert.Equal(t, int64(13), count)
 }
 
 func TestPackageNameCounts(t *testing.T) {


### PR DESCRIPTION
TODO:
- [x] add system_package2 test_data

original query - `(cost=1.40..26.06 rows=1 width=292) (actual time=2.213..3.124 rows=145 loops=1)`
```sql
SELECT
    count(*) over () as total,
    ih.tags as tags_str,
    ih.groups as groups_str,
    sp.inventory_id as id,
    sp.display_name as display_name,
    p.evra as installed_evra,
    spkg.latest_evra as available_evra,
    (update_status(spkg.update_data) = 'Installable') as updatable,
    null as Tags,
    bl.name as baseline_name,
    sp.baseline_uptodate as baseline_uptodate,
    bl.id as baseline_id,
    ih.system_profile -> 'operating_system' ->> 'name' || ' ' || coalesce(
        ih.system_profile -> 'operating_system' ->> 'major' || '.' || (ih.system_profile -> 'operating_system' ->> 'minor'),
        ''
    ) as os,
    ih.system_profile -> 'rhsm' ->> 'version' as rhsm,
    update_status(spkg.update_data) as update_status,
    Groups as Groups
FROM
    system_platform sp
    JOIN inventory.hosts ih ON ih.id = sp.inventory_id
    JOIN system_package spkg on spkg.system_id = sp.id
    AND spkg.rh_account_id = 50
    JOIN package p on p.id = spkg.package_id
    JOIN package_name pn on pn.id = spkg.name_id
    LEFT JOIN baseline bl ON sp.baseline_id = bl.id
    AND sp.rh_account_id = bl.rh_account_id
WHERE
    sp.rh_account_id = 50
    AND sp.stale = false
    AND pn.name = 'kernel'
    AND spkg.package_id in (2200, 2500);
```

new query - `(cost=1.97..38.07 rows=1 width=360) (actual time=4.045..4.123 rows=145 loops=1)`
```sql
SELECT
    count(*) over () as total,
    ih.tags as tags_str,
    ih.groups as groups_str,
    sp.inventory_id as id,
    sp.display_name as display_name,
    p.evra as installed_evra,
    null as AvailableEVRA,
    (spkg.installable_id IS NOT NULL) as updatable,
    null as Tags,
    bl.name as baseline_name,
    sp.baseline_uptodate as baseline_uptodate,
    spkg.installable_id as installable_id,
    spkg.applicable_id as applicable_id,
    pi.evra as installable_evra,
    pa.evra as applicable_evra,
    bl.id as baseline_id,
    ih.system_profile -> 'operating_system' ->> 'name' || ' ' || coalesce(
        ih.system_profile -> 'operating_system' ->> 'major' || '.' || (
            ih.system_profile -> 'operating_system' ->> 'minor'
        ),
        ''
    ) as os,
    ih.system_profile -> 'rhsm' ->> 'version' as rhsm,
    CASE
        WHEN spkg.installable_id is not null THEN 'Installable'
        WHEN spkg.applicable_id is not null THEN 'Applicable'
        ELSE 'None'
    END as update_status,
    Groups as Groups
FROM
    system_platform sp
    JOIN inventory.hosts ih ON ih.id = sp.inventory_id
    JOIN system_package2 spkg on spkg.system_id = sp.id
    AND spkg.rh_account_id = 50
    JOIN package p on p.id = spkg.package_id
    JOIN package_name pn on pn.id = spkg.name_id
    LEFT JOIN package pi ON pi.id = spkg.installable_id
    LEFT JOIN package pa ON pa.id = spkg.applicable_id
    LEFT JOIN baseline bl ON sp.baseline_id = bl.id
    AND sp.rh_account_id = bl.rh_account_id
WHERE
    sp.rh_account_id = 50
    AND sp.stale = false
    AND pn.name = 'kernel'
    AND spkg.package_id in (2200, 2500);
```
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
