### PR TITLE
RHINENG-1604: remove duplicated insert/update to system_platform

### DIFF
--- a/listener/upload.go
+++ b/listener/upload.go
@@ -348,11 +348,6 @@ func updateSystemPlatform(tx *gorm.DB, inventoryID string, accountID int, host *
 		colsToUpdate = append(colsToUpdate, "yum_updates")
 	}
 
-	if err := database.OnConflictUpdateMulti(tx, []string{"rh_account_id", "inventory_id"}, colsToUpdate...).
-		Save(&systemPlatform).Error; err != nil {
-		return nil, errors.Wrap(err, "Unable to save or update system in database")
-	}
-
 	if err := storeOrUpdateSysPlatform(tx, &systemPlatform, colsToUpdate); err != nil {
 		return nil, errors.Wrap(err, "Unable to save or update system in database")
 	}

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -377,6 +377,9 @@ func storeOrUpdateSysPlatform(tx *gorm.DB, system *models.SystemPlatform, colsTo
 		utils.LogWarn("err", errSelect, "couldn't find system for update")
 	}
 
+	// return system_platform record after update
+	tx = tx.Clauses(clause.Returning{})
+
 	if system.ID != 0 {
 		// update system
 		err = tx.Select(colsToUpdate).Updates(system).Error


### PR DESCRIPTION
insert/update should be handled by the `storeOrUpdateSysPlatform` function which should avoid doing upserts
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
