### PR TITLE
RHINENG-25944: add search to the tags list endpoint

### DIFF
--- a/docs/v3/openapi.json
+++ b/docs/v3/openapi.json
@@ -5657,6 +5657,14 @@
                         }
                     },
                     {
+                        "name": "search",
+                        "in": "query",
+                        "description": "Find matching text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name": "offset",
                         "in": "query",
                         "description": "Offset for paging",

--- a/manager/controllers/systemtags.go
+++ b/manager/controllers/systemtags.go
@@ -1,10 +1,11 @@
 package controllers
 
 import (
-	"app/base/database"
-	"app/base/utils"
 	"errors"
 	"net/http"
+
+	"app/base/database"
+	"app/base/utils"
 
 	"app/manager/middlewares"
 
@@ -48,6 +49,11 @@ var SystemTagsOpts = ListOpts{
 	},
 	StableSort:  "tag",
 	DefaultSort: "tag",
+	SearchFields: []string{
+		"sq.tag->>'namespace'",
+		"sq.tag->>'key'",
+		"sq.tag->>'value'",
+	},
 }
 
 // @Summary Show me systems tags applicable to this application
@@ -55,9 +61,10 @@ var SystemTagsOpts = ListOpts{
 // @ID listSystemTags
 // @Security RhIdentity
 // @Produce  json
-// @Param	sort	query	string	false	"Sort field" Enums(tag, count)
-// @Param	limit	query	int		fals	"Limit for paging"
-// @Param 	offset	query	int		false	"Offset for paging"
+// @Param sort   query string false "Sort field" Enums(tag, count)
+// @Param limit  query int    false "Limit for paging"
+// @Param search query string false "Find matching text"
+// @Param offset query int    false "Offset for paging"
 // @Success 200 {object} SystemTagsResponse
 // @Failure 400 {object} utils.ErrorResponse
 // @Failure 500 {object} utils.ErrorResponse

--- a/manager/controllers/systemtags_test.go
+++ b/manager/controllers/systemtags_test.go
@@ -1,9 +1,10 @@
 package controllers
 
 import (
-	"app/base/core"
 	"net/http"
 	"testing"
+
+	"app/base/core"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -75,4 +76,39 @@ func TestSystemTagsListBadRequestOnIdtSort(t *testing.T) {
 
 	w := CreateRequestRouterWithAccount("GET", "/", "", "?sort=id", nil, "", SystemTagListHandler, 1)
 	assert.Equal(t, 400, w.Code)
+}
+
+func TestSystemTagsListSearch(t *testing.T) {
+	core.SetupTest(t)
+
+	w := CreateRequestRouterWithAccount("GET", "/", "", "?search=k3", nil, "", SystemTagListHandler, 1)
+
+	var output SystemTagsResponse
+	CheckResponse(t, w, http.StatusOK, &output)
+
+	assert.Equal(t, 2, len(output.Data))
+	assert.Equal(t, 2, output.Meta.TotalItems)
+	assert.Equal(t, "k3", output.Meta.Search)
+
+	assert.Equal(t, 1, output.Data[0].Count)
+	assert.Equal(t, "k3", output.Data[0].Tag.Key)
+	assert.Equal(t, "ns1", output.Data[0].Tag.Namespace)
+	assert.Equal(t, "val3", output.Data[0].Tag.Value)
+
+	assert.Equal(t, 3, output.Data[1].Count)
+	assert.Equal(t, "k3", output.Data[1].Tag.Key)
+	assert.Equal(t, "ns1", output.Data[1].Tag.Namespace)
+	assert.Equal(t, "val4", output.Data[1].Tag.Value)
+}
+
+func TestSystemTagsListSearchUnknown(t *testing.T) {
+	core.SetupTest(t)
+
+	w := CreateRequestRouterWithAccount("GET", "/", "", "?search=unknown", nil, "", SystemTagListHandler, 1)
+
+	var output SystemTagsResponse
+	CheckResponse(t, w, http.StatusOK, &output)
+
+	assert.Equal(t, 0, len(output.Data))
+	assert.Equal(t, "unknown", output.Meta.Search)
 }


### PR DESCRIPTION
## Summary
Allow `/tags` to filter returned tags by matching the search term against tag namespace, key, and value.
With this the `/tags` endpoint could be used in the frontend for tag filtering.

## Summary by Sourcery

Add search support to the system tags listing endpoint and document the new query parameter.

New Features:
- Allow filtering system tags by a search term matching tag namespace, key, or value via the /tags endpoint.

Documentation:
- Document the search query parameter for the system tags list endpoint in the API documentation.

Tests:
- Add tests covering successful tag search results and empty results when no tags match the search term.