### PR TITLE
RHINENG-15506: fix typo in API path

### DIFF
--- a/manager/controllers/template_systems_update.go
+++ b/manager/controllers/template_systems_update.go
@@ -189,7 +189,7 @@ func templateArchVersionMatch(
 
 func callCandlepin(ctx context.Context, owner string, request *candlepin.ConsumersEnvironmentsRequest) (
 	*candlepin.ConsumersUpdateResponse, error) {
-	candlepinEnvConsumersURL := utils.CoreCfg.CandlepinAddress + "/owner/" + owner + "/consumers/environments"
+	candlepinEnvConsumersURL := utils.CoreCfg.CandlepinAddress + "/owners/" + owner + "/consumers/environments"
 	candlepinFunc := func() (interface{}, *http.Response, error) {
 		candlepinResp := candlepin.ConsumersUpdateResponse{}
 		resp, err := candlepinClient.Request(&ctx, http.MethodPut, candlepinEnvConsumersURL, request, &candlepinResp)

--- a/platform/candlepin.go
+++ b/platform/candlepin.go
@@ -57,5 +57,5 @@ func candlepinConsumersEnvironmentsHandler(c *gin.Context) {
 func initCandlepin(app *gin.Engine) {
 	app.PUT("/candlepin/consumers/:consumer", candlepinConsumersPutHandler)
 	app.GET("/candlepin/consumers/:consumer", candlepinConsumersGetHandler)
-	app.PUT("/candlepin/owner/:owner/consumers/environments", candlepinConsumersEnvironmentsHandler)
+	app.PUT("/candlepin/owners/:owner/consumers/environments", candlepinConsumersEnvironmentsHandler)
 }


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Fix typo in candlepin consumers environments API path by changing the URL segment from "owner" to "owners" in both client calls and server routes

Bug Fixes:
- Correct the client request URL to use "/owners/:owner/consumers/environments" instead of "/owner/:owner/consumers/environments"
- Update the server route registration to match the corrected "/candlepin/owners/:owner/consumers/environments" path