### PR TITLE
RHINENG-2610: use latest_repo_change timestamp for repo based re-eval

### DIFF
--- a/base/vmaas/vmaas.go
+++ b/base/vmaas/vmaas.go
@@ -264,11 +264,12 @@ type ReposRequest struct {
 }
 
 type ReposResponse struct {
-	Page           int                                 `json:"page,omitempty"`
-	PageSize       int                                 `json:"page_size,omitempty"`
-	Pages          int                                 `json:"pages,omitempty"`
-	RepositoryList map[string][]map[string]interface{} `json:"repository_list,omitempty"`
-	LastChange     *string                             `json:"last_change,omitempty"`
+	Page             int                                 `json:"page,omitempty"`
+	PageSize         int                                 `json:"page_size,omitempty"`
+	Pages            int                                 `json:"pages,omitempty"`
+	RepositoryList   map[string][]map[string]interface{} `json:"repository_list,omitempty"`
+	LastChange       *string                             `json:"last_change,omitempty"`
+	LatestRepoChange *types.Rfc3339Timestamp             `json:"latest_repo_change,omitempty"`
 }
 
 type DBChangeResponse struct {

--- a/platform/vmaas.go
+++ b/platform/vmaas.go
@@ -201,6 +201,7 @@ func reposHandler(c *gin.Context) {
     "page": 0,
     "page_size": 3,
     "pages": 1,
+    "latest_repo_change": "2222-04-16 20:07:55.214266+00",
     "repository_list": {
         "repo1": [],
         "repo2": [],

--- a/tasks/vmaas_sync/repo_based_test.go
+++ b/tasks/vmaas_sync/repo_based_test.go
@@ -95,7 +95,7 @@ func TestGetUpdatedRepos(t *testing.T) {
 	Configure()
 
 	modifiedSince := time.Now().Format(types.Rfc3339NoTz)
-	redhat, thirdparty, err := getUpdatedRepos(time.Now(), &modifiedSince)
+	redhat, thirdparty, _, err := getUpdatedRepos(time.Now(), &modifiedSince)
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(redhat))
 	assert.Equal(t, 0, len(thirdparty))

--- a/tasks/vmaas_sync/repo_sync.go
+++ b/tasks/vmaas_sync/repo_sync.go
@@ -9,7 +9,7 @@ import (
 
 func syncRepos(syncStart time.Time) error {
 	// mark non-thirdparty repos known to vmaas
-	redhatRepos, _, err := getUpdatedRepos(syncStart, nil)
+	redhatRepos, _, _, err := getUpdatedRepos(syncStart, nil)
 	if err != nil {
 		return err
 	}

--- a/tasks/vmaas_sync/vmaas_sync_test.go
+++ b/tasks/vmaas_sync/vmaas_sync_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"testing"
-	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -75,7 +74,8 @@ func TestSync(t *testing.T) {
 
 	ts, err := database.GetTimestampKVValueStr(LastEvalRepoBased) // check updated timestamp
 	assert.Nil(t, err)
-	assert.Equal(t, time.Now().Format("2006"), (*ts)[0:4])
+	// timestamp comes from vmaas - latest_repo_change
+	assert.Equal(t, "2222", (*ts)[0:4])
 	resetLastEvalTimestamp(t)
 	database.DeleteNewlyAddedPackages(t)
 	database.DeleteNewlyAddedAdvisories(t)


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
