### PR TITLE
RHINENG-8136: remove DeprecateV1V2APIs middleware

### DIFF
--- a/base/deprecations/base.go
+++ b/base/deprecations/base.go
@@ -14,6 +14,7 @@ type Deprecation interface {
 	Deprecate(*gin.Context)
 }
 
+//lint:ignore U1000 ignore unused, may be used in the future
 type apiDeprecation struct {
 	shouldDeprecate func(c *gin.Context) bool
 	// datetime when API will be deprecated

--- a/base/deprecations/deprecations.go
+++ b/base/deprecations/deprecations.go
@@ -2,27 +2,10 @@ package deprecations
 
 import (
 	"app/base/utils"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
 )
-
-// Deprecate V1 and V2 APIs
-func DeprecateV1V2APIs() Deprecation {
-	redirectTS := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	return apiDeprecation{
-		deprecationTimestamp: time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC),
-		redirectTimestamp:    &redirectTS,
-		// currentLocation is set by Deprecate receiver
-		locationReplacer: strings.NewReplacer("v1", "v3", "v2", "v3"),
-		message:          "APIs /v1 and /v2 are deprecated, use /v3 instead",
-		shouldDeprecate: func(c *gin.Context) bool {
-			apiver := c.GetInt(utils.KeyApiver)
-			return apiver < 3
-		},
-	}
-}
 
 // Deprecate maximum `limit`
 func DeprecateLimit() Deprecation {

--- a/manager/routes/routes.go
+++ b/manager/routes/routes.go
@@ -16,7 +16,6 @@ func InitAPI(api *gin.RouterGroup, config docs.EndpointsConfig) { // nolint: fun
 	api.Use(middlewares.PublicAuthenticator())
 	api.Use(middlewares.CheckReferer())
 	api.Use(middlewares.SetAPIVersion(api.BasePath()))
-	api.Use(middlewares.Deprecate(deprecations.DeprecateV1V2APIs()))
 	api.Use(middlewares.Deprecate(deprecations.DeprecateLimit()))
 	api.Use(middlewares.DatabaseWithContext())
 


### PR DESCRIPTION
Also added ignore for `apiDeprecation` unused error, it may be used in the future

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
