### PR TITLE
RHINENG-15783: remove permissions for deleted APIs

### DIFF
--- a/manager/middlewares/rbac.go
+++ b/manager/middlewares/rbac.go
@@ -29,10 +29,6 @@ const patchWritePerm = "patch:*:write"
 
 // handlerName to permissions mapping
 var granularPerms = map[string]string{
-	"CreateBaselineHandler":        "patch:template:write",
-	"BaselineUpdateHandler":        "patch:template:write",
-	"BaselineDeleteHandler":        "patch:template:write",
-	"BaselineSystemsRemoveHandler": "patch:template:write",
 	"TemplateSystemsUpdateHandler": "content-sources:templates:write",
 	"TemplateSystemsDeleteHandler": "content-sources:templates:write",
 	"SystemDeleteHandler":          "patch:system:write",

--- a/manager/middlewares/rbac_test.go
+++ b/manager/middlewares/rbac_test.go
@@ -47,11 +47,11 @@ func TestRBACPut(t *testing.T) {
 }
 
 func TestPermissionsSingleWrite(t *testing.T) {
-	// handler needs `patch:template:write`
-	handler := "CreateBaselineHandler"
+	// handler needs `content-sources:templates:write`
+	handler := "TemplateSystemsUpdateHandler"
 	access := rbac.AccessPagination{
 		Data: []rbac.Access{
-			{Permission: "patch:*:*"},
+			{Permission: "content-sources:*:*"},
 			{Permission: "inventory:*:*"},
 		},
 	}
@@ -59,7 +59,7 @@ func TestPermissionsSingleWrite(t *testing.T) {
 
 	access = rbac.AccessPagination{
 		Data: []rbac.Access{
-			{Permission: "patch:*:write"},
+			{Permission: "content-sources:*:write"},
 			{Permission: "inventory:*:*"},
 		},
 	}
@@ -67,7 +67,7 @@ func TestPermissionsSingleWrite(t *testing.T) {
 
 	access = rbac.AccessPagination{
 		Data: []rbac.Access{
-			{Permission: "patch:template:write"},
+			{Permission: "content-sources:templates:write"},
 			{Permission: "inventory:*:*"},
 		},
 	}
@@ -75,14 +75,14 @@ func TestPermissionsSingleWrite(t *testing.T) {
 
 	access = rbac.AccessPagination{
 		Data: []rbac.Access{
-			{Permission: "patch:asdf:write"},
+			{Permission: "content-sources:asdf:write"},
 		},
 	}
 	assert.False(t, checkPermissions(&access, handler, "PUT"))
 
 	access = rbac.AccessPagination{
 		Data: []rbac.Access{
-			{Permission: "patch:asdf:read"},
+			{Permission: "content-sources:asdf:read"},
 			{Permission: "inventory:*:*"},
 		},
 	}
@@ -90,7 +90,7 @@ func TestPermissionsSingleWrite(t *testing.T) {
 
 	access = rbac.AccessPagination{
 		Data: []rbac.Access{
-			{Permission: "patch:*:read"},
+			{Permission: "content-sources:*:read"},
 			{Permission: "inventory:*:*"},
 		},
 	}


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Remove outdated RBAC mappings for deleted baseline APIs and update remaining handlers to use the new "content-sources" permission scope.

Enhancements:
- Replace legacy "patch:*" permission patterns with "content-sources:*" scopes for relevant RBAC handlers

Tests:
- Update RBAC tests to reference the new handler names and "content-sources" permission strings instead of legacy "patch" patterns