### PR TITLE
RHINENG-8049: improve CreateRequestRouterWithParams func

### DIFF
--- a/manager/controllers/advisories_export_test.go
+++ b/manager/controllers/advisories_export_test.go
@@ -69,7 +69,8 @@ func TestAdvisoriesExportCSVFilter(t *testing.T) {
 
 func TestAdvisoriesExportTagsInvalid(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/?tags=ns1/k3=val4&tags=invalidTag", nil, "", AdvisoriesExportHandler, "/")
+	w := CreateRequestRouterWithPath("GET", "/", "", "?tags=ns1/k3=val4&tags=invalidTag", nil, "",
+		AdvisoriesExportHandler)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -78,8 +79,8 @@ func TestAdvisoriesExportTagsInvalid(t *testing.T) {
 
 func TestAdvisoriesExportIncorrectFilter(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/?filter[filteriamnotexitst]=abcd", nil, "text/csv",
-		AdvisoriesExportHandler, "/")
+	w := CreateRequestRouterWithPath("GET", "/", "", "?filter[filteriamnotexitst]=abcd", nil, "text/csv",
+		AdvisoriesExportHandler)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/manager/controllers/advisories_test.go
+++ b/manager/controllers/advisories_test.go
@@ -283,7 +283,8 @@ func TestAdvisoriesTags(t *testing.T) {
 
 func TestListAdvisoriesTagsInvalid(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/?tags=ns1/k3=val4&tags=invalidTag", nil, "", AdvisoriesListHandler, "/")
+	w := CreateRequestRouterWithPath("GET", "/", "", "?tags=ns1/k3=val4&tags=invalidTag", nil, "",
+		AdvisoriesListHandler)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -304,8 +305,8 @@ func TestAdvisoriesWrongOffset(t *testing.T) {
 
 func TestAdvisoryTagsInMetadata(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "", AdvisoriesListHandler,
-		"/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "",
+		AdvisoriesListHandler)
 
 	var output AdvisoriesResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)

--- a/manager/controllers/advisories_test.go
+++ b/manager/controllers/advisories_test.go
@@ -290,17 +290,16 @@ func TestListAdvisoriesTagsInvalid(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf(InvalidTagMsg, "invalidTag"), errResp.Error)
 }
 
-func doTestWrongOffset(t *testing.T, path, q string, handler gin.HandlerFunc) {
+func doTestWrongOffset(t *testing.T, path, param, q string, handler gin.HandlerFunc) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", q, nil, "", handler, 3, "GET", path)
-
+	w := CreateRequestRouterWithParams("GET", path, param, q, nil, "", handler, 3)
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
 	assert.Equal(t, InvalidOffsetMsg, errResp.Error)
 }
 
 func TestAdvisoriesWrongOffset(t *testing.T) {
-	doTestWrongOffset(t, "/", "/?offset=1000", AdvisoriesListHandler)
+	doTestWrongOffset(t, "/", "", "?offset=1000", AdvisoriesListHandler)
 }
 
 func TestAdvisoryTagsInMetadata(t *testing.T) {

--- a/manager/controllers/advisory_detail_test.go
+++ b/manager/controllers/advisory_detail_test.go
@@ -15,16 +15,14 @@ import (
 
 func TestAdvisoryDetailDefault(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-9", nil, "", AdvisoryDetailHandler, "/:advisory_id",
-		core.V1APICtx)
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-9", "", nil, "", AdvisoryDetailHandler, core.V1APICtx)
 
 	var outputV1 AdvisoryDetailResponseV1
 	CheckResponse(t, w, http.StatusOK, &outputV1)
 	// data
 	outputV1.checkRH9Fields(t)
 
-	w = CreateRequestRouterWithPath("GET", "/RH-9", nil, "", AdvisoryDetailHandler, "/:advisory_id",
-		core.V2APICtx)
+	w = CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-9", "", nil, "", AdvisoryDetailHandler, core.V2APICtx)
 
 	var outputV2 AdvisoryDetailResponseV2
 	CheckResponse(t, w, http.StatusOK, &outputV2)
@@ -69,8 +67,7 @@ func (r *AdvisoryDetailResponseV2) checkRH9Fields(t *testing.T) {
 
 func TestAdvisoryDetailCVE(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-3", nil, "", AdvisoryDetailHandler, "/:advisory_id",
-		core.V1APICtx)
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-3", "", nil, "", AdvisoryDetailHandler, core.V1APICtx)
 
 	var outputV1 AdvisoryDetailResponseV1
 	CheckResponse(t, w, http.StatusOK, &outputV1)
@@ -78,8 +75,7 @@ func TestAdvisoryDetailCVE(t *testing.T) {
 	assert.Equal(t, "CVE-1", outputV1.Data.Attributes.Cves[0])
 	assert.Equal(t, "CVE-2", outputV1.Data.Attributes.Cves[1])
 
-	w = CreateRequestRouterWithPath("GET", "/RH-3", nil, "", AdvisoryDetailHandler, "/:advisory_id",
-		core.V2APICtx)
+	w = CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-3", "", nil, "", AdvisoryDetailHandler, core.V2APICtx)
 
 	var outputV2 AdvisoryDetailResponseV2
 	CheckResponse(t, w, http.StatusOK, &outputV2)
@@ -107,26 +103,24 @@ func TestAdvisoryNotFound(t *testing.T) {
 	core.SetupTest(t)
 
 	var errResp utils.ErrorResponse
-	w := CreateRequestRouterWithPath("GET", "/foo", nil, "", AdvisoryDetailHandler, "/:advisory_id",
-		core.V1APICtx)
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "foo", "", nil, "", AdvisoryDetailHandler, core.V1APICtx)
 
 	CheckResponse(t, w, http.StatusNotFound, &errResp)
 	assert.Equal(t, "advisory not found", errResp.Error)
 
-	w = CreateRequestRouterWithPath("GET", "/foo", nil, "", AdvisoryDetailHandler, "/:advisory_id",
-		core.V2APICtx)
+	w = CreateRequestRouterWithPath("GET", "/:advisory_id", "foo", "", nil, "", AdvisoryDetailHandler, core.V2APICtx)
 
 	CheckResponse(t, w, http.StatusNotFound, &errResp)
 	assert.Equal(t, "advisory not found", errResp.Error)
 }
 
 func testReqV1() *httptest.ResponseRecorder {
-	return CreateRequestRouterWithPath("GET", "/RH-9", nil, "", AdvisoryDetailHandler, "/:advisory_id",
+	return CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-9", "", nil, "", AdvisoryDetailHandler,
 		core.V1APICtx)
 }
 
 func testReqV2() *httptest.ResponseRecorder {
-	return CreateRequestRouterWithPath("GET", "/RH-9", nil, "", AdvisoryDetailHandler, "/:advisory_id",
+	return CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-9", "", nil, "", AdvisoryDetailHandler,
 		core.V2APICtx)
 }
 
@@ -171,14 +165,14 @@ func TestAdvisoryDetailFiltering(t *testing.T) {
 	core.SetupTest(t)
 
 	var errResp utils.ErrorResponse
-	w := CreateRequestRouterWithPath("GET", "/RH-9?filter[filter]=abcd", nil, "", AdvisoryDetailHandler,
-		"/:advisory_id", core.V1APICtx)
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-9", "?filter[filter]=abcd", nil, "",
+		AdvisoryDetailHandler, core.V1APICtx)
 
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
 	assert.Equal(t, FilterNotSupportedMsg, errResp.Error)
 
-	w = CreateRequestRouterWithPath("GET", "/RH-9?filter[filter]=abcd", nil, "", AdvisoryDetailHandler,
-		"/:advisory_id", core.V2APICtx)
+	w = CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-9", "?filter[filter]=abcd", nil, "",
+		AdvisoryDetailHandler, core.V2APICtx)
 
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
 	assert.Equal(t, FilterNotSupportedMsg, errResp.Error)

--- a/manager/controllers/advisory_systems_export_test.go
+++ b/manager/controllers/advisory_systems_export_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestAdvisorySystemsExportJSON(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1", nil, "application/json", AdvisorySystemsExportHandler,
-		"/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "", nil, "application/json",
+		AdvisorySystemsExportHandler)
 
 	var output []SystemDBLookup
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -23,7 +23,7 @@ func TestAdvisorySystemsExportJSON(t *testing.T) {
 
 func TestAdvisorySystemsExportCSV(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1", nil, "text/csv", AdvisorySystemsExportHandler, "/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "", nil, "text/csv", AdvisorySystemsExportHandler)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := w.Body.String()

--- a/manager/controllers/advisory_systems_test.go
+++ b/manager/controllers/advisory_systems_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAdvisorySystemsDefault(t *testing.T) { //nolint:dupl
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1", nil, "", AdvisorySystemsListHandler, "/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "", nil, "", AdvisorySystemsListHandler)
 
 	var output AdvisorySystemsResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -36,7 +36,7 @@ func TestAdvisorySystemsDefault(t *testing.T) { //nolint:dupl
 
 func TestAdvisorySystemsIDsDefault(t *testing.T) { //nolint:dupl
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1", nil, "", AdvisorySystemsListIDsHandler, "/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "", nil, "", AdvisorySystemsListIDsHandler)
 
 	var output IDsStatusResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -49,15 +49,16 @@ func TestAdvisorySystemsIDsDefault(t *testing.T) { //nolint:dupl
 
 func TestAdvisorySystemsNotFound(t *testing.T) { //nolint:dupl
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/nonexistant/systems", nil, "", AdvisorySystemsListHandler, "/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "nonexistant/systems", "", nil, "",
+		AdvisorySystemsListHandler)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestAdvisorySystemsOffsetLimit(t *testing.T) { //nolint:dupl
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1?offset=5&limit=3", nil, "", AdvisorySystemsListHandler,
-		"/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "?offset=5&limit=3", nil, "",
+		AdvisorySystemsListHandler)
 
 	var output AdvisorySystemsResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -69,8 +70,8 @@ func TestAdvisorySystemsOffsetLimit(t *testing.T) { //nolint:dupl
 
 func TestAdvisorySystemsOffsetOverflow(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1?offset=100&limit=3", nil, "", AdvisorySystemsListHandler,
-		"/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "?offset=100&limit=3", nil, "",
+		AdvisorySystemsListHandler)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -81,8 +82,8 @@ func TestAdvisorySystemsSorts(t *testing.T) {
 	core.SetupTest(t)
 
 	for sort := range AdvisorySystemsFields {
-		w := CreateRequestRouterWithPath("GET", fmt.Sprintf("/RH-1?sort=%v", sort), nil, "",
-			AdvisorySystemsListHandler, "/:advisory_id")
+		w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", fmt.Sprintf("?sort=%v", sort), nil, "",
+			AdvisorySystemsListHandler)
 
 		var output AdvisorySystemsResponseV3
 		CheckResponse(t, w, http.StatusOK, &output)
@@ -93,16 +94,16 @@ func TestAdvisorySystemsSorts(t *testing.T) {
 
 func TestAdvisorySystemsWrongSort(t *testing.T) { //nolint:dupl
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1?sort=unknown_key", nil, "", AdvisorySystemsListHandler,
-		"/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "?sort=unknown_key", nil, "",
+		AdvisorySystemsListHandler)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestAdvisorySystemsTags(t *testing.T) { //nolint:dupl
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1?tags=ns1/k1=val1", nil, "", AdvisorySystemsListHandler,
-		"/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "?tags=ns1/k1=val1", nil, "",
+		AdvisorySystemsListHandler)
 
 	var output AdvisorySystemsResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -111,8 +112,8 @@ func TestAdvisorySystemsTags(t *testing.T) { //nolint:dupl
 
 func TestAdvisorySystemsTagsMultiple(t *testing.T) { //nolint:dupl
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "",
-		AdvisorySystemsListHandler, "/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "",
+		AdvisorySystemsListHandler)
 
 	var output AdvisorySystemsResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -122,8 +123,8 @@ func TestAdvisorySystemsTagsMultiple(t *testing.T) { //nolint:dupl
 
 func TestAdvisorySystemsTagsInvalid(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1?tags=ns1/k3=val4&tags=invalidTag", nil, "",
-		AdvisorySystemsListHandler, "/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "?tags=ns1/k3=val4&tags=invalidTag", nil, "",
+		AdvisorySystemsListHandler)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -132,8 +133,8 @@ func TestAdvisorySystemsTagsInvalid(t *testing.T) {
 
 func TestAdvisorySystemsTagsUnknown(t *testing.T) { //nolint:dupl
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1?tags=ns1/k3=val4&tags=ns1/k1=unk", nil, "",
-		AdvisorySystemsListHandler, "/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "?tags=ns1/k3=val4&tags=ns1/k1=unk", nil, "",
+		AdvisorySystemsListHandler)
 
 	var output AdvisorySystemsResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -146,8 +147,8 @@ func TestAdvisorySystemsWrongOffset(t *testing.T) {
 
 func TestAdvisorySystemsTagsInMetadata(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/RH-1?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "",
-		AdvisorySystemsListHandler, "/:advisory_id")
+	w := CreateRequestRouterWithPath("GET", "/:advisory_id", "RH-1", "?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "",
+		AdvisorySystemsListHandler)
 
 	var output AdvisorySystemsResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)

--- a/manager/controllers/advisory_systems_test.go
+++ b/manager/controllers/advisory_systems_test.go
@@ -141,7 +141,7 @@ func TestAdvisorySystemsTagsUnknown(t *testing.T) { //nolint:dupl
 }
 
 func TestAdvisorySystemsWrongOffset(t *testing.T) {
-	doTestWrongOffset(t, "/:advisory_id", "/RH-1?offset=1000", AdvisorySystemsListHandler)
+	doTestWrongOffset(t, "/:advisory_id", "RH-1", "?offset=1000", AdvisorySystemsListHandler)
 }
 
 func TestAdvisorySystemsTagsInMetadata(t *testing.T) {

--- a/manager/controllers/baseline_create_test.go
+++ b/manager/controllers/baseline_create_test.go
@@ -24,7 +24,7 @@ func TestCreateBaseline(t *testing.T) {
         "config": {"to_time": "2022-12-31T12:00:00-04:00"},
 		"description": "desc"
 	}`
-	w := CreateRequestRouterWithParams("PUT", "/", bytes.NewBufferString(data), "", CreateBaselineHandler, 1, "PUT", "/")
+	w := CreateRequestRouterWithParams("PUT", "/", "", "", bytes.NewBufferString(data), "", CreateBaselineHandler, 1)
 
 	var resp CreateBaselineResponse
 	ParseResponseBody(t, w.Body.Bytes(), &resp)
@@ -39,7 +39,7 @@ func TestCreateBaseline(t *testing.T) {
 func TestCreateBaselineNameOnly(t *testing.T) {
 	core.SetupTest(t)
 	data := `{"name": "my_empty_baseline"}`
-	w := CreateRequestRouterWithParams("PUT", "/", bytes.NewBufferString(data), "", CreateBaselineHandler, 1, "PUT", "/")
+	w := CreateRequestRouterWithParams("PUT", "/", "", "", bytes.NewBufferString(data), "", CreateBaselineHandler, 1)
 
 	var resp CreateBaselineResponse
 	ParseResponseBody(t, w.Body.Bytes(), &resp)
@@ -50,7 +50,7 @@ func TestCreateBaselineNameOnly(t *testing.T) {
 func TestCreateBaselineNameEmptyString(t *testing.T) {
 	core.SetupTest(t)
 	data := `{"name": ""}`
-	w := CreateRequestRouterWithParams("PUT", "/", bytes.NewBufferString(data), "", CreateBaselineHandler, 1, "PUT", "/")
+	w := CreateRequestRouterWithParams("PUT", "/", "", "", bytes.NewBufferString(data), "", CreateBaselineHandler, 1)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -60,7 +60,7 @@ func TestCreateBaselineNameEmptyString(t *testing.T) {
 func TestCreateBaselineMissingName(t *testing.T) {
 	core.SetupTest(t)
 	data := `{}`
-	w := CreateRequestRouterWithParams("PUT", "/", bytes.NewBufferString(data), "", CreateBaselineHandler, 1, "PUT", "/")
+	w := CreateRequestRouterWithParams("PUT", "/", "", "", bytes.NewBufferString(data), "", CreateBaselineHandler, 1)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -70,7 +70,7 @@ func TestCreateBaselineMissingName(t *testing.T) {
 func TestCreateBaselineInvalidRequest(t *testing.T) {
 	core.SetupTest(t)
 	data := `{"name": 0}`
-	w := CreateRequestRouterWithParams("PUT", "/", bytes.NewBufferString(data), "", CreateBaselineHandler, 1, "PUT", "/")
+	w := CreateRequestRouterWithParams("PUT", "/", "", "", bytes.NewBufferString(data), "", CreateBaselineHandler, 1)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -83,7 +83,7 @@ func TestCreateBaselineDuplicatedName(t *testing.T) {
 	data := `{
 		"name": "baseline_1-1"
 	}`
-	w := CreateRequestRouterWithParams("PUT", "/", bytes.NewBufferString(data), "", CreateBaselineHandler, 1, "PUT", "/")
+	w := CreateRequestRouterWithParams("PUT", "/", "", "", bytes.NewBufferString(data), "", CreateBaselineHandler, 1)
 
 	var errResp utils.ErrorResponse
 	ParseResponseBody(t, w.Body.Bytes(), &errResp)
@@ -93,7 +93,7 @@ func TestCreateBaselineDuplicatedName(t *testing.T) {
 func TestCreateBaselineDescriptionEmptyString(t *testing.T) {
 	core.SetupTest(t)
 	data := `{"name": "baseline_empty_desc", "description": ""}`
-	w := CreateRequestRouterWithParams("PUT", "/", bytes.NewBufferString(data), "", CreateBaselineHandler, 1, "PUT", "/")
+	w := CreateRequestRouterWithParams("PUT", "/", "", "", bytes.NewBufferString(data), "", CreateBaselineHandler, 1)
 
 	var resp CreateBaselineResponse
 	CheckResponse(t, w, http.StatusOK, &resp)
@@ -104,7 +104,7 @@ func TestCreateBaselineDescriptionEmptyString(t *testing.T) {
 func TestCreateBaselineDescriptionSpaces(t *testing.T) {
 	core.SetupTest(t)
 	data := `{"name": "baseline_spaces_desc", "description": "   "}`
-	w := CreateRequestRouterWithParams("PUT", "/", bytes.NewBufferString(data), "", CreateBaselineHandler, 1, "PUT", "/")
+	w := CreateRequestRouterWithParams("PUT", "/", "", "", bytes.NewBufferString(data), "", CreateBaselineHandler, 1)
 
 	var err utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &err)
@@ -134,8 +134,7 @@ func TestCreateBaselineSatelliteSystem(t *testing.T) {
 		"description": "desc"
 	}`
 
-	w := CreateRequestRouterWithParams("PUT", "/", bytes.NewBufferString(data), "",
-		CreateBaselineHandler, 1, "PUT", "/")
+	w := CreateRequestRouterWithParams("PUT", "/", "", "", bytes.NewBufferString(data), "", CreateBaselineHandler, 1)
 	var err utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &err)
 }

--- a/manager/controllers/baseline_delete_test.go
+++ b/manager/controllers/baseline_delete_test.go
@@ -19,8 +19,8 @@ func TestBaselineDelete(t *testing.T) {
 		"00000000-0000-0000-0000-000000000007"}
 	baselineID := database.CreateBaseline(t, "", inventoryIDs, nil)
 
-	w := CreateRequestRouterWithPath("GET", fmt.Sprintf(`/%v`, baselineID), nil, "", BaselineDeleteHandler,
-		"/:baseline_id")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id", fmt.Sprintf(`%v`, baselineID), "", nil, "",
+		BaselineDeleteHandler)
 
 	var resp DeleteBaselineResponse
 	CheckResponse(t, w, http.StatusOK, &resp)
@@ -29,7 +29,7 @@ func TestBaselineDelete(t *testing.T) {
 
 func TestBaselineDeleteNonExisting(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/88888", nil, "", BaselineDeleteHandler, "/:baseline_id")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id", "88888", "", nil, "", BaselineDeleteHandler)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusNotFound, &errResp)
@@ -38,7 +38,7 @@ func TestBaselineDeleteNonExisting(t *testing.T) {
 
 func TestBaselineDeleteInvalid(t *testing.T) {
 	core.SetupTestEnvironment()
-	w := CreateRequestRouterWithPath("GET", "/invalidBaseline", nil, "", BaselineDeleteHandler, "/:baseline_id")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id", "invalidBaseline", "", nil, "", BaselineDeleteHandler)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)

--- a/manager/controllers/baseline_detail_test.go
+++ b/manager/controllers/baseline_detail_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testBaselineDetail(t *testing.T, url string, expectedStatus int, output interface{}) {
+func testBaselineDetail(t *testing.T, param string, expectedStatus int, output interface{}) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", url, nil, "", BaselineDetailHandler, "/:baseline_id")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id", param, "", nil, "", BaselineDetailHandler)
 	CheckResponse(t, w, expectedStatus, &output)
 }
 
 func TestBaselineDetailDefault(t *testing.T) {
 	var output BaselineDetailResponse
-	testBaselineDetail(t, "/1", http.StatusOK, &output)
+	testBaselineDetail(t, "1", http.StatusOK, &output)
 	assert.Equal(t, int64(1), output.Data.ID)
 	assert.Equal(t, "baseline", output.Data.Type)
 	assert.Equal(t, "baseline_1-1", output.Data.Attributes.Name)
@@ -31,13 +31,13 @@ func TestBaselineDetailDefault(t *testing.T) {
 
 func TestBaselineDetailNotFound(t *testing.T) {
 	var output utils.ErrorResponse
-	testBaselineDetail(t, "/10000", http.StatusNotFound, &output)
+	testBaselineDetail(t, "10000", http.StatusNotFound, &output)
 	assert.Equal(t, "baseline not found", output.Error)
 }
 
 func TestBaselineDetailInvalid(t *testing.T) {
 	var output utils.ErrorResponse
-	testBaselineDetail(t, "/invalidID", http.StatusBadRequest, &output)
+	testBaselineDetail(t, "invalidID", http.StatusBadRequest, &output)
 	assert.Equal(t, "Invalid baseline_id: invalidID", output.Error)
 }
 
@@ -45,8 +45,7 @@ func TestBaselineDetailEmptyConfig(t *testing.T) {
 	core.SetupTest(t)
 	baselineID := database.CreateBaselineWithConfig(t, "", nil, nil, nil)
 	var output BaselineDetailResponse
-	url := fmt.Sprintf("/%d", baselineID)
-	testBaselineDetail(t, url, http.StatusOK, &output)
+	testBaselineDetail(t, fmt.Sprintf("%d", baselineID), http.StatusOK, &output)
 	assert.Equal(t, baselineID, output.Data.ID)
 	assert.Equal(t, "baseline", output.Data.Type)
 	assert.Equal(t, "temporary_baseline", output.Data.Attributes.Name)

--- a/manager/controllers/baseline_systems_export_test.go
+++ b/manager/controllers/baseline_systems_export_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestBaselineSystemsExportJSON(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/1/systems", nil, "application/json", BaselineSystemsExportHandler,
-		"/:baseline_id/systems")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id/systems", "1", "", nil, "application/json",
+		BaselineSystemsExportHandler)
 
 	var output []BaselineSystemsDBLookup
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -38,8 +38,8 @@ func TestBaselineSystemsExportJSON(t *testing.T) {
 
 func TestBaselineSystemsExportCSV(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/1/systems", nil, "text/csv", BaselineSystemsExportHandler,
-		"/:baseline_id/systems")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id/systems", "1", "", nil, "text/csv",
+		BaselineSystemsExportHandler)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := w.Body.String()
@@ -61,8 +61,8 @@ func TestBaselineSystemsExportCSV(t *testing.T) {
 
 func TestBaselineSystemsExportWrongFormat(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/1/systems", nil, "test-format", BaselineSystemsExportHandler,
-		"/:baseline_id/systems")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id/systems", "1", "", nil, "test-format",
+		BaselineSystemsExportHandler)
 
 	assert.Equal(t, http.StatusUnsupportedMediaType, w.Code)
 	body := w.Body.String()
@@ -71,8 +71,8 @@ func TestBaselineSystemsExportWrongFormat(t *testing.T) {
 
 func TestBaselineSystemsExportCSVFilter(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/1/systems?filter[display_name]=nonexistant", nil, "text/csv",
-		BaselineSystemsExportHandler, "/:baseline_id/systems")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id/systems", "1", "?filter[display_name]=nonexistant", nil,
+		"text/csv", BaselineSystemsExportHandler)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := w.Body.String()
@@ -88,8 +88,8 @@ func TestBaselineSystemsExportCSVFilter(t *testing.T) {
 
 func TestExportBaselineSystemsTags(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/1/systems?tags=ns1/k2=val2", nil, "application/json",
-		BaselineSystemsExportHandler, "/:baseline_id/systems")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id/systems", "1", "?tags=ns1/k2=val2", nil, "application/json",
+		BaselineSystemsExportHandler)
 
 	var output []BaselineSystemsDBLookup
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -100,8 +100,8 @@ func TestExportBaselineSystemsTags(t *testing.T) {
 
 func TestExportBaselineSystemsTagsInvalid(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/1/systems?tags=ns1/k3=val4&tags=invalidTag", nil, "application/json",
-		BaselineSystemsExportHandler, "/:baseline_id/systems")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id/systems", "1", "?tags=ns1/k3=val4&tags=invalidTag", nil,
+		"application/json", BaselineSystemsExportHandler)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -110,14 +110,9 @@ func TestExportBaselineSystemsTagsInvalid(t *testing.T) {
 
 func TestBaselineSystemsExportWorkloads(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath(
-		"GET",
-		"/1/systems?filter[system_profile][sap_system]=true&filter[system_profile][sap_sids]=ABC",
-		nil,
-		"application/json",
-		BaselineSystemsExportHandler,
-		"/:baseline_id/systems",
-	)
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id/systems", "1",
+		"?filter[system_profile][sap_system]=true&filter[system_profile][sap_sids]=ABC", nil, "application/json",
+		BaselineSystemsExportHandler)
 
 	var output []BaselineSystemsDBLookup
 	CheckResponse(t, w, http.StatusOK, &output)

--- a/manager/controllers/baseline_systems_remove_test.go
+++ b/manager/controllers/baseline_systems_remove_test.go
@@ -17,8 +17,8 @@ func testBaselineSystemsRemove(t *testing.T, body BaselineSystemsRemoveRequest, 
 		panic(err)
 	}
 
-	w := CreateRequestRouterWithParams("POST", "/systems/remove", bytes.NewBuffer(bodyJSON), "",
-		BaselineSystemsRemoveHandler, 1, "POST", "/systems/remove")
+	w := CreateRequestRouterWithParams("POST", "/systems/remove", "", "", bytes.NewBuffer(bodyJSON), "",
+		BaselineSystemsRemoveHandler, 1)
 
 	assert.Equal(t, status, w.Code)
 }

--- a/manager/controllers/baseline_systems_test.go
+++ b/manager/controllers/baseline_systems_test.go
@@ -9,9 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testBaselineSystems(t *testing.T, url string) BaselineSystemsResponse {
+func testBaselineSystems(t *testing.T, param, queryString string) BaselineSystemsResponse {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", url, nil, "", BaselineSystemsListHandler, "/:baseline_id/systems")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id/systems", param, queryString, nil, "",
+		BaselineSystemsListHandler)
 
 	var output BaselineSystemsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -20,7 +21,7 @@ func testBaselineSystems(t *testing.T, url string) BaselineSystemsResponse {
 }
 
 func TestBaselineSystemsDefault(t *testing.T) {
-	output := testBaselineSystems(t, "/1/systems")
+	output := testBaselineSystems(t, "1", "")
 
 	assert.Equal(t, 2, len(output.Data))
 	assert.Equal(t, "baseline_system", output.Data[0].Type)
@@ -42,7 +43,7 @@ func TestBaselineSystemsDefault(t *testing.T) {
 }
 
 func TestBaselinesystemsEmpty(t *testing.T) {
-	output := testBaselineSystems(t, "/3/systems")
+	output := testBaselineSystems(t, "3", "")
 
 	assert.Equal(t, 0, len(output.Data))
 	// links
@@ -58,7 +59,7 @@ func TestBaselinesystemsEmpty(t *testing.T) {
 }
 
 func TestBaselineSystemsOffsetLimit(t *testing.T) {
-	output := testBaselineSystems(t, "/1/systems?offset=0&limit=1")
+	output := testBaselineSystems(t, "1", "?offset=0&limit=1")
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, 0, output.Meta.Offset)
 	assert.Equal(t, 1, output.Meta.Limit)
@@ -66,7 +67,7 @@ func TestBaselineSystemsOffsetLimit(t *testing.T) {
 }
 
 func TestBaselineSystemsUnlimited(t *testing.T) {
-	output := testBaselineSystems(t, "/1/systems?offset=0&limit=-1")
+	output := testBaselineSystems(t, "1", "?offset=0&limit=-1")
 	assert.Equal(t, 2, len(output.Data))
 	assert.Equal(t, -1, output.Meta.Limit)
 	assert.Equal(t, 2, output.Meta.TotalItems)
@@ -74,8 +75,8 @@ func TestBaselineSystemsUnlimited(t *testing.T) {
 
 func TestBaselineSystemOffsetOverflow(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/1/systems?offset=10&limit=4", nil, "", BaselineSystemsListHandler,
-		"/:baseline_id/systems")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id/systems", "1", "?offset=10&limit=4", nil, "",
+		BaselineSystemsListHandler)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -83,28 +84,28 @@ func TestBaselineSystemOffsetOverflow(t *testing.T) {
 }
 
 func TestBaselinesFilterDisplayName(t *testing.T) {
-	output := testBaselineSystems(t, "/1/systems?filter[display_name]=00000000-0000-0000-0000-000000000001")
+	output := testBaselineSystems(t, "1", "?filter[display_name]=00000000-0000-0000-0000-000000000001")
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].InventoryID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].Attributes.DisplayName)
 }
 
 func TestBaselinesFilterTag(t *testing.T) {
-	output := testBaselineSystems(t, "/1/systems?tags=ns1/k3=val3")
+	output := testBaselineSystems(t, "1", "?tags=ns1/k3=val3")
 	assert.Equal(t, 1, len(output.Data))
 }
 
 func TestBaselineSystemsWrongSort(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/1/systems?sort=unknown_key", nil, "", BaselineSystemsListHandler,
-		"/:baseline_id/systems")
+	w := CreateRequestRouterWithPath("GET", "/:baseline_id/systems", "1", "?sort=unknown_key", nil, "",
+		BaselineSystemsListHandler)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 //nolint:lll
 func TestBaselineSystemsSearch(t *testing.T) {
-	output := testBaselineSystems(t, "/1/systems?search=00000000-0000-0000-0000-000000000001")
+	output := testBaselineSystems(t, "1", "?search=00000000-0000-0000-0000-000000000001")
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, "baseline_system", output.Data[0].Type)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].InventoryID)

--- a/manager/controllers/baseline_update_test.go
+++ b/manager/controllers/baseline_update_test.go
@@ -33,10 +33,8 @@ func TestUpdateBaseline(t *testing.T) {
         "config": {"to_time": "2022-12-31T12:00:00-04:00"},
 		"description": "desc"
 	}`
-
-	path := fmt.Sprintf(`/%v`, baselineID)
-	w := CreateRequestRouterWithParams("PUT", path, bytes.NewBufferString(data), "", BaselineUpdateHandler, 1,
-		"PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", fmt.Sprint(baselineID), "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var resp UpdateBaselineResponse
 	CheckResponse(t, w, http.StatusOK, &resp)
@@ -56,9 +54,8 @@ func TestUpdateBaselineWithEmptyAssociations(t *testing.T) {
 
 	baselineID := database.CreateBaseline(t, "", testingInventoryIDs, nil)
 	data := `{"inventory_ids": {}}`
-	path := fmt.Sprintf(`/%v`, baselineID)
-	w := CreateRequestRouterWithParams("PUT", path, bytes.NewBufferString(data), "", BaselineUpdateHandler, 1,
-		"PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", fmt.Sprint(baselineID), "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var resp UpdateBaselineResponse
 	CheckResponse(t, w, http.StatusOK, &resp)
@@ -85,9 +82,8 @@ func TestUpdateBaselineShouldRemoveAllAssociations(t *testing.T) {
 			"00000000-0000-0000-0000-000000000007": false
 		}
 	}`
-	path := fmt.Sprintf(`/%v`, baselineID)
-	w := CreateRequestRouterWithParams("PUT", path, bytes.NewBufferString(data), "", BaselineUpdateHandler, 1,
-		"PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", fmt.Sprint(baselineID), "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var resp UpdateBaselineResponse
 	CheckResponse(t, w, http.StatusOK, &resp)
@@ -102,8 +98,8 @@ func TestUpdateBaselineInvalidPayload(t *testing.T) {
 	core.SetupTest(t)
 
 	data := `{"name": 0}`
-	w := CreateRequestRouterWithParams("PUT", "/1", bytes.NewBufferString(data), "", BaselineUpdateHandler, 1,
-		"PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", "1", "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
 	assert.True(t, strings.Contains(errResp.Error, "name of type string"))
@@ -120,9 +116,8 @@ func TestUpdateBaselineInvalidSystem(t *testing.T) {
 			"00000000-0000-0000-0000-000000000009": true
 		}
 	}`
-	path := fmt.Sprintf(`/%v`, baselineID)
-	w := CreateRequestRouterWithParams("PUT", path, bytes.NewBufferString(data), "", BaselineUpdateHandler, 1,
-		"PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", fmt.Sprint(baselineID), "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusNotFound, &errResp)
@@ -136,9 +131,8 @@ func TestUpdateBaselineNullValues(t *testing.T) {
 
 	baselineID := database.CreateBaseline(t, "", testingInventoryIDs, nil)
 	data := `{}`
-	path := fmt.Sprintf(`/%v`, baselineID)
-	w := CreateRequestRouterWithParams("PUT", path, bytes.NewBufferString(data), "", BaselineUpdateHandler, 1,
-		"PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", fmt.Sprint(baselineID), "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var resp UpdateBaselineResponse
 	CheckResponse(t, w, http.StatusOK, &resp)
@@ -151,8 +145,8 @@ func TestUpdateBaselineNullValues(t *testing.T) {
 
 func TestUpdateBaselineInvalidBaselineID(t *testing.T) {
 	core.SetupTestEnvironment()
-	w := CreateRequestRouterWithParams("PUT", "/invalidBaseline", bytes.NewBufferString("{}"), "", BaselineUpdateHandler,
-		1, "PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", "invalidBaseline", "", bytes.NewBufferString("{}"), "",
+		BaselineUpdateHandler, 1)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -162,8 +156,8 @@ func TestUpdateBaselineInvalidBaselineID(t *testing.T) {
 func TestUpdateBaselineDuplicatedName(t *testing.T) {
 	core.SetupTest(t)
 	data := `{"name": "baseline_1-2"}`
-	w := CreateRequestRouterWithParams("PUT", "/1", bytes.NewBufferString(data), "", BaselineUpdateHandler, 1,
-		"PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", "1", "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var errResp utils.ErrorResponse
 	ParseResponseBody(t, w.Body.Bytes(), &errResp)
@@ -183,8 +177,8 @@ func TestUpdateBaselineSystems(t *testing.T) {
 			"00000000-0000-0000-0000-000000000002": true
 		}
 	}`
-	w := CreateRequestRouterWithParams("PUT", "/1", bytes.NewBufferString(data), "", BaselineUpdateHandler, 1,
-		"PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", "1", "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var resp UpdateBaselineResponse
 	CheckResponse(t, w, http.StatusOK, &resp)
@@ -203,8 +197,8 @@ func TestUpdateBaselineSystemsInvalid(t *testing.T) {
 			"00000000-0000-0000-0000-000000000003": false
 		}
 	}`
-	w := CreateRequestRouterWithParams("PUT", "/1", bytes.NewBufferString(data), "", BaselineUpdateHandler, 1,
-		"PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", "1", "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -219,8 +213,8 @@ func TestUpdateBaselineEmptyDescription(t *testing.T) {
 	defer database.DeleteBaseline(t, baselineID)
 
 	data := `{"description": ""}`
-	w := CreateRequestRouterWithParams("PUT", fmt.Sprintf(`/%v`, baselineID), bytes.NewBufferString(data), "",
-		BaselineUpdateHandler, 1, "PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", fmt.Sprint(baselineID), "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var resp UpdateBaselineResponse
 	CheckResponse(t, w, http.StatusOK, &resp)
@@ -236,8 +230,8 @@ func TestUpdateBaselineNilDescription(t *testing.T) {
 	defer database.DeleteBaseline(t, baselineID)
 
 	data := `{"name": "new_name", "description": null}`
-	w := CreateRequestRouterWithParams("PUT", fmt.Sprintf(`/%v`, baselineID), bytes.NewBufferString(data), "",
-		BaselineUpdateHandler, 1, "PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", fmt.Sprint(baselineID), "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var resp UpdateBaselineResponse
 	CheckResponse(t, w, http.StatusOK, &resp)
@@ -247,8 +241,8 @@ func TestUpdateBaselineNilDescription(t *testing.T) {
 
 	// missing description
 	data = `{"name": "new_name"}`
-	w = CreateRequestRouterWithParams("PUT", fmt.Sprintf(`/%v`, baselineID), bytes.NewBufferString(data), "",
-		BaselineUpdateHandler, 1, "PUT", "/:baseline_id")
+	w = CreateRequestRouterWithParams("PUT", "/:baseline_id", fmt.Sprint(baselineID), "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	CheckResponse(t, w, http.StatusOK, &resp)
 	assert.Equal(t, baselineID, resp.BaselineID)
@@ -264,8 +258,8 @@ func TestUpdateBaselineSpacesDescription(t *testing.T) {
 	defer database.DeleteBaseline(t, baselineID)
 
 	data := `{"description": "   "}`
-	w := CreateRequestRouterWithParams("PUT", fmt.Sprintf(`/%v`, baselineID), bytes.NewBufferString(data), "",
-		BaselineUpdateHandler, 1, "PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", fmt.Sprint(baselineID), "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 
 	var err utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &err)
@@ -297,8 +291,8 @@ func TestUpdateBaselineSatelliteSystem(t *testing.T) {
 		}
 	}`
 
-	w := CreateRequestRouterWithParams("PUT", fmt.Sprintf("/%v", baselineID), bytes.NewBufferString(data), "",
-		BaselineUpdateHandler, 1, "PUT", "/:baseline_id")
+	w := CreateRequestRouterWithParams("PUT", "/:baseline_id", fmt.Sprint(baselineID), "", bytes.NewBufferString(data), "",
+		BaselineUpdateHandler, 1)
 	var err utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &err)
 }

--- a/manager/controllers/common_test.go
+++ b/manager/controllers/common_test.go
@@ -59,10 +59,9 @@ func CreateRequestRouterWithPath(method, routerPath, param, queryString string, 
 }
 
 // Create request and initialize router with account
-func CreateRequestRouterWithAccount(method string, url string, body io.Reader, contentType string,
-	handler gin.HandlerFunc, routerPath string, routerAccount int,
-	contextKVs ...core.ContextKV) (w *httptest.ResponseRecorder) {
-	w, req := prepareRequest(method, url, body, contentType)
+func CreateRequestRouterWithAccount(method, routerPath, param, queryString string, body io.Reader, contentType string,
+	handler gin.HandlerFunc, routerAccount int, contextKVs ...core.ContextKV) (w *httptest.ResponseRecorder) {
+	w, req := prepareRequest(method, getURLFromRouterPath(routerPath, param, queryString), body, contentType)
 	core.InitRouterWithAccount(handler, routerPath, routerAccount, contextKVs...).ServeHTTP(w, req)
 	return w
 }

--- a/manager/controllers/common_test.go
+++ b/manager/controllers/common_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -16,6 +17,12 @@ func acceptContentType(req *http.Request, ct string) {
 	if ct != "" {
 		req.Header.Add("Accept", ct)
 	}
+}
+
+// Fill params and append query string to routerPath to get url
+func getURLFromRouterPath(routerPath, param, queryString string) string {
+	pattern := regexp.MustCompile(":[a-zA-Z0-9_]+")
+	return pattern.ReplaceAllString(routerPath, param) + queryString
 }
 
 // Init request
@@ -36,11 +43,10 @@ func CreateRequest(method string, url string, body io.Reader, contentType string
 }
 
 // Create request and initialize router with params
-func CreateRequestRouterWithParams(method string, url string, body io.Reader, contentType string,
-	handler gin.HandlerFunc, routerAccount int, routerMethod string, routerPath string,
-	contextKVs ...core.ContextKV) (w *httptest.ResponseRecorder) {
-	w, req := prepareRequest(method, url, body, contentType)
-	core.InitRouterWithParams(handler, routerAccount, routerMethod, routerPath, contextKVs...).ServeHTTP(w, req)
+func CreateRequestRouterWithParams(method, routerPath, param, queryString string, body io.Reader, contentType string,
+	handler gin.HandlerFunc, routerAccount int, contextKVs ...core.ContextKV) (w *httptest.ResponseRecorder) {
+	w, req := prepareRequest(method, getURLFromRouterPath(routerPath, param, queryString), body, contentType)
+	core.InitRouterWithParams(handler, routerAccount, method, routerPath, contextKVs...).ServeHTTP(w, req)
 	return w
 }
 

--- a/manager/controllers/common_test.go
+++ b/manager/controllers/common_test.go
@@ -51,9 +51,9 @@ func CreateRequestRouterWithParams(method, routerPath, param, queryString string
 }
 
 // Create request and initialize router with path
-func CreateRequestRouterWithPath(method string, url string, body io.Reader, contentType string,
-	handler gin.HandlerFunc, routerPath string, contextKVs ...core.ContextKV) (w *httptest.ResponseRecorder) {
-	w, req := prepareRequest(method, url, body, contentType)
+func CreateRequestRouterWithPath(method, routerPath, param, queryString string, body io.Reader, contentType string,
+	handler gin.HandlerFunc, contextKVs ...core.ContextKV) (w *httptest.ResponseRecorder) {
+	w, req := prepareRequest(method, getURLFromRouterPath(routerPath, param, queryString), body, contentType)
 	core.InitRouterWithPath(handler, routerPath, contextKVs...).ServeHTTP(w, req)
 	return w
 }

--- a/manager/controllers/package_detail_test.go
+++ b/manager/controllers/package_detail_test.go
@@ -12,8 +12,7 @@ import (
 // nolint: dupl
 func TestLatestPackage(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/packages/kernel", nil, "", PackageDetailHandler, 3,
-		"GET", "/packages/:package_name")
+	w := CreateRequestRouterWithParams("GET", "/packages/:package_name", "kernel", "", nil, "", PackageDetailHandler, 3)
 
 	var output PackageDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -29,8 +28,8 @@ func TestLatestPackage(t *testing.T) {
 // nolint: dupl
 func TestEvraPackage(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/packages/kernel-5.6.13-200.fc31.x86_64", nil, "",
-		PackageDetailHandler, 3, "GET", "/packages/:package_name")
+	w := CreateRequestRouterWithParams("GET", "/packages/:package_name", "kernel-5.6.13-200.fc31.x86_64", "", nil, "",
+		PackageDetailHandler, 3)
 
 	var output PackageDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -45,8 +44,7 @@ func TestEvraPackage(t *testing.T) {
 
 func TestNonExitentPackage(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/packages/python", nil, "", PackageDetailHandler, 3,
-		"GET", "/packages/:package_name")
+	w := CreateRequestRouterWithParams("GET", "/packages/:package_name", "python", "", nil, "", PackageDetailHandler, 3)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -55,8 +53,8 @@ func TestNonExitentPackage(t *testing.T) {
 
 func TestNonExitentEvra(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/packages/kernel-5.6.13-202.fc31.x86_64", nil, "",
-		PackageDetailHandler, 3, "GET", "/packages/:package_name")
+	w := CreateRequestRouterWithParams("GET", "/packages/:package_name", "kernel-5.6.13-202.fc31.x86_64", "", nil, "",
+		PackageDetailHandler, 3)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusNotFound, &errResp)
@@ -74,8 +72,8 @@ func TestPackageDetailNoPackage(t *testing.T) {
 
 func TestPackageDetailFiltering(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/packages/kernel-5.6.13-202.fc31.x86_64?filter[filter]=abcd",
-		nil, "", PackageDetailHandler, 3, "GET", "/packages/:package_name")
+	w := CreateRequestRouterWithParams("GET", "/packages/:package_name", "kernel-5.6.13-202.fc31.x86_64",
+		"?filter[filter]=abcd", nil, "", PackageDetailHandler, 3)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)

--- a/manager/controllers/package_systems_export_test.go
+++ b/manager/controllers/package_systems_export_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestPackageSystemsExportHandlerJSON(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/kernel/systems?sort=id", nil, "application/json",
-		PackageSystemsExportHandler, 3, "GET", "/:package_name/systems")
+	w := CreateRequestRouterWithParams("GET", "/:package_name/systems", "kernel", "?sort=id", nil, "application/json",
+		PackageSystemsExportHandler, 3)
 
 	var output []PackageSystemItemV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -28,8 +28,8 @@ func TestPackageSystemsExportHandlerJSON(t *testing.T) {
 
 func TestPackageSystemsExportHandlerCSV(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/kernel/systems?sort=id", nil, "text/csv",
-		PackageSystemsExportHandler, 3, "GET", "/:package_name/systems")
+	w := CreateRequestRouterWithParams("GET", "/:package_name/systems", "kernel", "?sort=id", nil, "text/csv",
+		PackageSystemsExportHandler, 3)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := w.Body.String()
@@ -49,8 +49,8 @@ func TestPackageSystemsExportHandlerCSV(t *testing.T) {
 
 func TestPackageSystemsExportInvalidName(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/unknown_package/systems", nil, "text/csv",
-		PackageSystemsExportHandler, 3, "GET", "/:package_name/systems")
+	w := CreateRequestRouterWithParams("GET", "/:package_name/systems", "unknown_package", "", nil, "text/csv",
+		PackageSystemsExportHandler, 3)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/manager/controllers/package_systems_test.go
+++ b/manager/controllers/package_systems_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPackageSystems(t *testing.T) {
-	output := testPackageSystems(t, "/kernel/systems?sort=id", 3)
+	output := testPackageSystems(t, "kernel", "?sort=id", 3)
 	assert.Equal(t, 3, len(output.Data))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000012", output.Data[0].ID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000012", output.Data[0].DisplayName)
@@ -23,51 +23,51 @@ func TestPackageSystems(t *testing.T) {
 }
 
 func TestPackageIDsSystems(t *testing.T) {
-	output := testPackageIDsSystems(t, "/kernel/systems?sort=id", 3)
+	output := testPackageIDsSystems(t, "kernel", "?sort=id", 3)
 	assert.Equal(t, 3, len(output.IDs))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000012", output.IDs[0])
 }
 
 func TestPackageSystemsWrongOffset(t *testing.T) {
-	doTestWrongOffset(t, "/:package_name/systems", "/kernel/systems?offset=1000", PackageSystemsListHandler)
+	doTestWrongOffset(t, "/:package_name/systems", "kernel", "?offset=1000", PackageSystemsListHandler)
 }
 
 func TestPackageSystemsTagsInvalid(t *testing.T) {
-	code, errResp := testPackageSystemsError(t, "/kernel/systems?tags=ns1/k3=val4&tags=invalidTag", 3)
+	code, errResp := testPackageSystemsError(t, "kernel", "?tags=ns1/k3=val4&tags=invalidTag", 3)
 	assert.Equal(t, http.StatusBadRequest, code)
 	assert.Equal(t, fmt.Sprintf(InvalidTagMsg, "invalidTag"), errResp.Error)
 }
 
 func TestPackageSystemsInvalidName(t *testing.T) {
-	code, errResp := testPackageSystemsError(t, "/unknown_package/systems", 3)
+	code, errResp := testPackageSystemsError(t, "unknown_package", "", 3)
 	assert.Equal(t, http.StatusNotFound, code)
 	assert.Equal(t, "package not found", errResp.Error)
 }
 
-func testPackageSystems(t *testing.T, url string, account int) PackageSystemsResponseV3 {
+func testPackageSystems(t *testing.T, param, queryString string, account int) PackageSystemsResponseV3 {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", url, nil, "", PackageSystemsListHandler, account, "GET",
-		"/:package_name/systems")
+	w := CreateRequestRouterWithParams("GET", "/:package_name/systems", param, queryString, nil, "",
+		PackageSystemsListHandler, account)
 
 	var output PackageSystemsResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
 	return output
 }
 
-func testPackageIDsSystems(t *testing.T, url string, account int) IDsResponse {
+func testPackageIDsSystems(t *testing.T, param, queryString string, account int) IDsResponse {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", url, nil, "", PackageSystemsListIDsHandler, account, "GET",
-		"/:package_name/systems")
+	w := CreateRequestRouterWithParams("GET", "/:package_name/systems", param, queryString, nil, "",
+		PackageSystemsListIDsHandler, account)
 
 	var output IDsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	return output
 }
 
-func testPackageSystemsError(t *testing.T, url string, account int) (int, utils.ErrorResponse) {
+func testPackageSystemsError(t *testing.T, param, queryString string, account int) (int, utils.ErrorResponse) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", url, nil, "", PackageSystemsListHandler, account, "GET",
-		"/:package_name/systems")
+	w := CreateRequestRouterWithParams("GET", "/:package_name/systems", param, queryString, nil, "",
+		PackageSystemsListHandler, account)
 
 	var errResp utils.ErrorResponse
 	ParseResponseBody(t, w.Body.Bytes(), &errResp)
@@ -76,8 +76,8 @@ func testPackageSystemsError(t *testing.T, url string, account int) (int, utils.
 
 func TestPackageSystemsTagsInMetadata(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/kernel/systems?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "",
-		PackageSystemsListHandler, 3, "GET", "/:package_name/systems")
+	w := CreateRequestRouterWithParams("GET", "/:package_name/systems", "kernel", "?tags=ns1/k3=val4&tags=ns1/k1=val1",
+		nil, "", PackageSystemsListHandler, 3)
 
 	var output PackageSystemsResponseV3
 	ParseResponseBody(t, w.Body.Bytes(), &output)

--- a/manager/controllers/package_versions_test.go
+++ b/manager/controllers/package_versions_test.go
@@ -11,8 +11,8 @@ import (
 // nolint: dupl
 func TestPackageVersions(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/firefox/versions", nil, "", PackageVersionsListHandler, 3,
-		"GET", "/:package_name/versions")
+	w := CreateRequestRouterWithParams("GET", "/:package_name/versions", "firefox", "", nil, "",
+		PackageVersionsListHandler, 3)
 
 	var output PackageVersionsResponse
 	assert.Greater(t, len(w.Body.Bytes()), 0)
@@ -23,8 +23,8 @@ func TestPackageVersions(t *testing.T) {
 
 func TestPackageVersionsInvalidName(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/not-existing/versions", nil, "", PackageVersionsListHandler, 3,
-		"GET", "/:package_name/versions")
+	w := CreateRequestRouterWithParams("GET", "/:package_name/versions", "not-existing", "", nil, "",
+		PackageVersionsListHandler, 3)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }

--- a/manager/controllers/packages_export_test.go
+++ b/manager/controllers/packages_export_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestPackageExportJSON(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/", nil, "application/json", PackagesExportHandler, 3, "GET", "/")
+	w := CreateRequestRouterWithParams("GET", "/", "", "", nil, "application/json", PackagesExportHandler, 3)
 
 	var output []PackageItem
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -21,7 +21,7 @@ func TestPackageExportJSON(t *testing.T) {
 
 func TestPackageExportCSV(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/", nil, "text/csv", PackagesExportHandler, 3, "GET", "/")
+	w := CreateRequestRouterWithParams("GET", "/", "", "", nil, "text/csv", PackagesExportHandler, 3)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := w.Body.String()

--- a/manager/controllers/packages_test.go
+++ b/manager/controllers/packages_test.go
@@ -12,7 +12,7 @@ import (
 
 func doTestPackagesBytes(t *testing.T, q string) (resp []byte, status int) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", q, nil, "", PackagesListHandler, 3, "GET", "/")
+	w := CreateRequestRouterWithParams("GET", "/", "", q, nil, "", PackagesListHandler, 3)
 
 	return w.Body.Bytes(), w.Code
 }
@@ -27,29 +27,29 @@ func doTestPackages(t *testing.T, q string) PackagesResponse {
 }
 
 func TestPackagesFilterInstalled(t *testing.T) {
-	output := doTestPackages(t, "/?filter[systems_installed]=44")
+	output := doTestPackages(t, "?filter[systems_installed]=44")
 	assert.Equal(t, 0, len(output.Data))
 }
 
 func TestPackagesEmptyResponse(t *testing.T) {
-	respBytes, code := doTestPackagesBytes(t, "/?filter[systems_installed]=44")
+	respBytes, code := doTestPackagesBytes(t, "?filter[systems_installed]=44")
 	assert.Equal(t, http.StatusOK, code)
 	respStr := string(respBytes)
 	assert.Equal(t, "{\"data\":[]", respStr[:10])
 }
 
 func TestPackagesFilterInstallable(t *testing.T) {
-	output := doTestPackages(t, "/?filter[systems_installable]=4")
+	output := doTestPackages(t, "?filter[systems_installable]=4")
 	assert.Equal(t, 0, len(output.Data))
 }
 
 func TestPackagesFilterApplicable(t *testing.T) {
-	output := doTestPackages(t, "/?filter[systems_applicable]=4")
+	output := doTestPackages(t, "?filter[systems_applicable]=4")
 	assert.Equal(t, 0, len(output.Data))
 }
 
 func TestPackagesFilterSummary(t *testing.T) {
-	output := doTestPackages(t, `/?filter[summary]=Mozilla Firefox Web browser`)
+	output := doTestPackages(t, `?filter[summary]=Mozilla Firefox Web browser`)
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, "firefox", output.Data[0].Name)
 	assert.Equal(t, 2, output.Data[0].SystemsInstalled)
@@ -58,7 +58,7 @@ func TestPackagesFilterSummary(t *testing.T) {
 }
 
 func TestPackagesFilterSAP(t *testing.T) {
-	output := doTestPackages(t, "/?filter[system_profile][sap_system]=true")
+	output := doTestPackages(t, "?filter[system_profile][sap_system]=true")
 	assert.Equal(t, 4, len(output.Data))
 	assert.Equal(t, "kernel", output.Data[3].Name)
 	assert.Equal(t, 2, output.Data[3].SystemsInstalled)
@@ -67,15 +67,15 @@ func TestPackagesFilterSAP(t *testing.T) {
 }
 
 func TestSearchPackages(t *testing.T) {
-	output := doTestPackages(t, "/?search=fire")
+	output := doTestPackages(t, "?search=fire")
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, "firefox", output.Data[0].Name)
 }
 
 func TestPackageTagsInvalid(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/?tags=ns1/k3=val4&tags=invalidTag", nil, "",
-		PackagesListHandler, 3, "GET", "/")
+	w := CreateRequestRouterWithParams("GET", "/", "", "?tags=ns1/k3=val4&tags=invalidTag", nil, "",
+		PackagesListHandler, 3)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -83,13 +83,13 @@ func TestPackageTagsInvalid(t *testing.T) {
 }
 
 func TestPackagesWrongOffset(t *testing.T) {
-	doTestWrongOffset(t, "/", "/?offset=1000", PackagesListHandler)
+	doTestWrongOffset(t, "/", "", "?offset=1000", PackagesListHandler)
 }
 
 func TestPackageTagsInMetadata(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "",
-		PackagesListHandler, 3, "GET", "/")
+	w := CreateRequestRouterWithParams("GET", "/", "", "?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "",
+		PackagesListHandler, 3)
 
 	var output PackagesResponse
 	CheckResponse(t, w, http.StatusOK, &output)

--- a/manager/controllers/system_advisories_export_test.go
+++ b/manager/controllers/system_advisories_export_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestSystemAdvisoriesExportJSON(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/00000000-0000-0000-0000-000000000001", nil,
-		"application/json", SystemAdvisoriesExportHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001", "", nil,
+		"application/json", SystemAdvisoriesExportHandler)
 
 	var output []AdvisoriesDBLookupV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -22,8 +22,8 @@ func TestSystemAdvisoriesExportJSON(t *testing.T) {
 
 func TestSystemAdvisoriesExportCSV(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/00000000-0000-0000-0000-000000000001", nil,
-		"text/csv", SystemAdvisoriesExportHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001", "", nil,
+		"text/csv", SystemAdvisoriesExportHandler)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := w.Body.String()
@@ -38,8 +38,8 @@ func TestSystemAdvisoriesExportCSV(t *testing.T) {
 
 func TestUnknownSystemAdvisoriesExport(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/unknownsystem", nil, "text/csv", SystemAdvisoriesExportHandler,
-		"/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "unknownsystem", "", nil, "text/csv",
+		SystemAdvisoriesExportHandler)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/manager/controllers/system_advisories_test.go
+++ b/manager/controllers/system_advisories_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestSystemAdvisoriesDefault(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/00000000-0000-0000-0000-000000000001", nil, "",
-		SystemAdvisoriesHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001", "", nil, "",
+		SystemAdvisoriesHandler)
 
 	var output SystemAdvisoriesResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -33,8 +33,8 @@ func TestSystemAdvisoriesDefault(t *testing.T) {
 
 func TestSystemAdvisoriesIDsDefault(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/00000000-0000-0000-0000-000000000001", nil, "",
-		SystemAdvisoriesIDsHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001", "", nil, "",
+		SystemAdvisoriesIDsHandler)
 
 	var output IDsStatusResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -47,24 +47,24 @@ func TestSystemAdvisoriesIDsDefault(t *testing.T) {
 
 func TestSystemAdvisoriesNotFound(t *testing.T) { //nolint:dupl
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/nonexistant/advisories", nil, "",
-		SystemAdvisoriesHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "nonexistant/advisories", "", nil, "",
+		SystemAdvisoriesHandler)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestSystemAdvisoriesIDsNotFound(t *testing.T) { //nolint:dupl
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/nonexistant/advisories", nil, "",
-		SystemAdvisoriesIDsHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "nonexistant/advisories", "", nil, "",
+		SystemAdvisoriesIDsHandler)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestSystemAdvisoriesOffsetLimit(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/00000000-0000-0000-0000-000000000001?offset=4&limit=3", nil, "",
-		SystemAdvisoriesHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001",
+		"?offset=4&limit=3", nil, "", SystemAdvisoriesHandler)
 
 	var output SystemAdvisoriesResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -74,8 +74,8 @@ func TestSystemAdvisoriesOffsetLimit(t *testing.T) {
 
 func TestSystemAdvisoriesIDsOffsetLimit(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/00000000-0000-0000-0000-000000000001?offset=4&limit=3", nil, "",
-		SystemAdvisoriesIDsHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001",
+		"?offset=4&limit=3", nil, "", SystemAdvisoriesIDsHandler)
 
 	var output IDsStatusResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -88,8 +88,8 @@ func TestSystemAdvisoriesIDsOffsetLimit(t *testing.T) {
 
 func TestSystemAdvisoriesOffsetOverflow(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/00000000-0000-0000-0000-000000000001?offset=100&limit=3", nil, "",
-		SystemAdvisoriesHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001",
+		"?offset=100&limit=3", nil, "", SystemAdvisoriesHandler)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
@@ -104,8 +104,8 @@ func TestSystemAdvisoriesPossibleSorts(t *testing.T) {
 			// this field is not sortable, skip it
 			continue
 		}
-		w := CreateRequestRouterWithPath("GET", fmt.Sprintf("/00000000-0000-0000-0000-000000000001?sort=%v", sort),
-			nil, "", SystemAdvisoriesHandler, "/:inventory_id")
+		w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001",
+			fmt.Sprintf("?sort=%v", sort), nil, "", SystemAdvisoriesHandler)
 
 		var output SystemAdvisoriesResponse
 		CheckResponse(t, w, http.StatusOK, &output)
@@ -115,16 +115,16 @@ func TestSystemAdvisoriesPossibleSorts(t *testing.T) {
 
 func TestSystemAdvisoriesWrongSort(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/00000000-0000-0000-0000-000000000001?sort=unknown_key", nil, "",
-		SystemAdvisoriesHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001",
+		"?sort=unknown_key", nil, "", SystemAdvisoriesHandler)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestSystemAdvisoriesSearch(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/00000000-0000-0000-0000-000000000001?search=h-3", nil, "",
-		SystemAdvisoriesHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001",
+		"?search=h-3", nil, "", SystemAdvisoriesHandler)
 
 	var output SystemAdvisoriesResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -146,7 +146,7 @@ func TestSystemAdvisoriesWrongOffset(t *testing.T) {
 
 func TestSystemAdvisoriesExportUnknown(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/unknownsystem", nil, "", SystemAdvisoriesHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "unknownsystem", "", nil, "", SystemAdvisoriesHandler)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/manager/controllers/system_advisories_test.go
+++ b/manager/controllers/system_advisories_test.go
@@ -140,7 +140,7 @@ func TestSystemAdvisoriesSearch(t *testing.T) {
 }
 
 func TestSystemAdvisoriesWrongOffset(t *testing.T) {
-	doTestWrongOffset(t, "/:inventory_id", "/00000000-0000-0000-0000-000000000001?offset=1000",
+	doTestWrongOffset(t, "/:inventory_id", "00000000-0000-0000-0000-000000000001", "?offset=1000",
 		SystemAdvisoriesHandler)
 }
 

--- a/manager/controllers/system_delete_test.go
+++ b/manager/controllers/system_delete_test.go
@@ -27,29 +27,28 @@ func TestInitDelete(t *testing.T) {
 
 func TestSystemDelete(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("DELETE", "/"+del, nil, "", SystemDeleteHandler, 1, "DELETE", "/:inventory_id")
+	w := CreateRequestRouterWithParams("DELETE", "/:inventory_id", del, "", nil, "", SystemDeleteHandler, 1)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestSystemDeleteWrongAccount(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("DELETE", "/"+del, nil, "", SystemDeleteHandler, 2, "DELETE", "/:inventory_id")
+	w := CreateRequestRouterWithParams("DELETE", "/:inventory_id", del, "", nil, "", SystemDeleteHandler, 2)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestSystemDeleteNotFound(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("DELETE", "/"+del, nil, "", SystemDeleteHandler, 1, "DELETE", "/:inventory_id")
+	w := CreateRequestRouterWithParams("DELETE", "/:inventory_id", del, "", nil, "", SystemDeleteHandler, 1)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestSystemDeleteUnknown(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("DELETE", "/unknownsystem", nil, "", SystemDeleteHandler, 1,
-		"DELETE", "/:inventory_id")
+	w := CreateRequestRouterWithParams("DELETE", "/:inventory_id", "unknownsystem", "", nil, "", SystemDeleteHandler, 1)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/manager/controllers/system_detail_test.go
+++ b/manager/controllers/system_detail_test.go
@@ -39,8 +39,8 @@ func TestSystemDetailDefault1(t *testing.T) {
 func TestSystemDetailDefault2(t *testing.T) {
 	core.SetupTest(t)
 	// get system with some installable/updatable packages
-	w := CreateRequestRouterWithAccount("GET", "/00000000-0000-0000-0000-000000000012", nil, "",
-		SystemDetailHandler, "/:inventory_id", 3)
+	w := CreateRequestRouterWithAccount("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000012", "", nil, "",
+		SystemDetailHandler, 3)
 
 	var output SystemDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -69,8 +69,8 @@ func TestSystemDetailNotFound(t *testing.T) {
 
 func TestSystemsNoRHSM(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithAccount("GET", "/00000000-0000-0000-0000-000000000014", nil, "",
-		SystemDetailHandler, "/:inventory_id", 3)
+	w := CreateRequestRouterWithAccount("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000014", "", nil, "",
+		SystemDetailHandler, 3)
 
 	var output SystemDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -81,8 +81,8 @@ func TestSystemsNoRHSM(t *testing.T) {
 
 func TestRHSMLessThanOS(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithAccount("GET", "/00000000-0000-0000-0000-000000000003", nil, "",
-		SystemDetailHandler, "/:inventory_id", 1)
+	w := CreateRequestRouterWithAccount("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000003", "", nil, "",
+		SystemDetailHandler, 1)
 
 	var output SystemDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -94,8 +94,8 @@ func TestRHSMLessThanOS(t *testing.T) {
 
 func TestRHSMGreaterThanOS(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithAccount("GET", "/00000000-0000-0000-0000-000000000004", nil, "",
-		SystemDetailHandler, "/:inventory_id", 1)
+	w := CreateRequestRouterWithAccount("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000004", "", nil, "",
+		SystemDetailHandler, 1)
 
 	var output SystemDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -107,14 +107,14 @@ func TestRHSMGreaterThanOS(t *testing.T) {
 
 func TestSystemUnknown(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithAccount("GET", "/unknownsystem", nil, "", SystemDetailHandler, "/:inventory_id", 1)
+	w := CreateRequestRouterWithAccount("GET", "/:inventory_id", "unknownsystem", "", nil, "", SystemDetailHandler, 1)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestSystemDetailFiltering(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithAccount("GET", "/00000000-0000-0000-0000-000000000001?filter[filter]=abcd",
-		nil, "", SystemDetailHandler, "/:inventory_id", 1)
+	w := CreateRequestRouterWithAccount("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001",
+		"?filter[filter]=abcd", nil, "", SystemDetailHandler, 1)
 
 	var errResp utils.ErrorResponse
 	ParseResponseBody(t, w.Body.Bytes(), &errResp)

--- a/manager/controllers/system_detail_test.go
+++ b/manager/controllers/system_detail_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestSystemDetailDefault1(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/00000000-0000-0000-0000-000000000001", nil, "",
-		SystemDetailHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "00000000-0000-0000-0000-000000000001", "", nil, "",
+		SystemDetailHandler)
 
 	var output SystemDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -59,8 +59,8 @@ func TestSystemDetailNoIdProvided(t *testing.T) {
 
 func TestSystemDetailNotFound(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", "/ffffffff-ffff-ffff-ffff-ffffffffffff", nil, "",
-		SystemDetailHandler, "/:inventory_id")
+	w := CreateRequestRouterWithPath("GET", "/:inventory_id", "ffffffff-ffff-ffff-ffff-ffffffffffff", "", nil, "",
+		SystemDetailHandler)
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusNotFound, &errResp)

--- a/manager/controllers/system_packages_export_test.go
+++ b/manager/controllers/system_packages_export_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestSystemPackagesExportHandlerJSON(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/00000000-0000-0000-0000-000000000013/packages",
-		nil, "application/json", SystemPackagesExportHandler, 3, "GET", "/:inventory_id/packages")
+	w := CreateRequestRouterWithParams("GET", "/:inventory_id/packages", "00000000-0000-0000-0000-000000000013", "",
+		nil, "application/json", SystemPackagesExportHandler, 3)
 
 	var output []SystemPackageInlineV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -26,8 +26,8 @@ func TestSystemPackagesExportHandlerJSON(t *testing.T) {
 
 func TestSystemPackagesExportHandlerCSV(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/00000000-0000-0000-0000-000000000013/packages",
-		nil, "text/csv", SystemPackagesExportHandler, 3, "GET", "/:inventory_id/packages")
+	w := CreateRequestRouterWithParams("GET", "/:inventory_id/packages", "00000000-0000-0000-0000-000000000013", "",
+		nil, "text/csv", SystemPackagesExportHandler, 3)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	body := w.Body.String()
@@ -44,8 +44,8 @@ func TestSystemPackagesExportHandlerCSV(t *testing.T) {
 
 func TestSystemPackagesExportUnknown(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/unknownsystem/packages", nil, "text/csv",
-		SystemPackagesExportHandler, 3, "GET", "/:inventory_id/packages")
+	w := CreateRequestRouterWithParams("GET", "/:inventory_id/packages", "unknownsystem", "", nil, "text/csv",
+		SystemPackagesExportHandler, 3)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/manager/controllers/system_packages_test.go
+++ b/manager/controllers/system_packages_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestSystemPackages(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/00000000-0000-0000-0000-000000000013/packages",
-		nil, "", SystemPackagesHandler, 3, "GET", "/:inventory_id/packages")
+	w := CreateRequestRouterWithParams("GET", "/:inventory_id/packages", "00000000-0000-0000-0000-000000000013", "",
+		nil, "", SystemPackagesHandler, 3)
 
 	var output SystemPackageResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -29,8 +29,8 @@ func TestSystemPackages(t *testing.T) {
 
 func TestPackagesSearch(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/00000000-0000-0000-0000-000000000012/packages?search=kernel",
-		nil, "", SystemPackagesHandler, 3, "GET", "/:inventory_id/packages")
+	w := CreateRequestRouterWithParams("GET", "/:inventory_id/packages", "00000000-0000-0000-0000-000000000012",
+		"?search=kernel", nil, "", SystemPackagesHandler, 3)
 
 	var output SystemPackageResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -40,16 +40,16 @@ func TestPackagesSearch(t *testing.T) {
 
 func TestNoPackages(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/00000000-0000-0000-0000-000000000001/packages",
-		nil, "", SystemPackagesHandler, 1, "GET", "/:inventory_id/packages")
+	w := CreateRequestRouterWithParams("GET", "/:inventory_id/packages", "00000000-0000-0000-0000-000000000001", "",
+		nil, "", SystemPackagesHandler, 1)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestSystemPackagesUpdatableOnly(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/00000000-0000-0000-0000-000000000013/packages?filter[updatable]=true",
-		nil, "", SystemPackagesHandler, 3, "GET", "/:inventory_id/packages")
+	w := CreateRequestRouterWithParams("GET", "/:inventory_id/packages", "00000000-0000-0000-0000-000000000013",
+		"?filter[updatable]=true", nil, "", SystemPackagesHandler, 3)
 
 	var output SystemPackageResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -59,8 +59,8 @@ func TestSystemPackagesUpdatableOnly(t *testing.T) {
 
 func TestSystemPackagesName(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/00000000-0000-0000-0000-000000000013/packages?filter[name]=firefox",
-		nil, "", SystemPackagesHandler, 3, "GET", "/:inventory_id/packages")
+	w := CreateRequestRouterWithParams("GET", "/:inventory_id/packages", "00000000-0000-0000-0000-000000000013",
+		"?filter[name]=firefox", nil, "", SystemPackagesHandler, 3)
 
 	var output SystemPackageResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -70,9 +70,8 @@ func TestSystemPackagesName(t *testing.T) {
 
 func TestSystemPackagesNonUpdatableOnly(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET",
-		"/00000000-0000-0000-0000-000000000013/packages?filter[updatable]=false", nil, "",
-		SystemPackagesHandler, 3, "GET", "/:inventory_id/packages")
+	w := CreateRequestRouterWithParams("GET", "/:inventory_id/packages", "00000000-0000-0000-0000-000000000013",
+		"?filter[updatable]=false", nil, "", SystemPackagesHandler, 3)
 
 	var output SystemPackageResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -84,13 +83,13 @@ func TestSystemPackagesNonUpdatableOnly(t *testing.T) {
 
 func TestSystemPackagesWrongOffset(t *testing.T) {
 	doTestWrongOffset(t, "/:inventory_id/packages",
-		"/00000000-0000-0000-0000-000000000001/packages?offset=1000", SystemPackagesHandler)
+		"00000000-0000-0000-0000-000000000001", "?offset=1000", SystemPackagesHandler)
 }
 
 func TestSystemPackagesUnknown(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithParams("GET", "/unknownsystem/packages", nil, "",
-		SystemPackagesHandler, 3, "GET", "/:inventory_id/packages")
+	w := CreateRequestRouterWithParams("GET", "/:inventory_id/packages", "unknownsystem", "", nil, "",
+		SystemPackagesHandler, 3)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/manager/controllers/systems_advisories_view_test.go
+++ b/manager/controllers/systems_advisories_view_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func doTestView(t *testing.T, handler gin.HandlerFunc, url string, limit, offset *int) *httptest.ResponseRecorder {
+func doTestView(t *testing.T, handler gin.HandlerFunc, q string, limit, offset *int) *httptest.ResponseRecorder {
 	core.SetupTest(t)
 	body := SystemsAdvisoriesRequest{
 		Systems:    []SystemID{"00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"},
@@ -26,12 +26,12 @@ func doTestView(t *testing.T, handler gin.HandlerFunc, url string, limit, offset
 		panic(err)
 	}
 
-	w := CreateRequestRouterWithParams("POST", url, bytes.NewBuffer(bodyJSON), "", handler, 1, "POST", "/")
+	w := CreateRequestRouterWithParams("POST", "/", "", q, bytes.NewBuffer(bodyJSON), "", handler, 1)
 	return w
 }
 
 func TestSystemsAdvisoriesView(t *testing.T) {
-	w := doTestView(t, PostSystemsAdvisories, "/", nil, nil)
+	w := doTestView(t, PostSystemsAdvisories, "", nil, nil)
 	var output SystemsAdvisoriesResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, output.Data["00000000-0000-0000-0000-000000000001"][0], AdvisoryName("RH-1"))
@@ -40,7 +40,7 @@ func TestSystemsAdvisoriesView(t *testing.T) {
 }
 
 func TestAdvisoriesSystemsView(t *testing.T) {
-	w := doTestView(t, PostAdvisoriesSystems, "/", nil, nil)
+	w := doTestView(t, PostAdvisoriesSystems, "", nil, nil)
 	var output AdvisoriesSystemsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, output.Data["RH-1"][0], SystemID("00000000-0000-0000-0000-000000000001"))
@@ -48,7 +48,7 @@ func TestAdvisoriesSystemsView(t *testing.T) {
 }
 
 func TestSystemsAdvisoriesViewTags(t *testing.T) {
-	w := doTestView(t, PostSystemsAdvisories, "/?filter[system_profile][sap_sids]=DEF", nil, nil)
+	w := doTestView(t, PostSystemsAdvisories, "?filter[system_profile][sap_sids]=DEF", nil, nil)
 	var output SystemsAdvisoriesResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, output.Data["00000000-0000-0000-0000-000000000001"][0], AdvisoryName("RH-1"))
@@ -56,7 +56,7 @@ func TestSystemsAdvisoriesViewTags(t *testing.T) {
 }
 
 func TestAdvisoriesSystemsViewTags(t *testing.T) {
-	w := doTestView(t, PostAdvisoriesSystems, "/?filter[system_profile][sap_sids]=DEF", nil, nil)
+	w := doTestView(t, PostAdvisoriesSystems, "?filter[system_profile][sap_sids]=DEF", nil, nil)
 	var output AdvisoriesSystemsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, output.Data["RH-1"][0], SystemID("00000000-0000-0000-0000-000000000001"))
@@ -65,7 +65,7 @@ func TestAdvisoriesSystemsViewTags(t *testing.T) {
 func TestSystemAdvisoriesViewOffsetLimit(t *testing.T) {
 	limit := 3
 	offset := 0
-	w := doTestView(t, PostSystemsAdvisories, "/", &limit, &offset)
+	w := doTestView(t, PostSystemsAdvisories, "", &limit, &offset)
 	var output SystemsAdvisoriesResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 2, len(output.Data))
@@ -76,7 +76,7 @@ func TestSystemAdvisoriesViewOffsetLimit(t *testing.T) {
 func TestSystemAdvisoriesViewOffsetOverflow(t *testing.T) {
 	limit := 1
 	offset := 100
-	w := doTestView(t, PostSystemsAdvisories, "/", &limit, &offset)
+	w := doTestView(t, PostSystemsAdvisories, "", &limit, &offset)
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
 	assert.Equal(t, InvalidOffsetMsg, errResp.Error)
@@ -84,7 +84,7 @@ func TestSystemAdvisoriesViewOffsetOverflow(t *testing.T) {
 
 func TestSystemAdvisoriesViewWrongOffset(t *testing.T) {
 	offset := 1000
-	w := doTestView(t, PostSystemsAdvisories, "/", nil, &offset)
+	w := doTestView(t, PostSystemsAdvisories, "", nil, &offset)
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
 	assert.Equal(t, InvalidOffsetMsg, errResp.Error)
@@ -93,7 +93,7 @@ func TestSystemAdvisoriesViewWrongOffset(t *testing.T) {
 func TestAvisorySystemsViewOffsetLimit(t *testing.T) {
 	limit := 3
 	offset := 0
-	w := doTestView(t, PostAdvisoriesSystems, "/", &limit, &offset)
+	w := doTestView(t, PostAdvisoriesSystems, "", &limit, &offset)
 	var output AdvisoriesSystemsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 2, len(output.Data))
@@ -104,7 +104,7 @@ func TestAvisorySystemsViewOffsetLimit(t *testing.T) {
 func TestAvisorySystemsViewOffsetOverflow(t *testing.T) {
 	limit := 1
 	offset := 100
-	w := doTestView(t, PostAdvisoriesSystems, "/", &limit, &offset)
+	w := doTestView(t, PostAdvisoriesSystems, "", &limit, &offset)
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
 	assert.Equal(t, InvalidOffsetMsg, errResp.Error)
@@ -112,7 +112,7 @@ func TestAvisorySystemsViewOffsetOverflow(t *testing.T) {
 
 func TestAvisorySystemsViewWrongOffset(t *testing.T) {
 	offset := 1000
-	w := doTestView(t, PostAdvisoriesSystems, "/", nil, &offset)
+	w := doTestView(t, PostAdvisoriesSystems, "", nil, &offset)
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
 	assert.Equal(t, InvalidOffsetMsg, errResp.Error)

--- a/manager/controllers/systems_auth_test.go
+++ b/manager/controllers/systems_auth_test.go
@@ -11,7 +11,7 @@ import (
 func testAccountSystemCounts(t *testing.T, acc int, count int) {
 	core.SetupTest(t)
 	var output SystemsResponseV3
-	w := CreateRequestRouterWithAccount("GET", "/", nil, "", SystemsListHandler, "/", acc)
+	w := CreateRequestRouterWithAccount("GET", "/", "", "", nil, "", SystemsListHandler, acc)
 	CheckResponse(t, w, http.StatusOK, &output)
 	// data
 	assert.Equal(t, count, len(output.Data))

--- a/manager/controllers/systems_ids_test.go
+++ b/manager/controllers/systems_ids_test.go
@@ -29,7 +29,7 @@ func TestSystemsIDsOffsetLimit(t *testing.T) {
 }
 
 func TestSystemsIDsWrongOffset(t *testing.T) {
-	doTestWrongOffset(t, "/", "/?offset=13&limit=4", SystemsListIDsHandler)
+	doTestWrongOffset(t, "/", "", "?offset=13&limit=4", SystemsListIDsHandler)
 }
 
 func TestSystemsIDsWrongSort(t *testing.T) {

--- a/manager/controllers/systems_ids_test.go
+++ b/manager/controllers/systems_ids_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSystemsIDsDefault(t *testing.T) {
-	output := testSystemsIDs(t, `/`, 1)
+	output := testSystemsIDs(t, ``, 1)
 
 	// data
 	assert.Equal(t, 8, len(output.IDs))
@@ -19,12 +19,12 @@ func TestSystemsIDsDefault(t *testing.T) {
 }
 
 func TestSystemsIDsOffset(t *testing.T) {
-	output := testSystemsIDs(t, `/?offset=0&limit=4`, 1)
+	output := testSystemsIDs(t, `?offset=0&limit=4`, 1)
 	assert.Equal(t, 4, len(output.IDs))
 }
 
 func TestSystemsIDsOffsetLimit(t *testing.T) {
-	output := testSystemsIDs(t, `/?offset=4&limit=4`, 1)
+	output := testSystemsIDs(t, `?offset=4&limit=4`, 1)
 	assert.Equal(t, 4, len(output.IDs))
 }
 
@@ -39,30 +39,30 @@ func TestSystemsIDsWrongSort(t *testing.T) {
 }
 
 func TestSystemsIDsSearch(t *testing.T) {
-	output := testSystemsIDs(t, "/?search=001", 1)
+	output := testSystemsIDs(t, "?search=001", 1)
 	assert.Equal(t, 1, len(output.IDs))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.IDs[0])
 }
 
 func TestSystemsIDsTags(t *testing.T) {
-	output := testSystemsIDs(t, "/?tags=ns1/k2=val2", 1)
+	output := testSystemsIDs(t, "?tags=ns1/k2=val2", 1)
 	assert.Equal(t, 2, len(output.IDs))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.IDs[0])
 }
 
 func TestSystemsIDsTagsMultiple(t *testing.T) {
-	output := testSystemsIDs(t, "/?tags=ns1/k3=val4&tags=ns1/k1=val1", 1)
+	output := testSystemsIDs(t, "?tags=ns1/k3=val4&tags=ns1/k1=val1", 1)
 	assert.Equal(t, 1, len(output.IDs))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000003", output.IDs[0])
 }
 
 func TestSystemsIDsTagsUnknown(t *testing.T) {
-	output := testSystemsIDs(t, "/?tags=ns1/k3=val4&tags=ns1/k1=unk", 1)
+	output := testSystemsIDs(t, "?tags=ns1/k3=val4&tags=ns1/k1=unk", 1)
 	assert.Equal(t, 0, len(output.IDs))
 }
 
 func TestSystemsIDsTagsNoVal(t *testing.T) {
-	output := testSystemsIDs(t, "/?tags=ns1/k3=val4&tags=ns1/k1", 1)
+	output := testSystemsIDs(t, "?tags=ns1/k3=val4&tags=ns1/k1", 1)
 	assert.Equal(t, 1, len(output.IDs))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000003", output.IDs[0])
 }
@@ -74,60 +74,58 @@ func TestSystemsIDsTagsInvalid(t *testing.T) {
 }
 
 func TestSystemsIDsWorkloads1(t *testing.T) {
-	url := "/?filter[system_profile][sap_system]=true&filter[system_profile][sap_sids]=ABC"
-	output := testSystemsIDs(t, url, 1)
+	output := testSystemsIDs(t, "?filter[system_profile][sap_system]=true&filter[system_profile][sap_sids]=ABC", 1)
 	assert.Equal(t, 2, len(output.IDs))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.IDs[0])
 }
 
 func TestSystemsIDsWorkloads2(t *testing.T) {
-	url := sapABCFilter
-	output := testSystemsIDs(t, url, 1)
+	output := testSystemsIDs(t, sapABCFilter, 1)
 	assert.Equal(t, 2, len(output.IDs))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.IDs[0])
 }
 
 func TestSystemsIDsWorkloads3(t *testing.T) {
-	output := testSystemsIDs(t, "/?filter[system_profile][sap_system]=false", 1)
+	output := testSystemsIDs(t, "?filter[system_profile][sap_system]=false", 1)
 	assert.Equal(t, 0, len(output.IDs))
 }
 
 func TestSystemsIDsPackagesCount(t *testing.T) {
-	output := testSystemsIDs(t, "/?sort=-packages_installed,id", 3)
+	output := testSystemsIDs(t, "?sort=-packages_installed,id", 3)
 	assert.Equal(t, 5, len(output.IDs))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000015", output.IDs[0])
 }
 
 func TestSystemsIDsFilterAdvCount1(t *testing.T) {
-	outputIDs := testSystemsIDs(t, "/?filter[rhba_count]=2", 1)
-	output := testSystems(t, "/?filter[rhba_count]=2", 1)
+	outputIDs := testSystemsIDs(t, "?filter[rhba_count]=2", 1)
+	output := testSystems(t, "?filter[rhba_count]=2", 1)
 	assert.Equal(t, 1, len(outputIDs.IDs))
 	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
 }
 
 func TestSystemsIDsFilterAdvCount2(t *testing.T) {
-	outputIDs := testSystemsIDs(t, "/?filter[rhea_count]=1", 1)
-	output := testSystems(t, "/?filter[rhea_count]=1", 1)
+	outputIDs := testSystemsIDs(t, "?filter[rhea_count]=1", 1)
+	output := testSystems(t, "?filter[rhea_count]=1", 1)
 	assert.Equal(t, 4, len(outputIDs.IDs))
 	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
 }
 
 func TestSystemsIDsFilterAdvCount3(t *testing.T) {
-	outputIDs := testSystemsIDs(t, "/?filter[rhsa_count]=2", 1)
-	output := testSystems(t, "/?filter[rhsa_count]=2", 1)
+	outputIDs := testSystemsIDs(t, "?filter[rhsa_count]=2", 1)
+	output := testSystems(t, "?filter[rhsa_count]=2", 1)
 	assert.Equal(t, 1, len(outputIDs.IDs))
 	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
 }
 
 func TestSystemsIDsFilterAdvCount4(t *testing.T) {
-	outputIDs := testSystemsIDs(t, "/?filter[other_count]=4", 1)
-	output := testSystems(t, "/?filter[other_count]=4", 1)
+	outputIDs := testSystemsIDs(t, "?filter[other_count]=4", 1)
+	output := testSystems(t, "?filter[other_count]=4", 1)
 	assert.Equal(t, 1, len(outputIDs.IDs))
 	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
 }
 
 func TestSystemsIDsFilterBaseline(t *testing.T) {
-	output := testSystemsIDs(t, "/?filter[baseline_name]=baseline_1-1", 1)
+	output := testSystemsIDs(t, "?filter[baseline_name]=baseline_1-1", 1)
 	assert.Equal(t, 2, len(output.IDs))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.IDs[0])
 	assert.Equal(t, "00000000-0000-0000-0000-000000000002", output.IDs[1])
@@ -140,16 +138,16 @@ func TestSystemsIDsFilterNotExisting(t *testing.T) {
 }
 
 func TestSystemsIDsFilterPartialOS(t *testing.T) {
-	outputIDs := testSystemsIDs(t, "/?filter[osname]=RHEL&filter[osmajor]=8&filter[osminor]=1", 1)
-	output := testSystems(t, "/?filter[osname]=RHEL&filter[osmajor]=8&filter[osminor]=1", 1)
+	outputIDs := testSystemsIDs(t, "?filter[osname]=RHEL&filter[osmajor]=8&filter[osminor]=1", 1)
+	output := testSystems(t, "?filter[osname]=RHEL&filter[osmajor]=8&filter[osminor]=1", 1)
 	assert.Equal(t, 2, len(outputIDs.IDs))
 	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
 	assert.Equal(t, output.Data[1].ID, outputIDs.IDs[1])
 }
 
 func TestSystemsIDsFilterOS(t *testing.T) {
-	outputIDs := testSystemsIDs(t, `/?filter[os]=in:RHEL 8.1,RHEL 7.3&sort=os`, 1)
-	output := testSystems(t, `/?filter[os]=in:RHEL 8.1,RHEL 7.3&sort=os`, 1)
+	outputIDs := testSystemsIDs(t, `?filter[os]=in:RHEL 8.1,RHEL 7.3&sort=os`, 1)
+	output := testSystems(t, `?filter[os]=in:RHEL 8.1,RHEL 7.3&sort=os`, 1)
 	assert.Equal(t, 3, len(outputIDs.IDs))
 	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
 	assert.Equal(t, output.Data[1].ID, outputIDs.IDs[1])
@@ -157,8 +155,8 @@ func TestSystemsIDsFilterOS(t *testing.T) {
 }
 
 func TestSystemsIDsOrderOS(t *testing.T) {
-	output := testSystems(t, `/?sort=os`, 1)
-	outputIDs := testSystemsIDs(t, `/?sort=os`, 1)
+	output := testSystems(t, `?sort=os`, 1)
+	outputIDs := testSystemsIDs(t, `?sort=os`, 1)
 	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
 	assert.Equal(t, output.Data[1].ID, outputIDs.IDs[1])
 	assert.Equal(t, output.Data[2].ID, outputIDs.IDs[2])
@@ -169,9 +167,9 @@ func TestSystemsIDsOrderOS(t *testing.T) {
 	assert.Equal(t, output.Data[7].ID, outputIDs.IDs[7])
 }
 
-func testSystemsIDs(t *testing.T, url string, account int) IDsResponse {
+func testSystemsIDs(t *testing.T, queryString string, account int) IDsResponse {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithAccount("GET", url, nil, "", SystemsListIDsHandler, "/", account)
+	w := CreateRequestRouterWithAccount("GET", "/", "", queryString, nil, "", SystemsListIDsHandler, account)
 
 	var output IDsResponse
 	CheckResponse(t, w, http.StatusOK, &output)

--- a/manager/controllers/systems_ids_test.go
+++ b/manager/controllers/systems_ids_test.go
@@ -33,7 +33,7 @@ func TestSystemsIDsWrongOffset(t *testing.T) {
 }
 
 func TestSystemsIDsWrongSort(t *testing.T) {
-	statusCode, errResp := testSystemsIDsError(t, "/?sort=unknown_key")
+	statusCode, errResp := testSystemsIDsError(t, "?sort=unknown_key")
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Equal(t, "Invalid sort field: unknown_key", errResp.Error)
 }
@@ -68,7 +68,7 @@ func TestSystemsIDsTagsNoVal(t *testing.T) {
 }
 
 func TestSystemsIDsTagsInvalid(t *testing.T) {
-	statusCode, errResp := testSystemsIDsError(t, "/?tags=ns1/k3=val4&tags=invalidTag")
+	statusCode, errResp := testSystemsIDsError(t, "?tags=ns1/k3=val4&tags=invalidTag")
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Equal(t, fmt.Sprintf(InvalidTagMsg, "invalidTag"), errResp.Error)
 }
@@ -134,7 +134,7 @@ func TestSystemsIDsFilterBaseline(t *testing.T) {
 }
 
 func TestSystemsIDsFilterNotExisting(t *testing.T) {
-	statusCode, errResp := testSystemsIDsError(t, "/?filter[not-existing]=1")
+	statusCode, errResp := testSystemsIDsError(t, "?filter[not-existing]=1")
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Equal(t, "cannot parse inventory filters: Invalid filter field: not-existing", errResp.Error)
 }
@@ -178,9 +178,9 @@ func testSystemsIDs(t *testing.T, url string, account int) IDsResponse {
 	return output
 }
 
-func testSystemsIDsError(t *testing.T, url string) (int, utils.ErrorResponse) {
+func testSystemsIDsError(t *testing.T, queryString string) (int, utils.ErrorResponse) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", url, nil, "", SystemsListIDsHandler, "/")
+	w := CreateRequestRouterWithPath("GET", "/", "", queryString, nil, "", SystemsListIDsHandler)
 
 	var errResp utils.ErrorResponse
 	ParseResponseBody(t, w.Body.Bytes(), &errResp)

--- a/manager/controllers/systems_test.go
+++ b/manager/controllers/systems_test.go
@@ -72,7 +72,7 @@ func TestSystemsWrongOffset(t *testing.T) {
 }
 
 func TestSystemsWrongSort(t *testing.T) {
-	statusCode, errResp := testSystemsError(t, "/?sort=unknown_key")
+	statusCode, errResp := testSystemsError(t, "?sort=unknown_key")
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Equal(t, "Invalid sort field: unknown_key", errResp.Error)
 }
@@ -109,7 +109,7 @@ func TestSystemsTagsNoVal(t *testing.T) {
 }
 
 func TestSystemsTagsInvalid(t *testing.T) {
-	statusCode, errResp := testSystemsError(t, "/?tags=ns1/k3=val4&tags=invalidTag")
+	statusCode, errResp := testSystemsError(t, "?tags=ns1/k3=val4&tags=invalidTag")
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Equal(t, fmt.Sprintf(InvalidTagMsg, "invalidTag"), errResp.Error)
 }
@@ -205,7 +205,7 @@ func TestSystemsFilterBaseline(t *testing.T) {
 }
 
 func TestSystemsFilterNotExisting(t *testing.T) {
-	statusCode, errResp := testSystemsError(t, "/?filter[not-existing]=1")
+	statusCode, errResp := testSystemsError(t, "?filter[not-existing]=1")
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Equal(t, "cannot parse inventory filters: Invalid filter field: not-existing", errResp.Error)
 }
@@ -239,9 +239,9 @@ func testSystems(t *testing.T, url string, account int) SystemsResponseV3 {
 	return output
 }
 
-func testSystemsError(t *testing.T, url string) (int, utils.ErrorResponse) {
+func testSystemsError(t *testing.T, queryString string) (int, utils.ErrorResponse) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithPath("GET", url, nil, "", SystemsListHandler, "/")
+	w := CreateRequestRouterWithPath("GET", "/", "", queryString, nil, "", SystemsListHandler)
 
 	var errResp utils.ErrorResponse
 	ParseResponseBody(t, w.Body.Bytes(), &errResp)

--- a/manager/controllers/systems_test.go
+++ b/manager/controllers/systems_test.go
@@ -68,7 +68,7 @@ func TestSystemsOffsetLimit(t *testing.T) {
 }
 
 func TestSystemsWrongOffset(t *testing.T) {
-	doTestWrongOffset(t, "/", "/?offset=13&limit=4", SystemsListHandler)
+	doTestWrongOffset(t, "/", "", "?offset=13&limit=4", SystemsListHandler)
 }
 
 func TestSystemsWrongSort(t *testing.T) {

--- a/manager/controllers/systems_test.go
+++ b/manager/controllers/systems_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const sapABCFilter = "/?filter[system_profile][sap_system]=true&filter[system_profile][sap_sids]=ABC"
+const sapABCFilter = "?filter[system_profile][sap_system]=true&filter[system_profile][sap_sids]=ABC"
 
 func TestSystemsDefault(t *testing.T) {
-	output := testSystems(t, `/`, 1)
+	output := testSystems(t, ``, 1)
 
 	// data
 	assert.Equal(t, 8, len(output.Data))
@@ -52,7 +52,7 @@ func TestSystemsDefault(t *testing.T) {
 }
 
 func TestSystemsOffset(t *testing.T) {
-	output := testSystems(t, `/?offset=0&limit=4`, 1)
+	output := testSystems(t, `?offset=0&limit=4`, 1)
 	assert.Equal(t, 4, len(output.Data))
 	assert.Equal(t, 0, output.Meta.Offset)
 	assert.Equal(t, 4, output.Meta.Limit)
@@ -60,7 +60,7 @@ func TestSystemsOffset(t *testing.T) {
 }
 
 func TestSystemsOffsetLimit(t *testing.T) {
-	output := testSystems(t, `/?offset=4&limit=4`, 1)
+	output := testSystems(t, `?offset=4&limit=4`, 1)
 	assert.Equal(t, 4, len(output.Data))
 	assert.Equal(t, 4, output.Meta.Offset)
 	assert.Equal(t, 4, output.Meta.Limit)
@@ -78,7 +78,7 @@ func TestSystemsWrongSort(t *testing.T) {
 }
 
 func TestSystemsSearch(t *testing.T) {
-	output := testSystems(t, "/?search=001", 1)
+	output := testSystems(t, "?search=001", 1)
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
 	assert.Equal(t, "system", output.Data[0].Type)
@@ -86,24 +86,24 @@ func TestSystemsSearch(t *testing.T) {
 }
 
 func TestSystemsTags(t *testing.T) {
-	output := testSystems(t, "/?tags=ns1/k2=val2", 1)
+	output := testSystems(t, "?tags=ns1/k2=val2", 1)
 	assert.Equal(t, 2, len(output.Data))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
 }
 
 func TestSystemsTagsMultiple(t *testing.T) {
-	output := testSystems(t, "/?tags=ns1/k3=val4&tags=ns1/k1=val1", 1)
+	output := testSystems(t, "?tags=ns1/k3=val4&tags=ns1/k1=val1", 1)
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000003", output.Data[0].ID)
 }
 
 func TestSystemsTagsUnknown(t *testing.T) {
-	output := testSystems(t, "/?tags=ns1/k3=val4&tags=ns1/k1=unk", 1)
+	output := testSystems(t, "?tags=ns1/k3=val4&tags=ns1/k1=unk", 1)
 	assert.Equal(t, 0, len(output.Data))
 }
 
 func TestSystemsTagsNoVal(t *testing.T) {
-	output := testSystems(t, "/?tags=ns1/k3=val4&tags=ns1/k1", 1)
+	output := testSystems(t, "?tags=ns1/k3=val4&tags=ns1/k1", 1)
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000003", output.Data[0].ID)
 }
@@ -115,57 +115,53 @@ func TestSystemsTagsInvalid(t *testing.T) {
 }
 
 func TestSystemsTagsEscaping1(t *testing.T) {
-	output := testSystems(t, `/?tags=ns1/k3=val4&tags="ns/key=quote"`, 1)
+	output := testSystems(t, `?tags=ns1/k3=val4&tags="ns/key=quote"`, 1)
 	assert.Equal(t, 0, len(output.Data))
 }
 
 func TestSystemsTagsEscaping2(t *testing.T) {
-	output := testSystems(t, `/?tags=ns1/k3=val4&tags='ns/key=singlequote'`, 1)
+	output := testSystems(t, `?tags=ns1/k3=val4&tags='ns/key=singlequote'`, 1)
 	assert.Equal(t, 0, len(output.Data))
 }
 
 func TestSystemsTagsEscaping3(t *testing.T) {
-	output := testSystems(t, `/?tags=ns1/k3=val4&tags='ns/key=inside""quote'`, 1)
+	output := testSystems(t, `?tags=ns1/k3=val4&tags='ns/key=inside""quote'`, 1)
 	assert.Equal(t, 0, len(output.Data))
 }
 
 func TestSystemsTagsEscaping4(t *testing.T) {
-	output := testSystems(t, `/?tags=ns1/k3=val4&tags=ne/key="{{malformed json}}"`, 1)
+	output := testSystems(t, `?tags=ns1/k3=val4&tags=ne/key="{{malformed json}}"`, 1)
 	assert.Equal(t, 0, len(output.Data))
 }
 
 func TestSystemsWorkloads1(t *testing.T) {
-	url := "/?filter[system_profile][sap_system]=true&filter[system_profile][sap_sids]=ABC"
-	output := testSystems(t, url, 1)
+	output := testSystems(t, "?filter[system_profile][sap_system]=true&filter[system_profile][sap_sids]=ABC", 1)
 	assert.Equal(t, 2, len(output.Data))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
 }
 
 func TestSystemsWorkloads2(t *testing.T) {
-	url := sapABCFilter
-	output := testSystems(t, url, 1)
+	output := testSystems(t, sapABCFilter, 1)
 	assert.Equal(t, 2, len(output.Data))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
 }
 
 func TestSystemsWorkloads3(t *testing.T) {
-	output := testSystems(t, "/?filter[system_profile][sap_system]=false", 1)
+	output := testSystems(t, "?filter[system_profile][sap_system]=false", 1)
 	assert.Equal(t, 0, len(output.Data))
 }
 
 func TestSystemsWorkloadEscaping1(t *testing.T) {
-	url := "/?filter[system_profile][sap_sids]='singlequote'"
-	output := testSystems(t, url, 1)
+	output := testSystems(t, "?filter[system_profile][sap_sids]='singlequote'", 1)
 	assert.Equal(t, 0, len(output.Data))
 }
 
 func TestSystemsWorkloadEscaping2(t *testing.T) {
-	url := `/?filter[system_profile][sap_sids]="{{malformed json}}"`
-	output := testSystems(t, url, 1)
+	output := testSystems(t, `?filter[system_profile][sap_sids]="{{malformed json}}"`, 1)
 	assert.Equal(t, 0, len(output.Data))
 }
 func TestSystemsPackagesCount(t *testing.T) {
-	output := testSystems(t, "/?sort=-packages_installed,id", 3)
+	output := testSystems(t, "?sort=-packages_installed,id", 3)
 	assert.Equal(t, 5, len(output.Data))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000015", output.Data[0].ID)
 	assert.Equal(t, "system", output.Data[0].Type)
@@ -174,31 +170,31 @@ func TestSystemsPackagesCount(t *testing.T) {
 }
 
 func TestSystemsFilterAdvCount1(t *testing.T) {
-	output := testSystems(t, "/?filter[rhba_count]=2", 1)
+	output := testSystems(t, "?filter[rhba_count]=2", 1)
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, 2, output.Data[0].Attributes.RhbaCount)
 }
 
 func TestSystemsFilterAdvCount2(t *testing.T) {
-	output := testSystems(t, "/?filter[rhea_count]=1", 1)
+	output := testSystems(t, "?filter[rhea_count]=1", 1)
 	assert.Equal(t, 4, len(output.Data))
 	assert.Equal(t, 1, output.Data[0].Attributes.RheaCount)
 }
 
 func TestSystemsFilterAdvCount3(t *testing.T) {
-	output := testSystems(t, "/?filter[rhsa_count]=2", 1)
+	output := testSystems(t, "?filter[rhsa_count]=2", 1)
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, 2, output.Data[0].Attributes.RhsaCount)
 }
 
 func TestSystemsFilterAdvCount4(t *testing.T) {
-	output := testSystems(t, "/?filter[other_count]=4", 1)
+	output := testSystems(t, "?filter[other_count]=4", 1)
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, 4, output.Data[0].Attributes.OtherCount)
 }
 
 func TestSystemsFilterBaseline(t *testing.T) {
-	output := testSystems(t, "/?filter[baseline_name]=baseline_1-1", 1)
+	output := testSystems(t, "?filter[baseline_name]=baseline_1-1", 1)
 	assert.Equal(t, 2, len(output.Data))
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000002", output.Data[1].ID)
@@ -211,7 +207,7 @@ func TestSystemsFilterNotExisting(t *testing.T) {
 }
 
 func TestSystemsFilterOS(t *testing.T) {
-	output := testSystems(t, `/?filter[os]=in:RHEL 8.1,RHEL 7.3&sort=os`, 1)
+	output := testSystems(t, `?filter[os]=in:RHEL 8.1,RHEL 7.3&sort=os`, 1)
 	assert.Equal(t, 3, len(output.Data))
 	assert.Equal(t, "RHEL 7.3", output.Data[0].Attributes.OS)
 	assert.Equal(t, "RHEL 8.1", output.Data[1].Attributes.OS)
@@ -219,7 +215,7 @@ func TestSystemsFilterOS(t *testing.T) {
 }
 
 func TestSystemsOrderOS(t *testing.T) {
-	output := testSystems(t, `/?sort=os`, 1)
+	output := testSystems(t, `?sort=os`, 1)
 	assert.Equal(t, "RHEL 7.3", output.Data[0].Attributes.OS)
 	assert.Equal(t, "RHEL 8.1", output.Data[1].Attributes.OS)
 	assert.Equal(t, "RHEL 8.1", output.Data[2].Attributes.OS)
@@ -230,9 +226,9 @@ func TestSystemsOrderOS(t *testing.T) {
 	assert.Equal(t, "RHEL 8.x", output.Data[7].Attributes.OS) // yes, we should be robust against this
 }
 
-func testSystems(t *testing.T, url string, account int) SystemsResponseV3 {
+func testSystems(t *testing.T, queryString string, account int) SystemsResponseV3 {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithAccount("GET", url, nil, "", SystemsListHandler, "/", account)
+	w := CreateRequestRouterWithAccount("GET", "/", "", queryString, nil, "", SystemsListHandler, account)
 
 	var output SystemsResponseV3
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -250,7 +246,8 @@ func testSystemsError(t *testing.T, queryString string) (int, utils.ErrorRespons
 
 func TestSystemsTagsInMetadata(t *testing.T) {
 	core.SetupTest(t)
-	w := CreateRequestRouterWithAccount("GET", "/?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "", SystemsListHandler, "/", 3)
+	w := CreateRequestRouterWithAccount("GET", "/", "", "?tags=ns1/k3=val4&tags=ns1/k1=val1", nil, "",
+		SystemsListHandler, 3)
 
 	var output SystemsResponseV3
 	ParseResponseBody(t, w.Body.Bytes(), &output)
@@ -264,8 +261,7 @@ func TestSystemsTagsInMetadata(t *testing.T) {
 }
 
 func TestSAPSystemMeta1(t *testing.T) {
-	url := "/?filter[system_profile][sap_sids]=ABC"
-	output := testSystems(t, url, 1)
+	output := testSystems(t, "?filter[system_profile][sap_sids]=ABC", 1)
 	testMap := map[string]FilterData{
 		"system_profile][sap_sids": {Operator: "eq", Values: []string{"ABC"}},
 		"stale":                    {Operator: "eq", Values: []string{"false"}},
@@ -274,8 +270,7 @@ func TestSAPSystemMeta1(t *testing.T) {
 }
 
 func TestSAPSystemMeta2(t *testing.T) {
-	url := "/?filter[system_profile][sap_sids]=ABC"
-	output := testSystems(t, url, 1)
+	output := testSystems(t, "?filter[system_profile][sap_sids]=ABC", 1)
 	testMap := map[string]FilterData{
 		"system_profile][sap_sids": {Operator: "eq", Values: []string{"ABC"}},
 		"stale":                    {Operator: "eq", Values: []string{"false"}},
@@ -284,8 +279,7 @@ func TestSAPSystemMeta2(t *testing.T) {
 }
 
 func TestSAPSystemMeta3(t *testing.T) {
-	url := sapABCFilter
-	output := testSystems(t, url, 1)
+	output := testSystems(t, sapABCFilter, 1)
 	testMap := map[string]FilterData{
 		"system_profile][sap_system": {Operator: "eq", Values: []string{"true"}},
 		"system_profile][sap_sids":   {Operator: "eq", Values: []string{"ABC"}},
@@ -295,8 +289,7 @@ func TestSAPSystemMeta3(t *testing.T) {
 }
 
 func TestSAPSystemMeta4(t *testing.T) {
-	url := "/?filter[system_profile][sap_sids]=ABC&filter[system_profile][sap_sids]=GHI"
-	output := testSystems(t, url, 1)
+	output := testSystems(t, "?filter[system_profile][sap_sids]=ABC&filter[system_profile][sap_sids]=GHI", 1)
 	testMap := map[string]FilterData{
 		"system_profile][sap_sids": {Operator: "eq", Values: []string{"GHI", "ABC"}},
 		"stale":                    {Operator: "eq", Values: []string{"false"}},
@@ -305,8 +298,7 @@ func TestSAPSystemMeta4(t *testing.T) {
 }
 
 func TestAAPSystemMeta(t *testing.T) {
-	url := `/?filter[system_profile][ansible][controller_version]=1.0`
-	output := testSystems(t, url, 1)
+	output := testSystems(t, `?filter[system_profile][ansible][controller_version]=1.0`, 1)
 	testMap := map[string]FilterData{
 		"system_profile][ansible][controller_version": {Operator: "eq", Values: []string{"1.0"}},
 		"stale": {Operator: "eq", Values: []string{"false"}},
@@ -315,8 +307,7 @@ func TestAAPSystemMeta(t *testing.T) {
 }
 
 func TestAAPSystemMeta2(t *testing.T) {
-	url := `/?filter[system_profile][ansible]=not_nil`
-	output := testSystems(t, url, 1)
+	output := testSystems(t, `?filter[system_profile][ansible]=not_nil`, 1)
 	testMap := map[string]FilterData{
 		"system_profile][ansible": {Operator: "eq", Values: []string{"not_nil"}},
 		"stale":                   {Operator: "eq", Values: []string{"false"}},
@@ -329,15 +320,13 @@ func TestAAPSystemMeta3(t *testing.T) {
 		ID         = "00000000-0000-0000-0000-000000000007"
 		totalItems = 1
 	)
-	url := `/?filter[system_profile][ansible][controller_version]=1.0`
-	output := testSystems(t, url, 1)
+	output := testSystems(t, `?filter[system_profile][ansible][controller_version]=1.0`, 1)
 	assert.Equal(t, ID, output.Data[0].ID)
 	assert.Equal(t, totalItems, output.Meta.TotalItems)
 }
 
 func TestMSSQLSystemMeta(t *testing.T) {
-	url := `/?filter[system_profile][mssql][version]=15.3.0`
-	output := testSystems(t, url, 1)
+	output := testSystems(t, `?filter[system_profile][mssql][version]=15.3.0`, 1)
 	testMap := map[string]FilterData{
 		"system_profile][mssql][version": {Operator: "eq", Values: []string{"15.3.0"}},
 		"stale":                          {Operator: "eq", Values: []string{"false"}},
@@ -346,8 +335,7 @@ func TestMSSQLSystemMeta(t *testing.T) {
 }
 
 func TestMSSQLSystemMeta2(t *testing.T) {
-	url := `/?filter[system_profile][mssql]=not_nil`
-	output := testSystems(t, url, 1)
+	output := testSystems(t, `?filter[system_profile][mssql]=not_nil`, 1)
 	testMap := map[string]FilterData{
 		"system_profile][mssql": {Operator: "eq", Values: []string{"not_nil"}},
 		"stale":                 {Operator: "eq", Values: []string{"false"}},
@@ -360,8 +348,7 @@ func TestMSSQLSystemMeta3(t *testing.T) {
 		ID         = "00000000-0000-0000-0000-000000000006"
 		totalItems = 1
 	)
-	url := `/?filter[system_profile][mssql][version]=15.3.0`
-	output := testSystems(t, url, 1)
+	output := testSystems(t, `?filter[system_profile][mssql][version]=15.3.0`, 1)
 	assert.Equal(t, ID, output.Data[0].ID)
 	assert.Equal(t, totalItems, output.Meta.TotalItems)
 }

--- a/manager/controllers/systemtags_test.go
+++ b/manager/controllers/systemtags_test.go
@@ -12,7 +12,7 @@ import (
 func TestSystemTagsListDefault(t *testing.T) {
 	core.SetupTest(t)
 
-	w := CreateRequestRouterWithAccount("GET", "/", nil, "", SystemTagListHandler, "/", 1)
+	w := CreateRequestRouterWithAccount("GET", "/", "", "", nil, "", SystemTagListHandler, 1)
 
 	var output SystemTagsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -29,7 +29,7 @@ func TestSystemTagsListDefault(t *testing.T) {
 func TestSystemTagsListPagination(t *testing.T) {
 	core.SetupTest(t)
 
-	w := CreateRequestRouterWithAccount("GET", "/?offset=1&limit=1", nil, "", SystemTagListHandler, "/", 1)
+	w := CreateRequestRouterWithAccount("GET", "/", "", "?offset=1&limit=1", nil, "", SystemTagListHandler, 1)
 
 	var output SystemTagsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -46,7 +46,7 @@ func TestSystemTagsListPagination(t *testing.T) {
 func TestSystemTagsTotalItems(t *testing.T) {
 	core.SetupTest(t)
 
-	w := CreateRequestRouterWithAccount("GET", "/", nil, "", SystemTagListHandler, "/", 1)
+	w := CreateRequestRouterWithAccount("GET", "/", "", "", nil, "", SystemTagListHandler, 1)
 
 	var output SystemTagsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -56,7 +56,7 @@ func TestSystemTagsTotalItems(t *testing.T) {
 func TestSystemTagsListSort(t *testing.T) {
 	core.SetupTest(t)
 
-	w := CreateRequestRouterWithAccount("GET", "/?sort=count", nil, "", SystemTagListHandler, "/", 1)
+	w := CreateRequestRouterWithAccount("GET", "/", "", "?sort=count", nil, "", SystemTagListHandler, 1)
 
 	var output SystemTagsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
@@ -73,6 +73,6 @@ func TestSystemTagsListSort(t *testing.T) {
 func TestSystemTagsListBadRequestOnIdtSort(t *testing.T) {
 	core.SetupTest(t)
 
-	w := CreateRequestRouterWithAccount("GET", "/?sort=id", nil, "", SystemTagListHandler, "/", 1)
+	w := CreateRequestRouterWithAccount("GET", "/", "", "?sort=id", nil, "", SystemTagListHandler, 1)
 	assert.Equal(t, 400, w.Code)
 }


### PR DESCRIPTION
- unify `method` and `routerMethod`
- use `routerPath`, `param`, and `queryString` to crete url
- update all function calls
- update doTestWrongOffset to work with the new CreateRequestRouterWithParams func

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
