### PR TITLE
RHINENG-26117: Add recompute infrastructure for account_advisory

### DIFF
--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -307,6 +308,48 @@ func DeleteSystemAdvisories(t *testing.T, systemID int64, advisoryIDs []int64) {
 	assert.Nil(t, query.Count(&cnt).Error)
 	assert.Equal(t, int64(0), cnt)
 	assert.Nil(t, DB.Exec("SELECT * FROM update_system_caches(?)", systemID).Error)
+}
+
+func CreateAccountAdvisory(t *testing.T, rhAccountID int, workspaceID string, advisoryIDs []int64,
+	systemsInstallable int) {
+	wsID := uuid.MustParse(workspaceID)
+	for _, advisoryID := range advisoryIDs {
+		err := DB.Create(&models.AccountAdvisory{
+			AdvisoryID: advisoryID, RhAccountID: rhAccountID, WorkspaceID: wsID,
+			SystemsInstallable: systemsInstallable, SystemsApplicable: systemsInstallable}).Error
+		assert.Nil(t, err)
+	}
+	CheckAccountAdvisory(t, rhAccountID, workspaceID, advisoryIDs, systemsInstallable)
+}
+
+func CheckAccountAdvisory(t *testing.T, rhAccountID int, workspaceID string, advisoryIDs []int64,
+	systemsInstallable int) {
+	var accountAdvisory []models.AccountAdvisory
+	err := DB.Where("rh_account_id = ? AND workspace_id = ? AND advisory_id IN (?)",
+		rhAccountID, workspaceID, advisoryIDs).
+		Find(&accountAdvisory).Error
+	assert.Nil(t, err)
+
+	sum := 0
+	for _, item := range accountAdvisory {
+		sum += item.SystemsInstallable
+	}
+	assert.Equal(t, systemsInstallable*len(advisoryIDs), sum, "sum of systems_installable does not match")
+}
+
+func DeleteAccountAdvisory(t *testing.T, rhAccountID int, workspaceID string, advisoryIDs []int64) {
+	query := DB.Model(&models.AccountAdvisory{}).Where("rh_account_id = ? AND workspace_id = ? AND advisory_id IN (?)",
+		rhAccountID, workspaceID, advisoryIDs)
+	assert.Nil(t, query.Delete(&models.AccountAdvisory{}).Error)
+
+	var cnt int64
+	assert.Nil(t, query.Count(&cnt).Error)
+	assert.Equal(t, int64(0), cnt)
+}
+
+func DeleteAccountAdvisoryByAccount(t *testing.T, rhAccountID int) {
+	assert.Nil(t, DB.Where("rh_account_id = ?", rhAccountID).
+		Delete(&models.AccountAdvisory{}).Error)
 }
 
 func DeleteAdvisoryAccountData(t *testing.T, rhAccountID int, advisoryIDs []int64) {

--- a/base/models/models.go
+++ b/base/models/models.go
@@ -281,6 +281,22 @@ func (AdvisoryAccountData) TableName() string {
 }
 
 type AdvisoryAccountDataSlice []AdvisoryAccountData
+
+type AccountAdvisory struct {
+	AdvisoryID         int64     `gorm:"primaryKey"`
+	RhAccountID        int       `gorm:"primaryKey"`
+	WorkspaceID        uuid.UUID `gorm:"primaryKey"`
+	SystemsApplicable  int
+	SystemsInstallable int
+	Notified           *time.Time
+}
+
+func (AccountAdvisory) TableName() string {
+	return "account_advisory"
+}
+
+type AccountAdvisorySlice []AccountAdvisory
+
 type Repo struct {
 	ID         int64 `gorm:"primaryKey"`
 	Name       string

--- a/database_admin/migrations/157_account_advisory_queries.down.sql
+++ b/database_admin/migrations/157_account_advisory_queries.down.sql
@@ -1,0 +1,10 @@
+DROP FUNCTION IF EXISTS backfill_account_advisory(INTEGER);
+
+DROP FUNCTION IF EXISTS refresh_account_advisory_caches(INTEGER, INTEGER);
+
+DROP FUNCTION IF EXISTS refresh_account_advisory_caches_multi(INTEGER[], INTEGER);
+
+DROP INDEX IF EXISTS account_advisory_systems_applicable_idx;
+DROP INDEX IF EXISTS account_advisory_systems_installable_idx;
+
+TRUNCATE account_advisory;

--- a/database_admin/migrations/157_account_advisory_queries.up.sql
+++ b/database_admin/migrations/157_account_advisory_queries.up.sql
@@ -1,0 +1,66 @@
+CREATE INDEX ON account_advisory (systems_applicable);
+CREATE INDEX ON account_advisory (systems_installable);
+
+CREATE OR REPLACE FUNCTION refresh_account_advisory_caches_multi(advisory_ids_in INTEGER[] DEFAULT NULL,
+                                                                  rh_account_id_in INTEGER DEFAULT NULL)
+    RETURNS VOID AS
+$refresh_account_advisory$
+BEGIN
+    PERFORM aa.rh_account_id, aa.workspace_id, aa.advisory_id
+    FROM account_advisory aa
+    WHERE (aa.advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+      AND (aa.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL)
+        FOR UPDATE OF aa;
+
+    WITH current_counts AS (
+        SELECT sa.advisory_id, sa.rh_account_id, (ws->>'id')::UUID AS workspace_id,
+               count(sa.*) FILTER (WHERE sa.status_id = 0) AS systems_installable,
+               count(sa.*) AS systems_applicable
+          FROM system_advisories sa
+          JOIN system_inventory si
+            ON sa.rh_account_id = si.rh_account_id AND sa.system_id = si.id
+          JOIN system_patch sp
+            ON si.id = sp.system_id AND sp.rh_account_id = si.rh_account_id
+         CROSS JOIN LATERAL jsonb_array_elements(si.workspaces) AS ws
+         WHERE sp.last_evaluation IS NOT NULL
+           AND si.stale = FALSE
+           AND si.workspaces IS NOT NULL
+           AND (sa.advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+           AND (si.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL)
+         GROUP BY sa.advisory_id, sa.rh_account_id, (ws->>'id')::UUID
+    ),
+        upserted AS (
+            INSERT INTO account_advisory (advisory_id, rh_account_id, workspace_id, systems_installable, systems_applicable)
+                 SELECT advisory_id, rh_account_id, workspace_id, systems_installable, systems_applicable
+                   FROM current_counts
+            ON CONFLICT (rh_account_id, workspace_id, advisory_id) DO UPDATE SET
+                     systems_installable = EXCLUDED.systems_installable,
+                     systems_applicable = EXCLUDED.systems_applicable
+         )
+    DELETE FROM account_advisory
+     WHERE (advisory_id, rh_account_id, workspace_id) NOT IN (SELECT advisory_id, rh_account_id, workspace_id FROM current_counts)
+       AND (advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+       AND (rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL);
+END;
+$refresh_account_advisory$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION refresh_account_advisory_caches(advisory_id_in INTEGER DEFAULT NULL,
+                                                            rh_account_id_in INTEGER DEFAULT NULL)
+    RETURNS VOID AS
+$refresh_account_advisory$
+BEGIN
+    IF advisory_id_in IS NOT NULL THEN
+        PERFORM refresh_account_advisory_caches_multi(ARRAY [advisory_id_in], rh_account_id_in);
+    ELSE
+        PERFORM refresh_account_advisory_caches_multi(NULL, rh_account_id_in);
+    END IF;
+END;
+$refresh_account_advisory$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION backfill_account_advisory(rh_account_id_in INTEGER)
+    RETURNS VOID AS
+$backfill$
+BEGIN
+    PERFORM refresh_account_advisory_caches_multi(NULL, rh_account_id_in);
+END;
+$backfill$ LANGUAGE plpgsql;

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (156, false);
+VALUES (157, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -189,6 +189,70 @@ BEGIN
     END IF;
 END;
 $refresh_advisory$ language plpgsql;
+
+CREATE OR REPLACE FUNCTION refresh_account_advisory_caches_multi(advisory_ids_in INTEGER[] DEFAULT NULL,
+                                                                  rh_account_id_in INTEGER DEFAULT NULL)
+    RETURNS VOID AS
+$refresh_account_advisory$
+BEGIN
+    PERFORM aa.rh_account_id, aa.workspace_id, aa.advisory_id
+    FROM account_advisory aa
+    WHERE (aa.advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+      AND (aa.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL)
+        FOR UPDATE OF aa;
+
+    WITH current_counts AS (
+        SELECT sa.advisory_id, sa.rh_account_id, (ws->>'id')::UUID AS workspace_id,
+               count(sa.*) FILTER (WHERE sa.status_id = 0) AS systems_installable,
+               count(sa.*) AS systems_applicable
+          FROM system_advisories sa
+          JOIN system_inventory si
+            ON sa.rh_account_id = si.rh_account_id AND sa.system_id = si.id
+          JOIN system_patch sp
+            ON si.id = sp.system_id AND sp.rh_account_id = si.rh_account_id
+         CROSS JOIN LATERAL jsonb_array_elements(si.workspaces) AS ws
+         WHERE sp.last_evaluation IS NOT NULL
+           AND si.stale = FALSE
+           AND si.workspaces IS NOT NULL
+           AND (sa.advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+           AND (si.rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL)
+         GROUP BY sa.advisory_id, sa.rh_account_id, (ws->>'id')::UUID
+    ),
+        upserted AS (
+            INSERT INTO account_advisory (advisory_id, rh_account_id, workspace_id, systems_installable, systems_applicable)
+                 SELECT advisory_id, rh_account_id, workspace_id, systems_installable, systems_applicable
+                   FROM current_counts
+            ON CONFLICT (rh_account_id, workspace_id, advisory_id) DO UPDATE SET
+                     systems_installable = EXCLUDED.systems_installable,
+                     systems_applicable = EXCLUDED.systems_applicable
+         )
+    DELETE FROM account_advisory
+     WHERE (advisory_id, rh_account_id, workspace_id) NOT IN (SELECT advisory_id, rh_account_id, workspace_id FROM current_counts)
+       AND (advisory_id = ANY (advisory_ids_in) OR advisory_ids_in IS NULL)
+       AND (rh_account_id = rh_account_id_in OR rh_account_id_in IS NULL);
+END;
+$refresh_account_advisory$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION refresh_account_advisory_caches(advisory_id_in INTEGER DEFAULT NULL,
+                                                            rh_account_id_in INTEGER DEFAULT NULL)
+    RETURNS VOID AS
+$refresh_account_advisory$
+BEGIN
+    IF advisory_id_in IS NOT NULL THEN
+        PERFORM refresh_account_advisory_caches_multi(ARRAY [advisory_id_in], rh_account_id_in);
+    ELSE
+        PERFORM refresh_account_advisory_caches_multi(NULL, rh_account_id_in);
+    END IF;
+END;
+$refresh_account_advisory$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION backfill_account_advisory(rh_account_id_in INTEGER)
+    RETURNS VOID AS
+$backfill$
+BEGIN
+    PERFORM refresh_account_advisory_caches_multi(NULL, rh_account_id_in);
+END;
+$backfill$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE FUNCTION refresh_system_caches(system_id_in BIGINT DEFAULT NULL,
                                                  rh_account_id_in INTEGER DEFAULT NULL)
@@ -833,6 +897,9 @@ SELECT grant_table_partitions('SELECT, INSERT, UPDATE, DELETE', 'account_advisor
 SELECT grant_table_partitions('SELECT, INSERT, UPDATE, DELETE', 'account_advisory', 'evaluator');
 SELECT grant_table_partitions('SELECT, INSERT, UPDATE, DELETE', 'account_advisory', 'listener');
 SELECT grant_table_partitions('SELECT, INSERT, UPDATE, DELETE', 'account_advisory', 'vmaas_sync');
+
+CREATE INDEX ON account_advisory (systems_applicable);
+CREATE INDEX ON account_advisory (systems_installable);
 
 -- repo
 CREATE TABLE IF NOT EXISTS repo

--- a/tasks/caches/refresh_account_advisory_caches_test.go
+++ b/tasks/caches/refresh_account_advisory_caches_test.go
@@ -1,0 +1,84 @@
+package caches
+
+import (
+	"app/base/core"
+	"app/base/database"
+	"app/base/models"
+	"app/base/utils"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const testWorkspace = "aaaaaaaa-0000-0000-0000-000000000001"
+
+func TestRefreshAccountAdvisoryCaches(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+	configure()
+
+	workspace := testWorkspace
+
+	// populate account_advisory using backfill
+	assert.Nil(t, database.DB.Exec("SELECT backfill_account_advisory(1)").Error)
+
+	// capture correct counts before corrupting
+	countAdv1 := database.PluckInt(database.DB.Table("account_advisory").
+		Where("advisory_id = 1 AND rh_account_id = 1 AND workspace_id = ?", workspace),
+		"systems_installable")
+	countAdv2 := database.PluckInt(database.DB.Table("account_advisory").
+		Where("advisory_id = 2 AND rh_account_id = 1 AND workspace_id = ?", workspace),
+		"systems_installable")
+
+	// set wrong counts
+	assert.Nil(t, database.DB.Model(&models.AccountAdvisory{}).
+		Where("advisory_id = 1 AND rh_account_id = 1 AND workspace_id = ?", workspace).
+		Update("systems_installable", 99).Error)
+	assert.Nil(t, database.DB.Model(&models.AccountAdvisory{}).
+		Where("advisory_id = 2 AND rh_account_id = 1 AND workspace_id = ?", workspace).
+		Update("systems_installable", 77).Error)
+
+	// refresh should correct them
+	assert.Nil(t, database.DB.Exec("SELECT refresh_account_advisory_caches(NULL, 1)").Error)
+
+	assert.Equal(t, countAdv1, database.PluckInt(database.DB.Table("account_advisory").
+		Where("advisory_id = 1 AND rh_account_id = 1 AND workspace_id = ?", workspace),
+		"systems_installable"))
+	assert.Equal(t, countAdv2, database.PluckInt(database.DB.Table("account_advisory").
+		Where("advisory_id = 2 AND rh_account_id = 1 AND workspace_id = ?", workspace),
+		"systems_installable"))
+
+	// cleanup
+	database.DeleteAccountAdvisoryByAccount(t, 1)
+}
+
+func TestRefreshAccountAdvisoryCachesRemovesOrphanedRows(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+	configure()
+
+	workspace := testWorkspace
+	assert.Nil(t, database.DB.Exec("SELECT backfill_account_advisory(1)").Error)
+
+	// mark all systems in this workspace as stale
+	assert.Nil(t, database.DB.Exec(
+		"UPDATE system_inventory SET stale = true WHERE rh_account_id = 1 AND workspace_id = ?",
+		workspace).Error)
+
+	// refresh should remove rows for this workspace since no non-stale systems remain
+	assert.Nil(t, database.DB.Exec("SELECT refresh_account_advisory_caches(NULL, 1)").Error)
+
+	var count int64
+	assert.Nil(t, database.DB.Table("account_advisory").
+		Where("rh_account_id = 1 AND workspace_id = ?", workspace).
+		Count(&count).Error)
+	assert.Equal(t, int64(0), count)
+
+	// restore systems to non-stale
+	assert.Nil(t, database.DB.Exec(
+		"UPDATE system_inventory SET stale = false WHERE rh_account_id = 1 AND workspace_id = ?",
+		workspace).Error)
+
+	// cleanup
+	database.DeleteAccountAdvisoryByAccount(t, 1)
+}


### PR DESCRIPTION
## Summary

This adds recompute and trigger infrastructure for account_advisory. It's mostly modeled after the existing recompute and trigger for account_advisory_data. I also added a little bit of Go infrastructure so that I could add unit tests.

This is dependent on this PR: https://github.com/RedHatInsights/patchman-engine/pull/2184

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Add database functions, indexes, models, and tests to support recomputing and backfilling account-level advisory aggregates.

New Features:
- Introduce PL/pgSQL functions to refresh and backfill account_advisory caches by advisory and account.
- Add indexes on account_advisory aggregate columns to support cache queries.
- Expose an AccountAdvisory GORM model and test helper functions for manipulating account_advisory data in tests.

Enhancements:
- Version the schema with a new migration adding account_advisory cache functions and indexes, with a corresponding down migration.

Tests:
- Add integration tests verifying that account_advisory cache refresh correctly recalculates counts and removes orphaned rows.