### PR TITLE
RHINENG-14936: fix wrong type casting in db

### DIFF
--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -351,7 +351,7 @@ func CreateBaselineWithConfig(t *testing.T, name string, inventoryIDs []string,
 	}
 
 	err := tx.Model(models.SystemPlatform{}).
-		Where("rh_account_id = (?) AND inventory_id::text IN (?) AND EXISTS (SELECT * FROM inventory.hosts WHERE id IN (?))",
+		Where("rh_account_id = (?) AND inventory_id IN (?::uuid) AND EXISTS (SELECT * FROM inventory.hosts WHERE id IN (?))",
 			1, inventoryIDs, inventoryIDs).
 		Update("baseline_id", temporaryBaseline.ID).Error
 

--- a/listener/upload_test.go
+++ b/listener/upload_test.go
@@ -112,7 +112,7 @@ func TestUploadHandler(t *testing.T) {
 	assertSystemInDB(t, id, nil, &reporterID)
 
 	var sys models.SystemPlatform
-	assert.NoError(t, database.DB.Where("inventory_id::text = ?", id).Find(&sys).Error)
+	assert.NoError(t, database.DB.Where("inventory_id = ?::uuid", id).Find(&sys).Error)
 	after := time.Now().Add(time.Hour)
 	sys.LastEvaluation = &after
 	assert.NoError(t, database.DB.Save(&sys).Error)

--- a/manager/controllers/baseline_create.go
+++ b/manager/controllers/baseline_create.go
@@ -160,7 +160,7 @@ func checkInventoryIDs(db *gorm.DB, accountID int, inventoryIDs []string, groups
 	var satelliteIDs []string
 	var bootcIDs []string
 	err = database.Systems(db, accountID, groups).
-		Where("inventory_id::text IN (?)", inventoryIDs).
+		Where("inventory_id IN (?::uuid)", inventoryIDs).
 		Scan(&containingSystems).Error
 	if err != nil {
 		return errors.Join(base.ErrDatabase, err)

--- a/manager/controllers/baseline_update.go
+++ b/manager/controllers/baseline_update.go
@@ -151,7 +151,7 @@ func updateSystemsBaselineID(tx *gorm.DB, rhAccountID int, inventoryIDs []string
 	newBaselineID, oldBaselineID *int64) error {
 	updateFields := map[string]interface{}{"baseline_id": newBaselineID, "unchanged_since": time.Now()}
 	tx = tx.Model(models.SystemPlatform{}).
-		Where("rh_account_id = (?) AND inventory_id::text IN (?)", rhAccountID, inventoryIDs)
+		Where("rh_account_id = (?) AND inventory_id IN (?::uuid)", rhAccountID, inventoryIDs)
 
 	// oldBaselineID is used to prevent overwriting inventory IDs of another baseline
 	if oldBaselineID != nil {

--- a/manager/controllers/baseline_update_test.go
+++ b/manager/controllers/baseline_update_test.go
@@ -112,7 +112,7 @@ func TestUpdateBaselineInvalidSystem(t *testing.T) {
 	data := `{
 		"inventory_ids": {
 			"00000000-0000-0000-0000-000000000005": false,
-			"incorrect_id": false,
+			"c0ffeec0-ffee-c0ff-eec0-ffeec0ffee00": false,
 			"00000000-0000-0000-0000-000000000009": true
 		}
 	}`
@@ -121,7 +121,8 @@ func TestUpdateBaselineInvalidSystem(t *testing.T) {
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusNotFound, &errResp)
-	assert.Equal(t, "not found\nunknown inventory_ids: [00000000-0000-0000-0000-000000000009 incorrect_id]",
+	assert.Equal(t, "not found\n"+
+		"unknown inventory_ids: [00000000-0000-0000-0000-000000000009 c0ffeec0-ffee-c0ff-eec0-ffeec0ffee00]",
 		errResp.Error)
 	database.DeleteBaseline(t, baselineID)
 }

--- a/manager/controllers/systems_advisories_view.go
+++ b/manager/controllers/systems_advisories_view.go
@@ -154,7 +154,7 @@ func advisoriesSystemsQuery(c *gin.Context, db *gorm.DB, acc int, groups map[str
 		Distinct(systemsAdvisoriesSelect).
 		Joins("LEFT JOIN system_advisories sa ON am.id = sa.advisory_id AND sa.rh_account_id = ? AND sa.status_id = 0", acc)
 	if len(systems) > 0 {
-		query = query.Joins(fmt.Sprintf("%s AND sp.inventory_id::text in (?)", spJoin), systems)
+		query = query.Joins(fmt.Sprintf("%s AND sp.inventory_id in (?::uuid)", spJoin), systems)
 	} else {
 		query = query.Joins(spJoin)
 	}

--- a/manager/controllers/template_systems_delete_test.go
+++ b/manager/controllers/template_systems_delete_test.go
@@ -57,5 +57,6 @@ func TestTemplateSystemsDeleteInvalid(t *testing.T) {
 		testTemplateSystemsDelete(t, req, http.StatusBadRequest)
 	}
 
-	testTemplateSystemsDelete(t, TemplateSystemsUpdateRequest{Systems: []string{"foo"}}, http.StatusNotFound)
+	testTemplateSystemsDelete(t, TemplateSystemsUpdateRequest{
+		Systems: []string{"c0ffeec0-ffee-c0ff-eec0-ffeec0ffee00"}}, http.StatusNotFound)
 }

--- a/manager/controllers/template_systems_update_test.go
+++ b/manager/controllers/template_systems_update_test.go
@@ -71,7 +71,7 @@ func TestUpdateTemplateInvalidSystem(t *testing.T) {
 	data := `{
 		"systems": [
 			"00000000-0000-0000-0000-000000000005",
-			"this-is-not-a-uuid",
+			"c0ffeec0-ffee-c0ff-eec0-ffeec0ffee00",
 			"00000000-0000-0000-0000-000000000009"
 		]
 	}`
@@ -82,8 +82,9 @@ func TestUpdateTemplateInvalidSystem(t *testing.T) {
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusNotFound, &errResp)
 	// 00000000-0000-0000-0000-000000000009 is from different account and should not be added
-	// this-is-not-a-uuid is not a valid uuid
-	assert.Equal(t, "not found\nunknown inventory_ids: [00000000-0000-0000-0000-000000000009 this-is-not-a-uuid]",
+	// c0ffeec0-ffee-c0ff-eec0-ffeec0ffee00 is not a valid uuid
+	assert.Equal(t, "not found\n"+
+		"unknown inventory_ids: [00000000-0000-0000-0000-000000000009 c0ffeec0-ffee-c0ff-eec0-ffeec0ffee00]",
 		errResp.Error)
 	database.DeleteTemplate(t, templateAccount, templateUUID)
 }


### PR DESCRIPTION
inventory_id::text IN (?) which prevents use of indexes correct cast is the other way: inventory_id IN (?::uuid)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
