### PR TITLE
POC: delete system also from system_package2

### DIFF
--- a/database_admin/migrations/116_delete_system_package2.down.sql
+++ b/database_admin/migrations/116_delete_system_package2.down.sql
@@ -1,0 +1,97 @@
+CREATE OR REPLACE FUNCTION delete_system(inventory_id_in uuid)
+    RETURNS TABLE
+            (
+                deleted_inventory_id uuid
+            )
+AS
+$delete_system$
+DECLARE
+    v_system_id  INT;
+    v_account_id INT;
+BEGIN
+    -- opt out to refresh cache and then delete
+    SELECT id, rh_account_id
+    FROM system_platform
+    WHERE inventory_id = inventory_id_in
+    LIMIT 1
+        FOR UPDATE OF system_platform
+    INTO v_system_id, v_account_id;
+
+    IF v_system_id IS NULL OR v_account_id IS NULL THEN
+        RAISE NOTICE 'Not found';
+        RETURN;
+    END IF;
+
+    UPDATE system_platform
+    SET stale = true
+    WHERE rh_account_id = v_account_id
+      AND id = v_system_id;
+
+    DELETE
+    FROM system_advisories
+    WHERE rh_account_id = v_account_id
+      AND system_id = v_system_id;
+
+    DELETE
+    FROM system_repo
+    WHERE rh_account_id = v_account_id
+      AND system_id = v_system_id;
+
+    DELETE
+    FROM system_package
+    WHERE rh_account_id = v_account_id
+      AND system_id = v_system_id;
+
+    RETURN QUERY DELETE FROM system_platform
+        WHERE rh_account_id = v_account_id AND
+              id = v_system_id
+        RETURNING inventory_id;
+END;
+$delete_system$ LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION delete_systems(inventory_ids UUID[])
+    RETURNS INTEGER
+AS
+$$
+DECLARE
+    tmp_cnt INTEGER;
+BEGIN
+
+    WITH systems as (
+        SELECT rh_account_id, id
+        FROM system_platform
+        WHERE inventory_id = ANY (inventory_ids)
+        ORDER BY rh_account_id, id FOR UPDATE OF system_platform),
+         marked as (
+             UPDATE system_platform sp
+                 SET stale = true
+                 WHERE (rh_account_id, id) in (select rh_account_id, id from systems)
+         ),
+         advisories as (
+             DELETE
+                 FROM system_advisories
+                     WHERE (rh_account_id, system_id) in (select rh_account_id, id from systems)
+         ),
+         repos as (
+             DELETE
+                 FROM system_repo
+                     WHERE (rh_account_id, system_id) in (select rh_account_id, id from systems)
+         ),
+         packages as (
+             DELETE
+                 FROM system_package
+                     WHERE (rh_account_id, system_id) in (select rh_account_id, id from systems)
+         ),
+         deleted as (
+             DELETE
+                 FROM system_platform
+                     WHERE (rh_account_id, id) in (select rh_account_id, id from systems)
+                     RETURNING id
+         )
+    SELECT count(*)
+    FROM deleted
+    INTO tmp_cnt;
+
+    RETURN tmp_cnt;
+END
+$$ LANGUAGE plpgsql;

--- a/database_admin/migrations/116_delete_system_package2.up.sql
+++ b/database_admin/migrations/116_delete_system_package2.up.sql
@@ -1,0 +1,107 @@
+CREATE OR REPLACE FUNCTION delete_system(inventory_id_in uuid)
+    RETURNS TABLE
+            (
+                deleted_inventory_id uuid
+            )
+AS
+$delete_system$
+DECLARE
+    v_system_id  INT;
+    v_account_id INT;
+BEGIN
+    -- opt out to refresh cache and then delete
+    SELECT id, rh_account_id
+    FROM system_platform
+    WHERE inventory_id = inventory_id_in
+    LIMIT 1
+        FOR UPDATE OF system_platform
+    INTO v_system_id, v_account_id;
+
+    IF v_system_id IS NULL OR v_account_id IS NULL THEN
+        RAISE NOTICE 'Not found';
+        RETURN;
+    END IF;
+
+    UPDATE system_platform
+    SET stale = true
+    WHERE rh_account_id = v_account_id
+      AND id = v_system_id;
+
+    DELETE
+    FROM system_advisories
+    WHERE rh_account_id = v_account_id
+      AND system_id = v_system_id;
+
+    DELETE
+    FROM system_repo
+    WHERE rh_account_id = v_account_id
+      AND system_id = v_system_id;
+
+    DELETE
+    FROM system_package
+    WHERE rh_account_id = v_account_id
+      AND system_id = v_system_id;
+
+    DELETE
+    FROM system_package2
+    WHERE rh_account_id = v_account_id
+      AND system_id = v_system_id;
+
+    RETURN QUERY DELETE FROM system_platform
+        WHERE rh_account_id = v_account_id AND
+              id = v_system_id
+        RETURNING inventory_id;
+END;
+$delete_system$ LANGUAGE 'plpgsql';
+
+CREATE OR REPLACE FUNCTION delete_systems(inventory_ids UUID[])
+    RETURNS INTEGER
+AS
+$$
+DECLARE
+    tmp_cnt INTEGER;
+BEGIN
+
+    WITH systems as (
+        SELECT rh_account_id, id
+        FROM system_platform
+        WHERE inventory_id = ANY (inventory_ids)
+        ORDER BY rh_account_id, id FOR UPDATE OF system_platform),
+         marked as (
+             UPDATE system_platform sp
+                 SET stale = true
+                 WHERE (rh_account_id, id) in (select rh_account_id, id from systems)
+         ),
+         advisories as (
+             DELETE
+                 FROM system_advisories
+                     WHERE (rh_account_id, system_id) in (select rh_account_id, id from systems)
+         ),
+         repos as (
+             DELETE
+                 FROM system_repo
+                     WHERE (rh_account_id, system_id) in (select rh_account_id, id from systems)
+         ),
+         packages as (
+             DELETE
+                 FROM system_package
+                     WHERE (rh_account_id, system_id) in (select rh_account_id, id from systems)
+         ),
+         packages2 as (
+             DELETE
+                 FROM system_package2
+                     WHERE (rh_account_id, system_id) in (select rh_account_id, id from systems)
+         ),
+         deleted as (
+             DELETE
+                 FROM system_platform
+                     WHERE (rh_account_id, id) in (select rh_account_id, id from systems)
+                     RETURNING id
+         )
+    SELECT count(*)
+    FROM deleted
+    INTO tmp_cnt;
+
+    RETURN tmp_cnt;
+END
+$$ LANGUAGE plpgsql;

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (115, false);
+VALUES (116, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -387,6 +387,11 @@ BEGIN
     WHERE rh_account_id = v_account_id
       AND system_id = v_system_id;
 
+    DELETE
+    FROM system_package2
+    WHERE rh_account_id = v_account_id
+      AND system_id = v_system_id;
+
     RETURN QUERY DELETE FROM system_platform
         WHERE rh_account_id = v_account_id AND
               id = v_system_id
@@ -425,6 +430,11 @@ BEGIN
          packages as (
              DELETE
                  FROM system_package
+                     WHERE (rh_account_id, system_id) in (select rh_account_id, id from systems)
+         ),
+         packages2 as (
+             DELETE
+                 FROM system_package2
                      WHERE (rh_account_id, system_id) in (select rh_account_id, id from systems)
          ),
          deleted as (


### PR DESCRIPTION
error when deleting system in listener
```
time="2023-09-12T10:14:30Z" level=error msg="Try failed" attempt=3 err="Could not opt_out system: ERROR: update or delete on table \"system_platform_8\" violates foreign key constraint \"system_package2_rh_account_id_system_id_fkey9\" on table \"system_package2\" (SQLSTATE 23503)"
time="2023-09-12T10:14:31Z" level=error msg="Could not delete system" err="ERROR: update or delete on table \"system_platform_8\" violates foreign key constraint \"system_package2_rh_account_id_system_id_fkey9\" on table \"system_package2\" (SQLSTATE 23503)" inventoryID=803eea15-79a5-4b9f-863b-631409911ed0
```
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
