### PR TITLE
RHINENG-6036: exclude satellite and discovery reporters

### DIFF
--- a/database_admin/migrations/120_add_new_yupana_reporters.up.sql
+++ b/database_admin/migrations/120_add_new_yupana_reporters.up.sql
@@ -1,0 +1,4 @@
+INSERT INTO reporter (id, name) VALUES 
+      (5, 'satellite'),
+      (6, 'discovery')
+ON CONFLICT DO NOTHING;

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (119, false);
+VALUES (120, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -661,7 +661,9 @@ INSERT INTO reporter (id, name)
 VALUES (1, 'puptoo'),
        (2, 'rhsm-conduit'),
        (3, 'yupana'),
-       (4, 'rhsm-system-profile-bridge')
+       (4, 'rhsm-system-profile-bridge'),
+       (5, 'satellite'),
+       (6, 'discovery')
 ON CONFLICT DO NOTHING;
 
 -- baseline

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -505,6 +505,15 @@ objects:
       enabled: true
       appName: patch
       insightsOnly: true
+      additionalFilters:
+        - name: "nonCentOS"
+          type: "com.redhat.insights.kafka.connect.transforms.Filter"
+          if: "!record.headers().lastWithName('os_name').value().match(/centos/i)"
+          where: "COALESCE(system_profile_facts->'operating_system'->>'name', '') NOT ILIKE '%centos%'"
+        - name: "excludedReporters"
+          type: "com.redhat.insights.kafka.connect.transforms.Filter"
+          if: "!record.headers().lastWithName('reporter').value().match(/^(yupana|satellite|discovery|rhsm-conduit)$/i)"
+          where: "reporter NOT IN ('yupana', 'satellite', 'discovery', 'rhsm-conduit')"
     testing:
       iqePlugin: patchman
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -593,7 +593,7 @@ parameters:
 - {name: DB_DEBUG_LISTENER, value: 'false'}
 - {name: CONSUMER_COUNT_LISTENER, value: '8'}
 - {name: ENABLE_BYPASS_LISTENER, value: 'false'} # Enable only bypass (fake) messages processing
-- {name: EXCLUDED_REPORTERS, value: 'yupana,rhsm-conduit'} # Comma-separated list of reporters to exclude from processing
+- {name: EXCLUDED_REPORTERS, value: 'yupana,rhsm-conduit,satellite,discovery'} # Comma-separated list of reporters to exclude from processing
 - {name: EXCLUDED_HOST_TYPES, value: 'edge'} # Comma-separated list of host types to exclude from processing
 - {name: RES_LIMIT_CPU_LISTENER, value: 250m}
 - {name: RES_LIMIT_MEM_LISTENER, value: 192Mi}

--- a/listener/listener_test.go
+++ b/listener/listener_test.go
@@ -13,7 +13,7 @@ func TestLoadValidReporters(t *testing.T) {
 	configure()
 
 	reporter := loadValidReporters()
-	assert.Equal(t, 4, len(reporter))
+	assert.Equal(t, 6, len(reporter))
 	assert.Equal(t, 1, reporter["puptoo"])
 	assert.Equal(t, 2, reporter["rhsm-conduit"])
 	assert.Equal(t, 3, reporter["yupana"])


### PR DESCRIPTION
I copied cyndi additionalFilters from Vulnerability since we didn't have it clowdapp.yaml. Do we have it defined somewhere else?
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
