### PR TITLE
task: Add required FIPS dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ COPY --from=buildimg /etc/pki/tls/certs/ca-bundle.crt /etc/pki/tls/certs/
 COPY --from=buildimg /etc/crypto-policies/ /etc/crypto-policies/
 COPY --from=buildimg /usr/lib64/.lib* /usr/lib64/
 COPY --from=buildimg /usr/lib64/libssl* /usr/lib64/
+COPY --from=buildimg /usr/lib64/ossl-modules/ /usr/lib64/ossl-modules/
 COPY --from=buildimg /usr/bin/pg_repack /usr/bin/
 
 # copy libs needed by main


### PR DESCRIPTION
When running in RHEL9, the /usr/lib64/ossl-modules directory is also required to be copied into the micro image. Without it, FIPS errors occur during the database init phase of the startup.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
