### PR TITLE
RHINENG-25740: mark deleted systems only as culled

### DIFF
--- a/listener/common_test.go
+++ b/listener/common_test.go
@@ -72,11 +72,11 @@ func assertSystemNotInDB(t *testing.T) {
 	assert.Equal(t, 0, int(systemCount))
 }
 
-func assertSystemStaleAndCulled(t *testing.T) {
+func assertSystemCulled(t *testing.T) {
 	var systemCount int64
 	now := time.Now()
 	assert.Nil(t, database.DB.Model(models.SystemPlatform{}).
-		Where("stale = true AND stale_timestamp < ? AND culled_timestamp < ?", now, now).
+		Where("culled_timestamp < ?", now).
 		Where("inventory_id = ?::uuid", id).Count(&systemCount).Error)
 
 	assert.Equal(t, 1, int(systemCount))

--- a/listener/events.go
+++ b/listener/events.go
@@ -81,8 +81,6 @@ func HandleDelete(event mqueue.PlatformEvent) error {
 	// mark system as stale and let system_culling job remove it later
 	query := database.DB.Model(&models.SystemInventory{}).Where("inventory_id = ?::uuid", event.ID).
 		Updates(map[string]interface{}{
-			"stale":            true,
-			"stale_timestamp":  gorm.Expr("NOW()"),
 			"culled_timestamp": gorm.Expr("NOW()"),
 		})
 	err = query.Error

--- a/listener/events_test.go
+++ b/listener/events_test.go
@@ -50,7 +50,7 @@ func TestDeleteSystem(t *testing.T) {
 	deleteEvent := createTestDeleteEvent(id)
 	err := HandleDelete(deleteEvent)
 	assert.NoError(t, err)
-	assertSystemStaleAndCulled(t)
+	assertSystemCulled(t)
 	deleteData(t)
 }
 
@@ -136,7 +136,7 @@ func TestCreateDeleteUpload(t *testing.T) {
 	deleteEvent := createTestDeleteEvent(id)
 	err = HandleDelete(deleteEvent)
 	assert.NoError(t, err)
-	assertSystemStaleAndCulled(t)
+	assertSystemCulled(t)
 
 	// second upload of now deleted system should not change anything
 	changedName := "UPDATED"


### PR DESCRIPTION
don't block message processing and let delete_system() running from the job deal with stale/unstale trigger

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Mark deleted systems as culled without flagging them as stale and align tests with the new deletion behavior.

Bug Fixes:
- Ensure delete handling no longer requires systems to be marked stale when they are deleted, relying solely on culled timestamps.

Tests:
- Update listener tests and helper assertions to validate that deleted systems are only marked as culled.