### PR TITLE
RHINENG-25948: add ff for refreshing advisory cache

### DIFF
--- a/tasks/config.go
+++ b/tasks/config.go
@@ -25,6 +25,8 @@ var (
 	EnablePackagesSync = utils.PodConfig.GetBool("packages_sync", true)
 	// Toggle repo sync in vmaas_sync
 	EnableReposSync = utils.PodConfig.GetBool("repos_sync", true)
+	// Toggle advisory cache refresh in vmaas_sync
+	EnableAdvisoryCacheRefresh = utils.PodConfig.GetBool("advisory_cache_refresh", true)
 	// Sync data in vnass_sync based on timestamp
 	EnableModifiedSinceSync = utils.PodConfig.GetBool("modified_since_sync", true)
 	// Page size for /errata vmass API call

--- a/tasks/vmaas_sync/vmaas_sync.go
+++ b/tasks/vmaas_sync/vmaas_sync.go
@@ -113,7 +113,11 @@ func SyncData(lastModifiedTS *types.Rfc3339TimestampWithZ, vmaasExportedTS *type
 	}
 
 	// refresh caches
-	caches.RefreshAdvisoryCaches()
+	if tasks.EnableAdvisoryCacheRefresh {
+		caches.RefreshAdvisoryCaches()
+	} else {
+		utils.LogInfo("Advisory cache refresh is disabled")
+	}
 
 	utils.LogInfo("Data sync finished successfully")
 	return nil


### PR DESCRIPTION
This PR creates a feature flag to enable/disable refreshing of advisory caches in vmaas sync task. Defaults to enabled.

## Summary by Sourcery

Enhancements:
- Introduce a configurable feature flag to enable or disable advisory cache refresh during vmaas sync, with logging when the refresh is disabled.