### PR TITLE
RHINENG-11685: debug only gin context request header

### DIFF
--- a/manager/middlewares/rbac.go
+++ b/manager/middlewares/rbac.go
@@ -108,7 +108,7 @@ func isAccessGranted(c *gin.Context) bool {
 		utils.LogDebug("response_headers", res.Header, "request_headers", res.Request.Header, "isAccessGranted rbac")
 	}
 	if c.Request != nil {
-		utils.LogDebug("gin_context_req", *c.Request, "isAccessGranted rbac")
+		utils.LogDebug("gin_context_req_header", c.Request.Header, "isAccessGranted rbac")
 	}
 	if res != nil && res.Body != nil {
 		defer res.Body.Close()
@@ -202,7 +202,7 @@ func RBAC() gin.HandlerFunc {
 			return
 		}
 		if c.Request != nil {
-			utils.LogDebug("context_req", c.Request, "RBAC")
+			utils.LogDebug("context_req_header", c.Request.Header, "RBAC")
 		}
 		c.AbortWithStatusJSON(http.StatusUnauthorized,
 			utils.ErrorResponse{Error: "You don't have access to this application"})


### PR DESCRIPTION
current log fails with
```
Unable to read entry, failed to marshal fields to JSON, json: unsupported type: func() (io.ReadCloser, error)
Failed to fire hook: failed to marshal fields to JSON, json: unsupported type: func() (io.ReadCloser, error)
```
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
