### PR TITLE
switch to grouped query for host template floorist query

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -557,6 +557,20 @@ objects:
             JOIN rh_account a ON a.id = sp.rh_account_id
             LEFT JOIN template t on t.id = sp.template_id
           ORDER BY a.org_id, sp.inventory_id;
+    queries:
+      - prefix: hms_analytics/content-sources/system-template-grouped
+        chunksize: ${{FLOORIST_HMS_CHUNKSIZE}}
+        query: >-
+          SELECT a.org_id,
+                 count(ih.id),
+                 t.uuid::text as template_uuid, t.environment_id, t.name as template_name
+            FROM system_platform sp
+            JOIN inventory.hosts ih ON sp.inventory_id = ih.id
+            JOIN rh_account a ON a.id = sp.rh_account_id
+            LEFT JOIN template t on t.id = sp.template_id
+            where sp.last_upload >= date_trunc('month', CURRENT_DATE)
+            group by a.org_id, template_uuid, t.environment_id, template_name
+            ORDER BY a.org_id;
 
 
 - apiVersion: v1


### PR DESCRIPTION
The current query was great, but produced a LOT of data, about 2.5 GB a month.  This one should reduce it down quite a bit more.  In addition it only includes systems that have checked in the current calendar month.  We only really care about data monthly, so i think this is fine.   

This will still give us the count of systems per template per org, and a count of systems not in any template per org.

we'll keep the old query around for continuity (and remove it once we have a whole month of the new data)


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Optimize the host template query to reduce data volume and focus on monthly system check-ins

Enhancements:
- Refactored database query to use grouped aggregation
- Limited query to systems checked in before the current month

Chores:
- Replaced existing query with a more efficient version