### PR TITLE
improve test reliability

### DIFF
--- a/dev/scripts/wait-for-kafka.sh
+++ b/dev/scripts/wait-for-kafka.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-until curl -s $KAFKA_READY_ADDRESS >/dev/null ; do
+until [[ "$(curl -s $KAFKA_READY_ADDRESS)" == "TOPICS READY" ]] ; do
   >&2 echo "Kafka topics not ready yet"
   sleep 1
 done

--- a/scripts/go_test_on_ci.sh
+++ b/scripts/go_test_on_ci.sh
@@ -15,5 +15,13 @@ set -e -o pipefail
 golangci-lint run --timeout 5m
 echo "Go code analysed successfully."
 
+if [[ -n $DB_HOST ]] ; then
+    ./dev/scripts/wait-for-services.sh
+fi
+
+if [[ -n $KAFKA_READY_ADDRESS ]] ; then
+   ./dev/scripts/wait-for-kafka.sh
+fi
+
 # Run project tests
 ./scripts/go_test_db.sh | ./scripts/colorize.sh


### PR DESCRIPTION
wait-for-kafka.sh sometimes infinitely loops because curl gets correct response but fails with Connection reset by peer
+ curl http://kafka:9099/ TOPICS READY
curl: (56) Recv failure: Connection reset by peer

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Ensure dependent services and Kafka readiness in CI scripts and fix infinite loop in Kafka readiness check

Bug Fixes:
- Prevent infinite looping in wait-for-kafka script by matching the exact "TOPICS READY" response

Enhancements:
- Invoke wait-for-services.sh and wait-for-kafka.sh conditionally in go_test_on_ci.sh based on environment variables