### PR TITLE
RHINENG-16833: disable semantic commits by renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "on Monday after 3am and before 10am"
   ],
   "timezone": "Europe/Prague",
+  "semanticCommits": "disabled",
   "tekton": {
     "automerge": true,
     "automergeStrategy": "rebase",


### PR DESCRIPTION
default setting is 'auto' which causes that renovate decides to use semantic commits based on last commits. It happens that closed PRs updating major versions are re-opened due to commits having different format

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices
