### PR TITLE
chore: remove `InventoryID` from AdvisoryUpdateEvent

### DIFF
--- a/base/mqueue/advisory_update_event.go
+++ b/base/mqueue/advisory_update_event.go
@@ -12,7 +12,6 @@ import (
 type AdvisoryUpdateEvent struct {
 	RhAccountID int                    `json:"rh_account_id"`
 	WorkspaceID uuid.UUID              `json:"workspace_id"`
-	InventoryID uuid.UUID              `json:"inventory_id"`
 	AdvisoryIDs []int64                `json:"advisory_ids"`
 	ProducedAt  types.Rfc3339Timestamp `json:"produced_at"`
 }

--- a/base/mqueue/advisory_update_event_test.go
+++ b/base/mqueue/advisory_update_event_test.go
@@ -20,7 +20,6 @@ func TestAdvisoryUpdateEventMarshal(t *testing.T) {
 	event := AdvisoryUpdateEvent{
 		RhAccountID: 1,
 		WorkspaceID: testWorkspaceID,
-		InventoryID: uuid.New(),
 		AdvisoryIDs: []int64{101, 202, 303},
 		ProducedAt:  testNow,
 	}
@@ -33,7 +32,6 @@ func TestAdvisoryUpdateEventMarshal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, event.RhAccountID, parsed.RhAccountID)
 	assert.Equal(t, event.WorkspaceID, parsed.WorkspaceID)
-	assert.Equal(t, event.InventoryID, parsed.InventoryID)
 	assert.Equal(t, event.AdvisoryIDs, parsed.AdvisoryIDs)
 	assert.NotNil(t, parsed.ProducedAt)
 }
@@ -45,14 +43,12 @@ func TestAdvisoryUpdateEventsWriteEvents(t *testing.T) {
 		{
 			RhAccountID: 1,
 			WorkspaceID: testWorkspaceID,
-			InventoryID: uuid.New(),
 			AdvisoryIDs: []int64{100, 200},
 			ProducedAt:  testNow,
 		},
 		{
 			RhAccountID: 2,
 			WorkspaceID: testWorkspaceID,
-			InventoryID: uuid.New(),
 			AdvisoryIDs: []int64{300},
 			ProducedAt:  testNow,
 		},
@@ -69,7 +65,6 @@ func TestAdvisoryUpdateEventsWriteEvents(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, events[0].RhAccountID, firstEvent.RhAccountID)
 	assert.Equal(t, events[0].WorkspaceID, firstEvent.WorkspaceID)
-	assert.Equal(t, events[0].InventoryID, firstEvent.InventoryID)
 	assert.Equal(t, events[0].AdvisoryIDs, firstEvent.AdvisoryIDs)
 	assert.NotNil(t, firstEvent.ProducedAt)
 
@@ -78,7 +73,6 @@ func TestAdvisoryUpdateEventsWriteEvents(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, events[1].RhAccountID, secondEvent.RhAccountID)
 	assert.Equal(t, events[1].WorkspaceID, secondEvent.WorkspaceID)
-	assert.Equal(t, events[1].InventoryID, secondEvent.InventoryID)
 	assert.Equal(t, events[1].AdvisoryIDs, secondEvent.AdvisoryIDs)
 	assert.NotNil(t, secondEvent.ProducedAt)
 }

--- a/base/notification/notification.go
+++ b/base/notification/notification.go
@@ -15,6 +15,10 @@ const (
 	Application = "patch"
 )
 
+// TODO: Remove Context after migrating to the new aggregator component
+// Advisories apply to multiple systems, so for aggregated notifications, system-specific context is unnecessary
+// See: https://redhat.atlassian.net/browse/RHINENG-26543
+
 type Context struct {
 	InventoryID string      `json:"inventory_id"`
 	DisplayName string      `json:"display_name"`


### PR DESCRIPTION
- This field is no longer required as part of the `AdvisoryUpdateEvent` structure
- Updated tests accordingly
- Added a TODO for future system context changes in notifications

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Remove inventory identifier from advisory update events and update related tests and notification context documentation.

Enhancements:
- Simplify AdvisoryUpdateEvent by dropping the now-unneeded InventoryID field from the payload.

Documentation:
- Document future removal of per-system notification context after aggregator migration.