### PR TITLE
chore: build from rhel repo on registered rhel system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,9 @@ FROM ${BUILDIMG} as buildimg
 ARG INSTALL_TOOLS=no
 
 # install build, development and test environment
-RUN curl -o /etc/yum.repos.d/postgresql.repo \
-        https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo
-
-RUN dnf install -y go-toolset postgresql diffutils rpm-devel pg_repack
+RUN (dnf module enable -y postgresql:16 || curl -o /etc/yum.repos.d/postgresql.repo \
+        https://copr.fedorainfracloud.org/coprs/g/insights/postgresql-16/repo/epel-9/group_insights-postgresql-16-epel-9.repo) && \
+     dnf install -y go-toolset postgresql diffutils rpm-devel pg_repack
 
 ENV GOPATH=/go \
     GO111MODULE=on \


### PR DESCRIPTION
konflux hermetic build does not allow installation of packages from copr

postgresql 16 module may contain incompatible pg_repack version, it must be tested in stage

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Update Dockerfile to conditionally use the RHEL-9 native PostgreSQL 16 module when the build image is registered, and fall back to adding the Copr repository otherwise to ensure compatible pg_repack versions.

Enhancements:
- Add logic to detect a registered RHEL-9 system and enable the postgresql:16 module
- Fall back to installing from the Copr PostgreSQL 16 repo if the RHEL module is not available

Build:
- Adjust Dockerfile build stage to use microdnf module enable for PostgreSQL on RHEL or curl to add the Copr repo