### PR TITLE
docs: remove link to an archived repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,3 @@ available ports:
 - set `ENABLE_PROFILE_{container_name}=true` in the ClowdApp
 - download the profile file using internal api `/api/patch/admin/pprof/{manager|listener|evaluator_upload|evaluator_recalc}/{heap|profile|block|mutex|trace}`
 - `go tool pprof <saved.file>`
-
-## Deps backup
-[patchman-engine-deps](https://github.com/RedHatInsights/patchman-engine-deps)


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Documentation:
- Delete the deprecated "Deps backup" section and its link to the patchman-engine-deps repository from the README.