### PR TITLE
POC: use system_package2 in /packages

### DIFF
--- a/base/database/utils.go
+++ b/base/database/utils.go
@@ -28,7 +28,7 @@ func SystemAdvisories(tx *gorm.DB, accountID int, groups map[string]string) *gor
 }
 
 func SystemPackagesShort(tx *gorm.DB, accountID int) *gorm.DB {
-	return tx.Table("system_package spkg").
+	return tx.Table("system_package2 spkg").
 		Where("spkg.rh_account_id = ?", accountID)
 }
 

--- a/manager/controllers/packages.go
+++ b/manager/controllers/packages.go
@@ -78,8 +78,8 @@ type PackagesResponse struct {
 type queryItem struct {
 	NameID             int `query:"spkg.name_id" gorm:"column:name_id"`
 	SystemsInstalled   int `json:"systems_installed" query:"count(*)" gorm:"column:systems_installed"`
-	SystemsInstallable int `json:"systems_installable" query:"count(*) filter (where update_status(spkg.update_data) = 'Installable')" gorm:"column:systems_installable"`
-	SystemsApplicable  int `json:"systems_applicable" query:"count(*) filter (where update_status(spkg.update_data) != 'None')" gorm:"column:systems_applicable"`
+	SystemsInstallable int `json:"systems_installable" query:"count(*) filter (where spkg.installable_id is not null)" gorm:"column:systems_installable"`
+	SystemsApplicable  int `json:"systems_applicable" query:"count(*) filter (where spkg.installable_id is not null or spkg.applicable_id is not null)" gorm:"column:systems_applicable"`
 }
 
 var queryItemSelect = database.MustGetSelect(&queryItem{})


### PR DESCRIPTION
original query `(cost=21664.34..21672.64 rows=200 width=66) (actual time=177.243..181.107 rows=300 loops=1)`
```sql
SELECT
    count(*) over () as total,
    pn.name as name,
    pn.summary as summary,
    res.systems_installed as systems_installed,
    res.systems_installable as systems_updatable,
    res.systems_installable as systems_installable,
    res.systems_applicable as systems_applicable
FROM
    package_name pn
    JOIN (
        SELECT
            spkg.name_id as name_id,
            count(*) as systems_installed,
            count(*) filter (
                where
                    update_status(spkg.update_data) = 'Installable'
            ) as systems_installable,
            count(*) filter (
                where
                    update_status(spkg.update_data) != 'None'
            ) as systems_applicable
        FROM
            system_package spkg
        WHERE
            spkg.rh_account_id = 37
            AND spkg.system_id IN (
                SELECT
                    sp.id
                FROM
                    system_platform sp
                    JOIN inventory.hosts ih ON ih.id = sp.inventory_id
                WHERE
                    sp.rh_account_id = 37
                    AND (
                        sp.stale = false
                        AND sp.packages_installed > 0
                    )
            )
        GROUP BY
            "spkg"."name_id"
    ) res ON res.name_id = pn.id;
```

query with system_package2 `(cost=5265.89..5274.19 rows=200 width=66) (actual time=146.491..151.353 rows=300 loops=1)`
```sql
SELECT
    count(*) over () as total,
    pn.name as name,
    pn.summary as summary,
    res.systems_installed as systems_installed,
    res.systems_installable as systems_updatable,
    res.systems_installable as systems_installable,
    res.systems_applicable as systems_applicable
FROM
    package_name pn
    JOIN (
        SELECT
            spkg.name_id as name_id,
            count(*) as systems_installed,
            count(*) filter (
                where
                    spkg.installable_id is not null
            ) as systems_installable,
            count(*) filter (
                where
                    spkg.installable_id is not null
                    or spkg.applicable_id is not null
            ) as systems_applicable
        FROM
            system_package2 spkg
        WHERE
            spkg.rh_account_id = 37
            AND spkg.system_id IN (
                SELECT
                    sp.id
                FROM
                    system_platform sp
                    JOIN inventory.hosts ih ON ih.id = sp.inventory_id
                WHERE
                    sp.rh_account_id = 37
                    AND (
                        sp.stale = false
                        AND sp.packages_installed > 0
                    )
            )
        GROUP BY
            "spkg"."name_id"
    ) res ON res.name_id = pn.id;
```
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
