### PR TITLE
Remove old floorist query and add date of collection

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -546,24 +546,13 @@ objects:
         cpu: ${CPU_REQUEST_FLOORIST}
         memory: ${MEM_REQUEST_FLOORIST}
     queries:
-      - prefix: hms_analytics/content-sources/system-template
-        chunksize: ${{FLOORIST_HMS_CHUNKSIZE}}
-        query: >-
-          SELECT a.org_id, sp.inventory_id, sp.display_name,
-                 t.uuid::text as template_uuid, t.environment_id, t.name as template_name,
-                 sp.last_upload
-            FROM system_platform sp
-            JOIN inventory.hosts ih ON sp.inventory_id = ih.id
-            JOIN rh_account a ON a.id = sp.rh_account_id
-            LEFT JOIN template t on t.id = sp.template_id
-          ORDER BY a.org_id, sp.inventory_id;
-    queries:
       - prefix: hms_analytics/content-sources/system-template-grouped
         chunksize: ${{FLOORIST_HMS_CHUNKSIZE}}
         query: >-
           SELECT a.org_id,
                  count(ih.id),
-                 t.uuid::text as template_uuid, t.environment_id, t.name as template_name
+                 t.uuid::text as template_uuid, t.environment_id, t.name as template_name,
+                 CURRENT_DATE as collected_at 
             FROM system_platform sp
             JOIN inventory.hosts ih ON sp.inventory_id = ih.id
             JOIN rh_account a ON a.id = sp.rh_account_id


### PR DESCRIPTION
Removes old query that was slower now that the new query is running, and adds a date to the query to make processing easier.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Remove the old slow floorist query and add a collection date field to the grouped system-template query

Enhancements:
- Remove the deprecated floorist query for system-template
- Include CURRENT_DATE as a timestamp in the system-template-grouped query results