### PR TITLE
RHINENG-19363: update golangci-lint version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN if [ "$INSTALL_TOOLS" == "yes" ] ; then \
         go install github.com/swaggo/swag/cmd/swag@v1.16.4 && \
         go install gotest.tools/gotestsum@v1.12.0 && \
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-        | sh -s -- -b $(go env GOPATH)/bin v1.63.4 ; \
+        | sh -s -- -b $(go env GOPATH)/bin v1.64.8 ; \
     fi
 
 ADD --chown=insights:insights dev/kafka/secrets/ca.crt /opt/kafka/


### PR DESCRIPTION
Update golangci-lint version to one that was built with at least go1.23.0 to resolve mismatch between the go versions of the app and golangci-lint, which is the most likely cause of failing check on all PRs.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Update Dockerfile to install golangci-lint v1.64.8 built with Go 1.23+ to align tool and application Go versions and resolve CI check failures

Bug Fixes:
- Address linting failures caused by Go version mismatch between the app and golangci-lint

Enhancements:
- Bump golangci-lint from v1.63.4 to v1.64.8 for compatibility with Go 1.23