### PR TITLE
RHINENG-8389: make /ids responses consistent

### DIFF
--- a/docs/v3/openapi.json
+++ b/docs/v3/openapi.json
@@ -2911,7 +2911,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/controllers.IDsResponse"
+                                    "$ref": "#/components/schemas/controllers.IDsPlainResponse"
                                 }
                             }
                         }
@@ -3400,7 +3400,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/controllers.IDsResponse"
+                                    "$ref": "#/components/schemas/controllers.IDsPlainResponse"
                                 }
                             }
                         }
@@ -6835,6 +6835,14 @@
                     }
                 }
             },
+            "controllers.IDPlain": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    }
+                }
+            },
             "controllers.IDSatelliteManaged": {
                 "type": "object",
                 "properties": {
@@ -6857,9 +6865,15 @@
                     }
                 }
             },
-            "controllers.IDsResponse": {
+            "controllers.IDsPlainResponse": {
                 "type": "object",
                 "properties": {
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/controllers.IDPlain"
+                        }
+                    },
                     "ids": {
                         "type": "array",
                         "items": {

--- a/manager/controllers/advisories.go
+++ b/manager/controllers/advisories.go
@@ -185,7 +185,7 @@ func AdvisoriesListHandler(c *gin.Context) {
 // @Param    filter[system_profile][ansible][controller_version]	query string 	false "Filter systems by ansible version"
 // @Param    filter[system_profile][mssql]							query string 	false "Filter systems by mssql version"
 // @Param    filter[system_profile][mssql][version]					query string 	false "Filter systems by mssql version"
-// @Success 200 {object} IDsResponse
+// @Success 200 {object} IDsPlainResponse
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
@@ -201,8 +201,7 @@ func AdvisoriesListIDsHandler(c *gin.Context) {
 		LogAndRespError(c, err, "db error")
 	}
 
-	ids := advisoriesIDs(aids)
-	var resp = IDsResponse{IDs: ids}
+	resp := advisoriesIDs(aids)
 	c.JSON(http.StatusOK, &resp)
 }
 

--- a/manager/controllers/advisories_test.go
+++ b/manager/controllers/advisories_test.go
@@ -24,11 +24,11 @@ func testAdvisories(t *testing.T, url string) AdvisoriesResponse {
 	return output
 }
 
-func testAdvisoriesIDs(t *testing.T, url string) IDsResponse {
+func testAdvisoriesIDs(t *testing.T, url string) IDsPlainResponse {
 	core.SetupTest(t)
 	w := CreateRequest("GET", url, nil, "", AdvisoriesListIDsHandler)
 
-	var output IDsResponse
+	var output IDsPlainResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	return output
 }
@@ -62,6 +62,8 @@ func TestAdvisoriesIDsDefault(t *testing.T) {
 	output := testAdvisoriesIDs(t, "/")
 	assert.Equal(t, 12, len(output.IDs))
 	assert.Equal(t, "RH-7", output.IDs[0])
+	assert.Equal(t, 12, len(output.Data))
+	assert.Equal(t, "RH-7", output.Data[0].ID)
 }
 
 func TestAdvisoriesOffsetLimit(t *testing.T) {
@@ -75,6 +77,7 @@ func TestAdvisoriesOffsetLimit(t *testing.T) {
 func TestAdvisoriesIDsOffsetLimit(t *testing.T) {
 	output := testAdvisoriesIDs(t, "/?offset=0&limit=2")
 	assert.Equal(t, 2, len(output.IDs))
+	assert.Equal(t, 2, len(output.Data))
 }
 
 func TestAdvisoriesUnlimited(t *testing.T) {
@@ -119,6 +122,8 @@ func TestAdvisoriesIDsOrderDate(t *testing.T) {
 	// Advisory RH-7 has latest public date
 	assert.Equal(t, 12, len(output.IDs))
 	assert.Equal(t, "RH-7", output.IDs[0])
+	assert.Equal(t, 12, len(output.Data))
+	assert.Equal(t, "RH-7", output.Data[0].ID)
 }
 
 func TestAdvisoriesOrderTypeID(t *testing.T) {

--- a/manager/controllers/baseline_systems.go
+++ b/manager/controllers/baseline_systems.go
@@ -180,7 +180,7 @@ func BaselineSystemsListHandler(c *gin.Context) {
 // @Param    filter[display_name]           query   string  false "Filter"
 // @Param    filter[os]           			query   string  false "Filter"
 // @Param    tags           query   []string  false "Tag filter"
-// @Success 200 {object} IDsResponse
+// @Success 200 {object} IDsPlainResponse
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 404 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse
@@ -201,11 +201,10 @@ func BaselineSystemsListIDsHandler(c *gin.Context) {
 		return
 	}
 
-	ids, err := systemsIDs(c, sids, meta)
+	resp, err := systemsIDs(c, sids, meta)
 	if err != nil {
 		return // Error handled in method itself
 	}
-	var resp = IDsResponse{IDs: ids}
 	c.JSON(http.StatusOK, &resp)
 }
 

--- a/manager/controllers/package_systems_test.go
+++ b/manager/controllers/package_systems_test.go
@@ -54,12 +54,12 @@ func testPackageSystems(t *testing.T, param, queryString string, account int) Pa
 	return output
 }
 
-func testPackageIDsSystems(t *testing.T, param, queryString string, account int) IDsResponse {
+func testPackageIDsSystems(t *testing.T, param, queryString string, account int) IDsStatusResponse {
 	core.SetupTest(t)
 	w := CreateRequestRouterWithParams("GET", "/:package_name/systems", param, queryString, nil, "",
 		PackageSystemsListIDsHandler, account)
 
-	var output IDsResponse
+	var output IDsStatusResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	return output
 }

--- a/manager/controllers/structures.go
+++ b/manager/controllers/structures.go
@@ -33,8 +33,8 @@ type ListMeta struct {
 	HasSystems *bool `json:"has_systems,omitempty"`
 }
 
-type IDsResponse struct {
-	IDs []string `json:"ids"`
+type IDPlain struct {
+	ID string `json:"id"`
 }
 
 type IDStatus struct {
@@ -47,18 +47,27 @@ type IDSatelliteManaged struct {
 	SatelliteManaged bool   `json:"satellite_managed"`
 }
 
+type IDsResponseCommon struct {
+	IDs []string `json:"ids"`
+}
+
+type IDsPlainResponse struct {
+	Data []IDPlain
+	IDsResponseCommon
+}
+
 type IDsStatusResponse struct {
 	Data []IDStatus `json:"data"`
 	// backward compatibility
 	// TODO: delete later once UI is using only the new `data` field
-	IDsResponse
+	IDsResponseCommon
 }
 
 type IDsSatelliteManagedResponse struct {
 	Data []IDSatelliteManaged `json:"data"`
 	// backward compatibility
 	// TODO: delete later once UI is using only the new `data` field
-	IDsResponse
+	IDsResponseCommon
 }
 
 type SystemGroup struct {

--- a/manager/controllers/systems_ids_test.go
+++ b/manager/controllers/systems_ids_test.go
@@ -167,11 +167,11 @@ func TestSystemsIDsOrderOS(t *testing.T) {
 	assert.Equal(t, output.Data[7].ID, outputIDs.IDs[7])
 }
 
-func testSystemsIDs(t *testing.T, queryString string, account int) IDsResponse {
+func testSystemsIDs(t *testing.T, queryString string, account int) IDsSatelliteManagedResponse {
 	core.SetupTest(t)
 	w := CreateRequestRouterWithAccount("GET", "/", "", queryString, nil, "", SystemsListIDsHandler, account)
 
-	var output IDsResponse
+	var output IDsSatelliteManagedResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	return output
 }

--- a/manager/controllers/utils.go
+++ b/manager/controllers/utils.go
@@ -504,15 +504,18 @@ func systemDBLookups2SystemItems(systems []SystemDBLookup) ([]SystemItem, int, m
 	return data, total, subtotals
 }
 
-func advisoriesIDs(advisories []AdvisoryID) []string {
+func advisoriesIDs(advisories []AdvisoryID) IDsPlainResponse {
+	var resp IDsPlainResponse
 	if advisories == nil {
-		return []string{}
+		return resp
 	}
-	ids := make([]string, len(advisories))
-	for i, x := range advisories {
-		ids[i] = x.ID
+	resp.IDs = make([]string, 0, len(advisories))
+	resp.Data = make([]IDPlain, 0, len(advisories))
+	for _, x := range advisories {
+		resp.IDs = append(resp.IDs, x.ID)
+		resp.Data = append(resp.Data, IDPlain(x))
 	}
-	return ids
+	return resp
 }
 
 func advisoriesStatusIDs(advisories []AdvisoryStatusID) IDsStatusResponse {
@@ -531,24 +534,27 @@ func advisoriesStatusIDs(advisories []AdvisoryStatusID) IDsStatusResponse {
 	return resp
 }
 
-func systemsIDs(c *gin.Context, systems []SystemsID, meta *ListMeta) ([]string, error) {
+func systemsIDs(c *gin.Context, systems []SystemsID, meta *ListMeta) (IDsPlainResponse, error) {
 	var total int
+	var resp IDsPlainResponse
 	if len(systems) > 0 {
 		total = systems[0].Total
 	}
 	if meta.Offset > total {
 		err := errors.New("Offset")
 		LogAndRespBadRequest(c, err, InvalidOffsetMsg)
-		return []string{}, err
+		return resp, err
 	}
 	if systems == nil {
-		return []string{}, nil
+		return resp, nil
 	}
-	ids := make([]string, len(systems))
-	for i, x := range systems {
-		ids[i] = x.ID
+	resp.IDs = make([]string, 0, len(systems))
+	resp.Data = make([]IDPlain, 0, len(systems))
+	for _, x := range systems {
+		resp.IDs = append(resp.IDs, x.ID)
+		resp.Data = append(resp.Data, IDPlain{ID: x.ID})
 	}
-	return ids, nil
+	return resp, nil
 }
 
 func systemsSatelliteIDs(c *gin.Context, systems []SystemsSatelliteManagedID, meta *ListMeta,


### PR DESCRIPTION
Currently some */ids* endpoints respond with a list of ids in `ids` section, other endpoints respond with `ids` and `data` sections. After the change, all endpoint responses should have both `ids` and `data` sections, even if the data section consists only of `IDPlain`s.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
