### PR TITLE
RHINENG-8716: fix dynamically set limit in c.Request.URL

### DIFF
--- a/base/utils/gin.go
+++ b/base/utils/gin.go
@@ -26,7 +26,10 @@ const (
 func LoadParamInt(c *gin.Context, param string, defaultValue int, query bool) (int, error) {
 	var valueStr string
 	if query {
-		valueStr = c.Query(param)
+		// don't use c.Query(), it caches query parameters in context
+		// and data changed directly in c.Request.URL won't be returned
+		// as they are not present in the cache
+		valueStr = c.Request.URL.Query().Get(param)
 	} else {
 		valueStr = c.Param(param)
 	}

--- a/manager/controllers/systems_advisories_view_test.go
+++ b/manager/controllers/systems_advisories_view_test.go
@@ -69,6 +69,8 @@ func TestSystemAdvisoriesViewOffsetLimit(t *testing.T) {
 	var output SystemsAdvisoriesResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 2, len(output.Data))
+	assert.Equal(t, limit, output.Meta.Limit)
+	assert.Equal(t, offset, output.Meta.Offset)
 	_, has := output.Data["00000000-0000-0000-0000-000000000001"]
 	assert.True(t, has)
 }
@@ -97,6 +99,8 @@ func TestAvisorySystemsViewOffsetLimit(t *testing.T) {
 	var output AdvisoriesSystemsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 2, len(output.Data))
+	assert.Equal(t, limit, output.Meta.Limit)
+	assert.Equal(t, offset, output.Meta.Offset)
 	_, has := output.Data["RH-1"]
 	assert.True(t, has)
 }


### PR DESCRIPTION
`c.Query(key)` claims to be a shortcut for `c.Request.URL.Query().Get(key)` by `gin` documentation. The reality is that `c.Query()` tries to get the value from QueryCache if cache exists, The cache is created with first c.Query() call on given context (might be created with other calls as well).

The problem is with /views apis. The query is added dynamically to `c.Request.URL.RawQuery` there. My guess is that it worked previously because we modified the context `c` with `apiver`... it looks like it stopped working after removal of `apiver` decisions and removal of v2 structs (it works in prod but not in stage) but I haven't tried to trace the exact commit.

IMO it should be safer to use `c.Request.URL.Query().Get(key)`
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
