### PR TITLE
fix checksum comparison in listener

### DIFF
--- a/base/models/models.go
+++ b/base/models/models.go
@@ -86,11 +86,12 @@ type SystemPlatform struct {
 	ThirdParty                       bool
 	ReporterID                       *int
 	BaselineID                       *int64
-	BaselineUpToDate                 *bool  `gorm:"column:baseline_uptodate"`
-	TemplateID                       *int64 `gorm:"column:template_id"`
-	YumUpdates                       []byte `gorm:"column:yum_updates"`
-	SatelliteManaged                 bool   `gorm:"column:satellite_managed"`
-	BuiltPkgcache                    bool   `gorm:"column:built_pkgcache"`
+	BaselineUpToDate                 *bool   `gorm:"column:baseline_uptodate"`
+	TemplateID                       *int64  `gorm:"column:template_id"`
+	YumUpdates                       []byte  `gorm:"column:yum_updates"`
+	YumChecksum                      *string `gorm:"column:yum_checksum"`
+	SatelliteManaged                 bool    `gorm:"column:satellite_managed"`
+	BuiltPkgcache                    bool    `gorm:"column:built_pkgcache"`
 }
 
 func (SystemPlatform) TableName() string {

--- a/database_admin/migrations/125_yum_checksum.down.sql
+++ b/database_admin/migrations/125_yum_checksum.down.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION check_unchanged()
+    RETURNS TRIGGER AS
+$check_unchanged$
+BEGIN
+    IF (TG_OP = 'INSERT') AND
+       NEW.unchanged_since IS NULL THEN
+        NEW.unchanged_since := CURRENT_TIMESTAMP;
+    END IF;
+    IF (TG_OP = 'UPDATE') AND
+       (NEW.json_checksum <> OLD.json_checksum OR NEW.yum_updates <> OLD.yum_updates) THEN
+        NEW.unchanged_since := CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+END;
+$check_unchanged$
+    LANGUAGE 'plpgsql';
+
+
+ALTER TABLE system_platform DROP COLUMN IF EXISTS yum_checksum;

--- a/database_admin/migrations/125_yum_checksum.up.sql
+++ b/database_admin/migrations/125_yum_checksum.up.sql
@@ -1,0 +1,18 @@
+ALTER TABLE system_platform ADD COLUMN IF NOT EXISTS yum_checksum TEXT CHECK (NOT empty(yum_checksum));
+
+CREATE OR REPLACE FUNCTION check_unchanged()
+    RETURNS TRIGGER AS
+$check_unchanged$
+BEGIN
+    IF (TG_OP = 'INSERT') AND
+       NEW.unchanged_since IS NULL THEN
+        NEW.unchanged_since := CURRENT_TIMESTAMP;
+    END IF;
+    IF (TG_OP = 'UPDATE') AND
+       (NEW.json_checksum <> OLD.json_checksum OR NEW.yum_checksum <> OLD.yum_checksum) THEN
+        NEW.unchanged_since := CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+END;
+$check_unchanged$
+    LANGUAGE 'plpgsql';

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (124, false);
+VALUES (125, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -70,7 +70,7 @@ BEGIN
         NEW.unchanged_since := CURRENT_TIMESTAMP;
     END IF;
     IF (TG_OP = 'UPDATE') AND
-       (NEW.json_checksum <> OLD.json_checksum OR NEW.yum_updates <> OLD.yum_updates) THEN
+       (NEW.json_checksum <> OLD.json_checksum OR NEW.yum_checksum <> OLD.yum_checksum) THEN
         NEW.unchanged_since := CURRENT_TIMESTAMP;
     END IF;
     RETURN NEW;
@@ -740,6 +740,7 @@ CREATE TABLE IF NOT EXISTS system_platform
     built_pkgcache                       BOOLEAN                  NOT NULL DEFAULT FALSE,
     packages_applicable      INT                      NOT NULL DEFAULT 0,
     template_id              BIGINT,
+    yum_checksum             TEXT                     CHECK (NOT empty(yum_checksum)),
     PRIMARY KEY (rh_account_id, id),
     UNIQUE (rh_account_id, inventory_id),
     CONSTRAINT reporter_id FOREIGN KEY (reporter_id) REFERENCES reporter (id),

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -387,7 +387,7 @@ func updateSystemPlatform(tx *gorm.DB, inventoryID string, accountID int, host *
 func storeOrUpdateSysPlatform(tx *gorm.DB, system *models.SystemPlatform, colsToUpdate []string) error {
 	var err error
 	if errSelect := tx.Where("rh_account_id = ? AND inventory_id = ?", system.RhAccountID, system.InventoryID).
-		Select("id").Find(system).Error; err != nil {
+		Select("id").Find(system).Error; errSelect != nil {
 		utils.LogWarn("err", errSelect, "couldn't find system for update")
 	}
 


### PR DESCRIPTION
There were a few issues with the current query
- First can be used only on Model
- can't load to map[string]string, gorm showing weird error about sql.Scan called but Next not used
- need to cast jsonb to text for `digest` and encode the hex value

Second issue is that digest can't be used for yum_updates as it contains a hash map and order of fields is not deterministic

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
