### PR TITLE
RHINENG-25900: grant permissions after pg_repack recreate

### DIFF
--- a/turnpike/controllers/database.go
+++ b/turnpike/controllers/database.go
@@ -24,12 +24,16 @@ type Session struct {
 // @Failure 500 {object} map[string]interface{}
 // @Router /database/pg_repack/recreate [put]
 func RepackRecreateHandler(c *gin.Context) {
-	if err := database.DB.Exec("DROP EXTENSION IF EXISTS pg_repack CASCADE").Error; err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
-		return
+	runSequence := []string{
+		"DROP EXTENSION IF EXISTS pg_repack CASCADE",
+		"CREATE EXTENSION pg_repack",
+		"GRANT USAGE ON SCHEMA repack TO vmaas_sync",
 	}
-	if err := database.DB.Exec("CREATE EXTENSION pg_repack").Error; err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
+	for _, query := range runSequence {
+		if err := database.DB.Exec(query).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
+			return
+		}
 	}
 	c.JSON(http.StatusOK, "pg_repack extension re-created")
 }


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Update the pg_repack recreation endpoint to also restore required permissions after recreating the extension.

Bug Fixes:
- Grant usage on the repack schema to the vmaas_sync role after recreating the pg_repack extension to restore necessary permissions.

Enhancements:
- Execute the pg_repack drop, create, and permission grant statements as a single ordered sequence in the recreation handler.