### PR TITLE
RHINENG-19880: defer system deletion using stale/culled markers

### DIFF
--- a/listener/events.go
+++ b/listener/events.go
@@ -102,11 +102,5 @@ func HandleDelete(event mqueue.PlatformEvent) error {
 	utils.LogInfo("inventoryID", event.ID, "count", query.RowsAffected, "Systems deleted")
 	eventMsgsReceivedCnt.WithLabelValues(EventDelete, ReceivedSuccess).Inc()
 
-	err = database.DB.
-		Delete(&models.DeletedSystem{}, "when_deleted < ?", time.Now().Add(-deletionThreshold)).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-		utils.LogWarn("inventoryID", event.ID, WarnNoRowsModified)
-		return nil
-	}
 	return nil
 }

--- a/tasks/config.go
+++ b/tasks/config.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"app/base/utils"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -39,4 +40,6 @@ var (
 	// How ofter run full vmaas sync, 7 days by default
 	FullSyncCadence    = utils.PodConfig.GetInt("full_sync_cadence", 24*7)
 	MaxChangedPackages = utils.PodConfig.GetInt("max_changed_packages", 30000)
+	// prune deleted_system table records older than threshold
+	DeletedSystemsThreshold = time.Hour * time.Duration(utils.PodConfig.GetInt("system_delete_hrs", 4))
 )


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Defer system deletion by marking records as stale and culled and prune them in the background system_culling job, update HandleDelete accordingly, and revise tests to cover the new deletion and pruning workflows

New Features:
- Mark systems as stale and culled instead of immediately removing them to defer physical deletion
- Introduce pruneDeletedSystems function in the system_culling task to purge old DeletedSystem entries

Enhancements:
- Modify HandleDelete to update stale and culled timestamps rather than calling the delete_system stored procedure
- Add DeletedSystemsThreshold configuration for controlling how long deleted records are retained

Tests:
- Update listener tests to assert stale and culled markers and cover delete–upload interactions
- Add TestPruneDeletedSystems to verify pruning of DeletedSystem records
- Introduce assertSystemStaleAndCulled test helper and include DeletedSystem cleanup in common test teardown