### PR TITLE
RHINENG-20474: simplify trigger on system_platform

### DIFF
--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -232,9 +232,6 @@ func CheckSystemAdvisories(t *testing.T, systemID int64, advisoryIDs []int64) {
 		Find(&systemAdvisories).Error
 	assert.Nil(t, err)
 	assert.Equal(t, len(advisoryIDs), len(systemAdvisories))
-	for _, systemAdvisory := range systemAdvisories {
-		assert.NotNil(t, systemAdvisory.FirstReported)
-	}
 }
 
 func CheckEVRAsInDB(t *testing.T, nExpected int, evras ...string) {

--- a/base/models/models.go
+++ b/base/models/models.go
@@ -215,12 +215,11 @@ func (AdvisoryMetadata) TableName() string {
 type AdvisoryMetadataSlice []AdvisoryMetadata
 
 type SystemAdvisories struct {
-	RhAccountID   int   `gorm:"primaryKey"`
-	SystemID      int64 `gorm:"primaryKey"`
-	AdvisoryID    int64 `gorm:"primaryKey"`
-	Advisory      AdvisoryMetadata
-	FirstReported *time.Time
-	StatusID      int
+	RhAccountID int   `gorm:"primaryKey"`
+	SystemID    int64 `gorm:"primaryKey"`
+	AdvisoryID  int64 `gorm:"primaryKey"`
+	Advisory    AdvisoryMetadata
+	StatusID    int
 }
 
 func (SystemAdvisories) TableName() string {

--- a/database_admin/migrations/134_on_system_update.down.sql
+++ b/database_admin/migrations/134_on_system_update.down.sql
@@ -1,0 +1,74 @@
+CREATE OR REPLACE FUNCTION on_system_update()
+-- this trigger updates advisory_account_data when server changes its stale flag
+    RETURNS TRIGGER
+AS
+$system_update$
+DECLARE
+    was_counted  BOOLEAN;
+    should_count BOOLEAN;
+    change       INT;
+BEGIN
+    -- Ignore not yet evaluated systems
+    IF TG_OP != 'UPDATE' OR NEW.last_evaluation IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    was_counted := OLD.stale = FALSE;
+    should_count := NEW.stale = FALSE;
+
+    -- Determine what change we are performing
+    IF was_counted and NOT should_count THEN
+        change := -1;
+    ELSIF NOT was_counted AND should_count THEN
+        change := 1;
+    ELSE
+        -- No change
+        RETURN NEW;
+    END IF;
+
+    -- find advisories linked to the server
+    WITH to_update_advisories AS (
+        SELECT aad.advisory_id,
+               aad.rh_account_id,
+               case when sa.status_id = 0 then change else 0 end as systems_installable_change,
+               change as systems_applicable_change
+          FROM advisory_account_data aad
+          JOIN system_advisories sa ON aad.advisory_id = sa.advisory_id
+          -- Filter advisory_account_data only for advisories affectign this system & belonging to system account
+         WHERE aad.rh_account_id =  NEW.rh_account_id
+           AND sa.system_id = NEW.id AND sa.rh_account_id = NEW.rh_account_id
+         ORDER BY aad.advisory_id),
+         -- update existing rows
+         update AS (
+            UPDATE advisory_account_data aad
+               SET systems_installable = aad.systems_installable + ta.systems_installable_change,
+                   systems_applicable = aad.systems_applicable + ta.systems_applicable_change
+              FROM to_update_advisories ta
+             WHERE aad.advisory_id = ta.advisory_id
+               AND aad.rh_account_id = NEW.rh_account_id
+         )
+    -- If we have system affected && no exisiting advisory_account_data entry, we insert new rows
+    INSERT
+      INTO advisory_account_data (advisory_id, rh_account_id, systems_installable, systems_applicable)
+    SELECT sa.advisory_id, NEW.rh_account_id,
+           case when sa.status_id = 0 then 1 else 0 end as systems_installable,
+           1 as systems_applicable
+    FROM system_advisories sa
+    WHERE sa.system_id = NEW.id AND sa.rh_account_id = NEW.rh_account_id
+      AND change > 0
+      -- create only rows which are not already in to_update_advisories
+      AND (NEW.rh_account_id, sa.advisory_id) NOT IN (
+            SELECT ta.rh_account_id, ta.advisory_id
+              FROM to_update_advisories ta
+    )
+    ON CONFLICT (advisory_id, rh_account_id) DO UPDATE
+        SET systems_installable = advisory_account_data.systems_installable + EXCLUDED.systems_installable,
+            systems_applicable = advisory_account_data.systems_applicable + EXCLUDED.systems_applicable;
+    RETURN NEW;
+END;
+$system_update$ LANGUAGE plpgsql;
+
+SELECT create_table_partition_triggers('system_platform_on_update',
+                                       $$AFTER UPDATE$$,
+                                       'system_platform',
+                                       $$FOR EACH ROW EXECUTE PROCEDURE on_system_update()$$);

--- a/database_admin/migrations/134_on_system_update.up.sql
+++ b/database_admin/migrations/134_on_system_update.up.sql
@@ -1,0 +1,47 @@
+CREATE OR REPLACE FUNCTION on_system_update()
+-- this trigger updates advisory_account_data when server changes its stale flag
+    RETURNS TRIGGER
+AS
+$system_update$
+DECLARE
+    was_counted  BOOLEAN;
+    should_count BOOLEAN;
+    change       INT;
+BEGIN
+    -- Ignore not yet evaluated systems
+    IF TG_OP != 'UPDATE' OR NEW.last_evaluation IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    was_counted := OLD.stale = FALSE;
+    should_count := NEW.stale = FALSE;
+
+    -- Determine what change we are performing
+    IF was_counted and NOT should_count THEN
+        change := -1;
+    ELSIF NOT was_counted AND should_count THEN
+        change := 1;
+    ELSE
+        -- No change
+        RETURN NEW;
+    END IF;
+
+    -- insert/update advisories linked to the server
+    INSERT
+      INTO advisory_account_data (advisory_id, rh_account_id, systems_installable, systems_applicable)
+    SELECT sa.advisory_id, NEW.rh_account_id,
+           case when sa.status_id = 0 then change else 0 end as systems_installable,
+           change as systems_applicable
+      FROM system_advisories sa
+     WHERE sa.system_id = NEW.id AND sa.rh_account_id = NEW.rh_account_id
+        ON CONFLICT (advisory_id, rh_account_id) DO UPDATE
+           SET systems_installable = advisory_account_data.systems_installable + EXCLUDED.systems_installable,
+               systems_applicable = advisory_account_data.systems_applicable + EXCLUDED.systems_applicable;
+    RETURN NEW;
+END;
+$system_update$ LANGUAGE plpgsql;
+
+SELECT create_table_partition_triggers('system_platform_on_update',
+                                       $$AFTER UPDATE$$,
+                                       'system_platform',
+                                       $$FOR EACH ROW EXECUTE PROCEDURE on_system_update()$$);

--- a/database_admin/migrations/135_set_first_reported.down.sql
+++ b/database_admin/migrations/135_set_first_reported.down.sql
@@ -1,0 +1,18 @@
+CREATE OR REPLACE FUNCTION set_first_reported()
+    RETURNS TRIGGER AS
+$set_first_reported$
+BEGIN
+    IF NEW.first_reported IS NULL THEN
+        NEW.first_reported := CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+END;
+$set_first_reported$
+    LANGUAGE 'plpgsql';
+
+ALTER TABLE system_advisories ALTER COLUMN first_reported DROP DEFAULT;
+
+SELECT create_table_partition_triggers('system_advisories_set_first_reported',
+                                       $$BEFORE INSERT$$,
+                                       'system_advisories',
+                                       $$FOR EACH ROW EXECUTE PROCEDURE set_first_reported()$$);

--- a/database_admin/migrations/135_set_first_reported.up.sql
+++ b/database_admin/migrations/135_set_first_reported.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE system_advisories ALTER COLUMN first_reported SET DEFAULT CURRENT_TIMESTAMP;
+
+select drop_table_partition_triggers('system_advisories_set_first_reported', '', 'system_advisories', '');
+
+DROP FUNCTION IF EXISTS set_first_reported();
+

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (133, false);
+VALUES (134, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -107,44 +107,17 @@ BEGIN
         RETURN NEW;
     END IF;
 
-    -- find advisories linked to the server
-    WITH to_update_advisories AS (
-        SELECT aad.advisory_id,
-               aad.rh_account_id,
-               case when sa.status_id = 0 then change else 0 end as systems_installable_change,
-               change as systems_applicable_change
-          FROM advisory_account_data aad
-          JOIN system_advisories sa ON aad.advisory_id = sa.advisory_id
-          -- Filter advisory_account_data only for advisories affectign this system & belonging to system account
-         WHERE aad.rh_account_id =  NEW.rh_account_id
-           AND sa.system_id = NEW.id AND sa.rh_account_id = NEW.rh_account_id
-         ORDER BY aad.advisory_id),
-         -- update existing rows
-         update AS (
-            UPDATE advisory_account_data aad
-               SET systems_installable = aad.systems_installable + ta.systems_installable_change,
-                   systems_applicable = aad.systems_applicable + ta.systems_applicable_change
-              FROM to_update_advisories ta
-             WHERE aad.advisory_id = ta.advisory_id
-               AND aad.rh_account_id = NEW.rh_account_id
-         )
-    -- If we have system affected && no exisiting advisory_account_data entry, we insert new rows
+    -- insert/update advisories linked to the server
     INSERT
       INTO advisory_account_data (advisory_id, rh_account_id, systems_installable, systems_applicable)
     SELECT sa.advisory_id, NEW.rh_account_id,
-           case when sa.status_id = 0 then 1 else 0 end as systems_installable,
-           1 as systems_applicable
-    FROM system_advisories sa
-    WHERE sa.system_id = NEW.id AND sa.rh_account_id = NEW.rh_account_id
-      AND change > 0
-      -- create only rows which are not already in to_update_advisories
-      AND (NEW.rh_account_id, sa.advisory_id) NOT IN (
-            SELECT ta.rh_account_id, ta.advisory_id
-              FROM to_update_advisories ta
-    )
-    ON CONFLICT (advisory_id, rh_account_id) DO UPDATE
-        SET systems_installable = advisory_account_data.systems_installable + EXCLUDED.systems_installable,
-            systems_applicable = advisory_account_data.systems_applicable + EXCLUDED.systems_applicable;
+           case when sa.status_id = 0 then change else 0 end as systems_installable,
+           change as systems_applicable
+      FROM system_advisories sa
+     WHERE sa.system_id = NEW.id AND sa.rh_account_id = NEW.rh_account_id
+        ON CONFLICT (advisory_id, rh_account_id) DO UPDATE
+           SET systems_installable = advisory_account_data.systems_installable + EXCLUDED.systems_installable,
+               systems_applicable = advisory_account_data.systems_applicable + EXCLUDED.systems_applicable;
     RETURN NEW;
 END;
 $system_update$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Simplify database trigger logic for system_platform updates by consolidating upsert operations, replace first_reported trigger with a default timestamp, update development scripts and Go models to match schema changes

Enhancements:
- Simplify on_system_update trigger to use a single INSERT ... ON CONFLICT upsert for advisory_account_data
- Remove set_first_reported trigger and add default CURRENT_TIMESTAMP on system_advisories.first_reported
- Update test data generation scripts to include last_evaluation, packages_installable, and packages_applicable columns and use truncate for inventory.hosts
- Remove FirstReported field and associated test assertions from the SystemAdvisories Go model

Build:
- Bump schema migration version to 135 and add dedicated up/down SQL migrations for on_system_update trigger and first_reported default