### PR TITLE
fix: format timestamps with nanoseconds

### DIFF
--- a/base/database/utils.go
+++ b/base/database/utils.go
@@ -90,7 +90,7 @@ func Timestamp2Str(ts *types.Rfc3339TimestampWithZ) *string {
 	if ts == nil {
 		return nil
 	}
-	ret := ts.Time().Format(time.RFC3339)
+	ret := ts.Time().Format(time.RFC3339Nano)
 	return &ret
 }
 
@@ -119,7 +119,7 @@ func GetTimestampKVValue(key string) (*types.Rfc3339TimestampWithZ, error) {
 }
 
 func UpdateTimestampKVValue(key string, value time.Time) {
-	ts := value.Format(time.RFC3339)
+	ts := value.Format(time.RFC3339Nano)
 	err := UpdateTimestampKVValueStr(key, ts)
 	if err != nil {
 		utils.LogError("err", err.Error(), "key", key, "Unable to updated timestamp KV value")

--- a/base/types/timestamp.go
+++ b/base/types/timestamp.go
@@ -53,7 +53,7 @@ func (d *Rfc3339Timestamp) Time() *time.Time {
 }
 
 func (d Rfc3339TimestampWithZ) MarshalJSON() ([]byte, error) {
-	return sonic.Marshal(d.Time().Format(time.RFC3339))
+	return sonic.Marshal(d.Time().Format(time.RFC3339Nano))
 }
 
 func (d *Rfc3339TimestampWithZ) UnmarshalJSON(data []byte) error {

--- a/tasks/vmaas_sync/vmaas_sync_test.go
+++ b/tasks/vmaas_sync/vmaas_sync_test.go
@@ -34,7 +34,7 @@ func TestSyncDates(t *testing.T) {
 	evalWriter = &mockKafkaWriter{}
 
 	// ensure timestamp_kv is empty
-	assert.NoError(t, database.DB.Table("timestamp_kv").Delete(&models.TimestampKV{}).Error)
+	assert.NoError(t, database.DB.Table("timestamp_kv").Where("1=1").Delete(&models.TimestampKV{}).Error)
 
 	// there's no timestamp before first sync
 	ts := GetLastSync(VmaasExported)
@@ -55,7 +55,7 @@ func TestSync(t *testing.T) {
 	Configure()
 
 	// ensure timestamp_kv is empty
-	assert.NoError(t, database.DB.Table("timestamp_kv").Delete(&models.TimestampKV{}).Error)
+	assert.NoError(t, database.DB.Table("timestamp_kv").Where("1=1").Delete(&models.TimestampKV{}).Error)
 
 	// ensure all repos to be marked "third_party" = true
 	assert.NoError(t, database.DB.Table("repo").Where("name IN (?)", []string{"repo1", "repo2", "repo3"}).

--- a/tasks/vmaas_sync/vmaas_sync_test.go
+++ b/tasks/vmaas_sync/vmaas_sync_test.go
@@ -33,6 +33,9 @@ func TestSyncDates(t *testing.T) {
 	Configure()
 	evalWriter = &mockKafkaWriter{}
 
+	// ensure timestamp_kv is empty
+	assert.NoError(t, database.DB.Table("timestamp_kv").Delete(&models.TimestampKV{}).Error)
+
 	// there's no timestamp before first sync
 	ts := GetLastSync(VmaasExported)
 	assert.Nil(t, ts)
@@ -40,7 +43,7 @@ func TestSyncDates(t *testing.T) {
 	runSync()
 
 	ts = GetLastSync(VmaasExported)
-	assert.Equal(t, "2222-04-16 20:07:59 +0000 UTC", ts.Time().String())
+	assert.Equal(t, "2222-04-16 20:07:59.235962 +0000 UTC", ts.Time().String())
 	database.DeleteNewlyAddedPackages(t)
 	database.DeleteNewlyAddedAdvisories(t)
 	msgs = nil
@@ -50,6 +53,9 @@ func TestSync(t *testing.T) {
 	utils.SkipWithoutDB(t)
 	core.SetupTestEnvironment()
 	Configure()
+
+	// ensure timestamp_kv is empty
+	assert.NoError(t, database.DB.Table("timestamp_kv").Delete(&models.TimestampKV{}).Error)
 
 	// ensure all repos to be marked "third_party" = true
 	assert.NoError(t, database.DB.Table("repo").Where("name IN (?)", []string{"repo1", "repo2", "repo3"}).


### PR DESCRIPTION
vmaas sync was syncing data when there was nothing to sync, timestamp from vmaas had timestamp with nanoseconds but timestamp from db was trimmed

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Use nanosecond-precision formatting for all timestamps to maintain consistency and avoid false sync triggers.

Bug Fixes:
- Prevent unnecessary syncing by preserving nanosecond precision in timestamp comparisons

Enhancements:
- Switch timestamp formatting to RFC3339Nano in database utilities and JSON marshaling