### PR TITLE
refactor: remove tStart variable when it is not needed

### DIFF
--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -135,8 +135,7 @@ func confugureEvaluator() {
 }
 
 func Evaluate(ctx context.Context, event *mqueue.PlatformEvent, inventoryID, evaluationType string) error {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationDuration.WithLabelValues(evaluationType))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationDuration.WithLabelValues(evaluationType))
 
 	utils.LogInfo("inventoryID", inventoryID, "Evaluating system")
 	if enableBypass {
@@ -282,8 +281,7 @@ func tryGetYumUpdates(system *models.SystemPlatformV2) (*vmaas.UpdatesV3Response
 
 func evaluateWithVmaas(updatesData *vmaas.UpdatesV3Response,
 	system *models.SystemPlatformV2, event *mqueue.PlatformEvent) (*vmaas.UpdatesV3Response, error) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("evaluate-with-vmaas-full"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("evaluate-with-vmaas-full"))
 
 	err := evaluateAndStore(system, updatesData, event)
 	if err != nil {
@@ -293,8 +291,7 @@ func evaluateWithVmaas(updatesData *vmaas.UpdatesV3Response,
 }
 
 func getUpdatesData(ctx context.Context, system *models.SystemPlatformV2) (*vmaas.UpdatesV3Response, error) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("get-updates-data"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("get-updates-data"))
 
 	var yumUpdates *vmaas.UpdatesV3Response
 	var yumErr error
@@ -335,8 +332,7 @@ func getUpdatesData(ctx context.Context, system *models.SystemPlatformV2) (*vmaa
 }
 
 func getVmaasUpdates(ctx context.Context, system *models.SystemPlatformV2) (*vmaas.UpdatesV3Response, error) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("vmaas-updates-prepare"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("vmaas-updates-prepare"))
 
 	var vmaasDataCopy vmaas.UpdatesV3Response
 	// first check if we have data in cache
@@ -448,8 +444,7 @@ func tryGetSystem(accountID int, inventoryID string,
 }
 
 func commitWithObserve(tx *gorm.DB) error {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("commit-to-db"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("commit-to-db"))
 
 	err := tx.Commit().Error
 	if err != nil {
@@ -528,8 +523,7 @@ func analyzeRepos(system *models.SystemPlatformV2) (thirdParty bool, err error) 
 		return false, nil
 	}
 
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("repo-analysis"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("repo-analysis"))
 
 	// if system has associated at least one third party repo
 	// it's marked as third party system
@@ -563,8 +557,7 @@ func incrementAdvisoryTypeCounts(advisory models.AdvisoryMetadata, enhCount, bug
 // nolint: funlen
 func updateSystemPlatform(tx *gorm.DB, system *models.SystemPlatformV2,
 	advisories SystemAdvisoryMap, installed, installable, applicable int) error {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("system-update"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("system-update"))
 	if system.Inventory.LastUpload != nil {
 		defer utils.ObserveSecondsSince(*system.Inventory.LastUpload, uploadEvaluationDelay)
 	}
@@ -652,8 +645,7 @@ func updateSystemPlatform(tx *gorm.DB, system *models.SystemPlatformV2,
 }
 
 func callVMaas(ctx context.Context, request *vmaas.UpdatesV3Request) (*vmaas.UpdatesV3Response, error) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("vmaas-updates-call"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("vmaas-updates-call"))
 
 	vmaasCallFunc := func() (interface{}, *http.Response, error) {
 		utils.LogTrace("request", *request, "vmaas /updates request")
@@ -677,8 +669,7 @@ func callVMaas(ctx context.Context, request *vmaas.UpdatesV3Request) (*vmaas.Upd
 }
 
 func loadSystemData(accountID int, inventoryID string) (*models.SystemPlatformV2, error) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("data-loading"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("data-loading"))
 
 	var system models.SystemPlatformV2
 	err := database.DB.Table("system_inventory si").
@@ -704,8 +695,7 @@ func validSystem(accountID int, systemID int64) bool {
 }
 
 func parseVmaasJSON(inv *models.SystemInventory) (vmaas.UpdatesV3Request, error) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("parse-vmaas-json"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("parse-vmaas-json"))
 	return utils.ParseVmaasJSON(inv)
 }
 

--- a/evaluator/evaluate_advisories.go
+++ b/evaluator/evaluate_advisories.go
@@ -41,8 +41,7 @@ func lazySaveAndLoadAdvisories(system *models.SystemPlatformV2, vmaasData *vmaas
 		return nil, nil
 	}
 
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("advisories-lazy-save-and-load"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("advisories-lazy-save-and-load"))
 
 	err := lazySaveAdvisories(vmaasData, system.GetInventoryID())
 	if err != nil {

--- a/evaluator/evaluate_packages.go
+++ b/evaluator/evaluate_packages.go
@@ -22,8 +22,7 @@ func lazySaveAndLoadPackages(system *models.SystemPlatformV2, vmaasData *vmaas.U
 		return nil, 0, 0, 0, nil
 	}
 
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("packages-lazy-save-and-load"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("packages-lazy-save-and-load"))
 
 	err := lazySavePackages(vmaasData)
 	if err != nil {

--- a/evaluator/inventory_views.go
+++ b/evaluator/inventory_views.go
@@ -29,8 +29,7 @@ func publishInventoryViewsEvent(tx *gorm.DB, systems []models.SystemPlatformV2, 
 		return nil
 	}
 
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("inventory-views-publish"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("inventory-views-publish"))
 
 	orgID := origin.GetOrgID()
 	var requestID string

--- a/evaluator/notifications.go
+++ b/evaluator/notifications.go
@@ -74,8 +74,7 @@ func publishNewAdvisoriesNotification(tx *gorm.DB, system *models.SystemPlatform
 		return nil
 	}
 
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("advisory-notification-publish"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("advisory-notification-publish"))
 
 	advisories, err := getUnnotifiedAdvisories(tx, system.Inventory.RhAccountID, newAdvisories)
 	if err != nil {

--- a/evaluator/remediations.go
+++ b/evaluator/remediations.go
@@ -71,8 +71,7 @@ func getReportedPackageUpdates(vmaasData *vmaas.UpdatesV3Response) map[string]bo
 }
 
 func publishRemediationsState(system *models.SystemPlatformV2, response *vmaas.UpdatesV3Response) error {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, evaluationPartDuration.WithLabelValues("remediations-publish"))
+	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("remediations-publish"))
 
 	if remediationsPublisher == nil {
 		return nil

--- a/listener/event_buffers.go
+++ b/listener/event_buffers.go
@@ -35,8 +35,7 @@ func (b *eventBuffer) bufferEvalEvents(
 	rhAccountID int,
 	ptEvent *mqueue.PayloadTrackerEvent,
 ) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, messagePartDuration.WithLabelValues("buffer-eval-events"))
+	defer utils.ObserveSecondsSince(time.Now(), messagePartDuration.WithLabelValues("buffer-eval-events"))
 
 	b.lock.Lock()
 	evalData := mqueue.EvalData{

--- a/listener/events.go
+++ b/listener/events.go
@@ -63,8 +63,7 @@ func EventsMessageHandler(m mqueue.KafkaMessage) error {
 }
 
 func HandleDelete(event mqueue.PlatformEvent) error {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, messageHandlingDuration.WithLabelValues(EventDelete))
+	defer utils.ObserveSecondsSince(time.Now(), messageHandlingDuration.WithLabelValues(EventDelete))
 	// TODO: Do we need locking here ?
 	err := database.OnConflictUpdate(database.DB, "inventory_id", "when_deleted").
 		Create(models.DeletedSystem{

--- a/listener/templates.go
+++ b/listener/templates.go
@@ -55,8 +55,7 @@ func TemplatesMessageHandler(m mqueue.KafkaMessage) error {
 }
 
 func TemplateDelete(template mqueue.TemplateResponse) error {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, templateMsgHandlingDuration.WithLabelValues(TemplateEventDelete))
+	defer utils.ObserveSecondsSince(time.Now(), templateMsgHandlingDuration.WithLabelValues(TemplateEventDelete))
 
 	// check account
 	accountID, err := middlewares.GetOrCreateAccount(template.OrgID)

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -255,8 +255,7 @@ func checkPackagesEpoch(packages []string) error {
 }
 
 func sendPayloadStatus(w mqueue.Writer, event mqueue.PayloadTrackerEvent, status string, statusMsg string) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, messagePartDuration.WithLabelValues("payload-tracker-status"))
+	defer utils.ObserveSecondsSince(time.Now(), messagePartDuration.WithLabelValues("payload-tracker-status"))
 	if status != "" {
 		event.Status = status
 	}
@@ -311,8 +310,7 @@ func hostTemplate(tx *gorm.DB, accountID int, host *Host) *int64 {
 // Stores or updates base system profile, returning inventory + patch aggregate.
 func updateSystemPlatform(tx *gorm.DB, accountID int, host *Host,
 	yumUpdates *YumUpdates, updatesReq *vmaas.UpdatesV3Request) (*models.SystemPlatformV2, error) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, messagePartDuration.WithLabelValues("update-system-platform"))
+	defer utils.ObserveSecondsSince(time.Now(), messagePartDuration.WithLabelValues("update-system-platform"))
 	// NOTE: if we add a map to vmaas.UpdatesV3Request in the future, we need to use
 	//  	 `encoder.Encode(updatesReq, encoder.SortMapKeys)` to compute the hash correctly
 	updatesReqJSON, err := sonic.Marshal(updatesReq)
@@ -547,8 +545,7 @@ func fixEpelRepos(sys *inventory.SystemProfile, repos []string) []string {
 
 func updateRepos(tx *gorm.DB, profile inventory.SystemProfile, rhAccountID int,
 	systemID int64, repos []string) (addedRepos int64, addedSysRepos int64, deletedSysRepos int64, err error) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, messagePartDuration.WithLabelValues("update-repos"))
+	defer utils.ObserveSecondsSince(time.Now(), messagePartDuration.WithLabelValues("update-repos"))
 	repos = fixEpelRepos(&profile, repos)
 	repoIDs, addedRepos, err := ensureReposInDB(tx, repos)
 	if err != nil {
@@ -743,8 +740,7 @@ func processModules(systemProfile *inventory.SystemProfile) *[]vmaas.UpdatesV3Re
 
 // We have received new upload, update stored host data, and re-evaluate the host against VMaaS
 func processUpload(host *Host, yumUpdates *YumUpdates) (*models.SystemPlatformV2, error) {
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, messagePartDuration.WithLabelValues("upload-processing"))
+	defer utils.ObserveSecondsSince(time.Now(), messagePartDuration.WithLabelValues("upload-processing"))
 	// Ensure we have account stored
 	accountID, err := middlewares.GetOrCreateAccount(host.GetOrgID())
 	if err != nil {

--- a/tasks/vmaas_sync/send_messages.go
+++ b/tasks/vmaas_sync/send_messages.go
@@ -26,8 +26,7 @@ func SendReevaluationMessages() error {
 		return err
 	}
 
-	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, messageSendDuration)
+	defer utils.ObserveSecondsSince(time.Now(), messageSendDuration)
 	err = mqueue.SendMessages(base.Context, evalWriter, &inventoryAIDs)
 	if err != nil {
 		utils.LogError("err", err.Error(), "sending to re-evaluate failed")


### PR DESCRIPTION
This PR is a small refactoring to remove the `tStart` variable when it is not needed (single-time usage in defer).

Note: the parameters in `deferred` functions are evaluated during registration not during execution, so using `time.Now()` as a parameter is completely safe.

## Summary by Sourcery

Enhancements:
- Remove unnecessary local tStart variables and pass time.Now() directly to utils.ObserveSecondsSince in all affected functions for clearer and more concise timing instrumentation.