### PR TITLE
RHINENG-9077: fix sorting by groups and tags

### DIFF
--- a/manager/controllers/common_attributes.go
+++ b/manager/controllers/common_attributes.go
@@ -21,11 +21,11 @@ type SystemTimestamps struct {
 }
 
 type SystemTags struct {
-	Tags SystemTagsList `json:"tags" csv:"tags" query:"ih.tags" gorm:"column:tags_json"`
+	Tags SystemTagsList `json:"tags" csv:"tags" query:"ih.tags" gorm:"column:tags"`
 }
 
 type SystemGroups struct {
-	Groups SystemGroupsList `json:"groups" csv:"groups" query:"ih.groups" gorm:"column:groups_json" order_query:"ih.groups->0->>'name'"`
+	Groups SystemGroupsList `json:"groups" csv:"groups" query:"ih.groups" gorm:"column:groups" order_query:"ih.groups->0->>'name'"`
 }
 
 type BaselineAttributes struct {


### PR DESCRIPTION
change gorm column name of groups and tags so we are able to sort by `sort=groups` and `sort=tags` (`sort=tags` isn't documented but I changed it) it was possible to sort with `sort=groups_json` (breaks sorting in prod) and `sort=tags_json`

I would expect that sorting should work according to attribute name in json, I tried to changed that to use the json attribute name instead of gorm column name but that broke osname, osmajor, osminor sorts...
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
