### PR TITLE
RHINENG-2394: set KafkaSslEnabled from clowder SecurityProtocol

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -34,7 +34,6 @@ objects:
         - {name: GIN_MODE, value: '${GIN_MODE}'}
         - {name: KAFKA_GROUP, value: patchman}
         - {name: KAFKA_WRITER_MAX_ATTEMPTS, value: '${KAFKA_WRITER_MAX_ATTEMPTS}'}
-        - {name: KAFKA_SSL_ENABLED, value: '${KAFKA_SSL_ENABLED}'}
         - {name: EVAL_TOPIC, value: patchman.evaluator.recalc}
         - {name: ENABLE_REPO_BASED_RE_EVALUATION, value: '${ENABLE_REPO_BASED_RE_EVALUATION}'}
         - {name: ENABLE_RECALC_MESSAGES_SEND, value: '${ENABLE_RECALC_MESSAGES_SEND}'}
@@ -117,7 +116,6 @@ objects:
         - {name: ENABLE_BASELINE_CHANGE_EVAL, value: '${ENABLE_BASELINE_CHANGE_EVAL}'}
         - {name: KAFKA_GROUP, value: patchman}
         - {name: KAFKA_WRITER_MAX_ATTEMPTS, value: '${KAFKA_WRITER_MAX_ATTEMPTS}'}
-        - {name: KAFKA_SSL_ENABLED, value: '${KAFKA_SSL_ENABLED}'}
         - {name: EVAL_TOPIC, value: '${EVAL_TOPIC_MANAGER}'}
         - {name: ENABLE_PACKAGE_CACHE, value: '${ENABLE_PACKAGE_CACHE_MANAGER}'}
         - {name: RESPONSE_TIMEOUT, value: '${RESPONSE_TIMEOUT}'}
@@ -162,7 +160,6 @@ objects:
         - {name: KAFKA_GROUP, value: patchman}
         - {name: KAFKA_READER_MAX_ATTEMPTS, value: '${KAFKA_READER_MAX_ATTEMPTS}'}
         - {name: KAFKA_WRITER_MAX_ATTEMPTS, value: '${KAFKA_WRITER_MAX_ATTEMPTS}'}
-        - {name: KAFKA_SSL_ENABLED, value: '${KAFKA_SSL_ENABLED}'}
         - {name: EVENTS_TOPIC, value: platform.inventory.events}
         - {name: EVAL_TOPIC, value: patchman.evaluator.upload}
         - {name: PAYLOAD_TRACKER_TOPIC, value: platform.payload-status}
@@ -210,7 +207,6 @@ objects:
         - {name: KAFKA_GROUP, value: patchman}
         - {name: KAFKA_READER_MAX_ATTEMPTS, value: '${KAFKA_READER_MAX_ATTEMPTS}'}
         - {name: KAFKA_WRITER_MAX_ATTEMPTS, value: '${KAFKA_WRITER_MAX_ATTEMPTS}'}
-        - {name: KAFKA_SSL_ENABLED, value: '${KAFKA_SSL_ENABLED}'}
         - {name: EVAL_TOPIC, value: patchman.evaluator.upload}
         - {name: PAYLOAD_TRACKER_TOPIC, value: platform.payload-status}
         - {name: REMEDIATIONS_UPDATE_TOPIC, value: 'platform.remediation-updates.patch'}
@@ -279,7 +275,6 @@ objects:
         - {name: KAFKA_GROUP, value: patchman}
         - {name: KAFKA_READER_MAX_ATTEMPTS, value: '${KAFKA_READER_MAX_ATTEMPTS}'}
         - {name: KAFKA_WRITER_MAX_ATTEMPTS, value: '${KAFKA_WRITER_MAX_ATTEMPTS}'}
-        - {name: KAFKA_SSL_ENABLED, value: '${KAFKA_SSL_ENABLED}'}
         - {name: EVAL_TOPIC, value: patchman.evaluator.recalc}
         - {name: PAYLOAD_TRACKER_TOPIC, value: platform.payload-status}
         - {name: REMEDIATIONS_UPDATE_TOPIC, value: 'platform.remediation-updates.patch'}
@@ -345,7 +340,6 @@ objects:
                                                        key: vmaas-sync-database-password}}}
         - {name: KAFKA_GROUP, value: patchman}
         - {name: KAFKA_WRITER_MAX_ATTEMPTS, value: '${KAFKA_WRITER_MAX_ATTEMPTS}'}
-        - {name: KAFKA_SSL_ENABLED, value: '${KAFKA_SSL_ENABLED}'}
         - {name: EVAL_TOPIC, value: patchman.evaluator.recalc}
         - {name: ENABLE_REPO_BASED_RE_EVALUATION, value: '${ENABLE_REPO_BASED_RE_EVALUATION}'}
         - {name: ENABLE_RECALC_MESSAGES_SEND, value: '${ENABLE_RECALC_MESSAGES_SEND}'}
@@ -722,7 +716,6 @@ parameters:
 - {name: GIN_MODE, value: 'release'} # Gin webframework running mode
 - {name: PACKAGE_CACHE_SIZE, value: '1000000'}
 - {name: PACKAGE_NAME_CACHE_SIZE, value: '60000'}
-- {name: KAFKA_SSL_ENABLED, value: 'true'}
 - {name: KAFKA_READER_MAX_ATTEMPTS, value: '3'} # Limit of how many attempts will be made before kafka read error.
 - {name: KAFKA_WRITER_MAX_ATTEMPTS, value: '10'} # Limit of how many attempts will be made before kafka write error.
 - {name: VMAAS_CALL_MAX_RETRIES, value: '8'} # Limit of how many unsuccessful vmaas calls are allowed before panic.


### PR DESCRIPTION
Set as mentioned in `Upcoming Stage Changes for Kafka Migration Testing` email thread
* if kafka.brokers[0].securityProtocol is defined and its value is "SSL" or "SASL_SSL", then SSL should be ON

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
