### PR TITLE
HMS-10740: add org_id to template initiated messages

### DIFF
--- a/manager/controllers/template_subscribed_systems_update.go
+++ b/manager/controllers/template_subscribed_systems_update.go
@@ -29,7 +29,7 @@ func TemplateSubscribedSystemsUpdateHandler(c *gin.Context) {
 
 	db := middlewares.DBFromContext(c)
 
-	account, systemUUID, err := getSubscribedSystem(c, db)
+	account, orgID, systemUUID, err := getSubscribedSystem(c, db)
 	if err != nil {
 		// respose set in getTemplateID()
 		return
@@ -58,14 +58,15 @@ func TemplateSubscribedSystemsUpdateHandler(c *gin.Context) {
 
 	// re-evaluate systems added/removed from templates
 	if config.EnableTemplateChangeEval {
-		inventoryAIDs := kafka.InventoryIDs2InventoryAIDs(account, systemList)
+		inventoryAIDs := kafka.InventoryIDs2InventoryAIDs(account, orgID, systemList)
 		kafka.RecalcSystems(inventoryAIDs)
 	}
 	c.Status(http.StatusOK)
 }
 
-func getSubscribedSystem(c *gin.Context, tx *gorm.DB) (int, string, error) {
+func getSubscribedSystem(c *gin.Context, tx *gorm.DB) (int, string, string, error) {
 	account := c.GetInt(utils.KeyAccount)
+	orgID := c.GetString(utils.KeyOrgID)
 	systemCn := c.GetString(utils.KeySystem)
 
 	var inventoryID string
@@ -75,12 +76,12 @@ func getSubscribedSystem(c *gin.Context, tx *gorm.DB) (int, string, error) {
 		Limit(1).Find(&inventoryID).Error
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		utils.LogAndRespError(c, err, "database error")
-		return 0, "", err
+		return 0, "", "", err
 	}
 	if inventoryID == "" {
 		err := errors.Errorf("System %s not found", systemCn)
 		utils.LogAndRespNotFound(c, err, err.Error())
-		return 0, "", err
+		return 0, "", "", err
 	}
-	return account, inventoryID, err
+	return account, orgID, inventoryID, err
 }

--- a/manager/controllers/template_subscribed_systems_update.go
+++ b/manager/controllers/template_subscribed_systems_update.go
@@ -58,8 +58,8 @@ func TemplateSubscribedSystemsUpdateHandler(c *gin.Context) {
 
 	// re-evaluate systems added/removed from templates
 	if config.EnableTemplateChangeEval {
-		inventoryAIDs := kafka.InventoryIDs2InventoryAIDs(account, orgID, systemList)
-		kafka.RecalcSystems(inventoryAIDs)
+		evalDataList := kafka.InventoryIDs2EvalData(account, orgID, systemList)
+		kafka.RecalcSystems(evalDataList)
 	}
 	c.Status(http.StatusOK)
 }

--- a/manager/controllers/template_subscribed_systems_update_test.go
+++ b/manager/controllers/template_subscribed_systems_update_test.go
@@ -23,10 +23,12 @@ func TestSubscribedSystemID(t *testing.T) {
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	c.Set(utils.KeyAccount, templateAccount)
 	c.Set(utils.KeySystem, subscriptionUUID)
-	account, systemID, err := getSubscribedSystem(c, database.DB)
+	c.Set(utils.KeyOrgID, orgID)
+	account, org, systemID, err := getSubscribedSystem(c, database.DB)
 
 	assert.Nil(t, err)
 	assert.Equal(t, templateAccount, account)
+	assert.Equal(t, orgID, org)
 	assert.Equal(t, templateSystemUUID, systemID)
 }
 
@@ -35,11 +37,13 @@ func TestUnknownSubscribedSystemID(t *testing.T) {
 
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	c.Set(utils.KeyAccount, templateAccount)
+	c.Set(utils.KeyOrgID, orgID)
 	c.Set(utils.KeySystem, "cccccccc-0000-0000-0001-000000000001")
-	account, systemID, err := getSubscribedSystem(c, database.DB)
+	account, org, systemID, err := getSubscribedSystem(c, database.DB)
 
 	assert.EqualError(t, err, "System cccccccc-0000-0000-0001-000000000001 not found")
 	assert.Equal(t, 0, account)
+	assert.Equal(t, "", org)
 	assert.Equal(t, "", systemID)
 }
 

--- a/manager/controllers/template_systems_delete.go
+++ b/manager/controllers/template_systems_delete.go
@@ -57,8 +57,8 @@ func TemplateSystemsDeleteHandler(c *gin.Context) {
 
 	// re-evaluate systems removed from templates
 	if config.EnableTemplateChangeEval {
-		inventoryAIDs := kafka.InventoryIDs2InventoryAIDs(account, orgID, req.Systems)
-		kafka.RecalcSystems(inventoryAIDs)
+		evalDataList := kafka.InventoryIDs2EvalData(account, orgID, req.Systems)
+		kafka.RecalcSystems(evalDataList)
 	}
 	c.Status(http.StatusOK)
 }

--- a/manager/controllers/template_systems_delete.go
+++ b/manager/controllers/template_systems_delete.go
@@ -24,6 +24,7 @@ import (
 // @Router /templates/systems [DELETE]
 func TemplateSystemsDeleteHandler(c *gin.Context) {
 	account := c.GetInt(utils.KeyAccount)
+	orgID := c.GetString(utils.KeyOrgID)
 	groups := c.GetStringMapString(utils.KeyInventoryGroups)
 
 	var req TemplateSystemsUpdateRequest
@@ -56,7 +57,7 @@ func TemplateSystemsDeleteHandler(c *gin.Context) {
 
 	// re-evaluate systems removed from templates
 	if config.EnableTemplateChangeEval {
-		inventoryAIDs := kafka.InventoryIDs2InventoryAIDs(account, req.Systems)
+		inventoryAIDs := kafka.InventoryIDs2InventoryAIDs(account, orgID, req.Systems)
 		kafka.RecalcSystems(inventoryAIDs)
 	}
 	c.Status(http.StatusOK)

--- a/manager/controllers/template_systems_update.go
+++ b/manager/controllers/template_systems_update.go
@@ -53,6 +53,7 @@ type SystemTemplateDBLookup struct {
 // @Router /templates/{template_id}/systems [PATCH]
 func TemplateSystemsUpdateHandler(c *gin.Context) {
 	account := c.GetInt(utils.KeyAccount)
+	orgID := c.GetString(utils.KeyOrgID)
 	templateUUID := c.Param("template_id")
 	groups := c.GetStringMapString(utils.KeyInventoryGroups)
 
@@ -90,7 +91,7 @@ func TemplateSystemsUpdateHandler(c *gin.Context) {
 
 	// re-evaluate systems added/removed from templates
 	if config.EnableTemplateChangeEval {
-		inventoryAIDs := kafka.InventoryIDs2InventoryAIDs(account, req.Systems)
+		inventoryAIDs := kafka.InventoryIDs2InventoryAIDs(account, orgID, req.Systems)
 		kafka.RecalcSystems(inventoryAIDs)
 	}
 	c.Status(http.StatusOK)

--- a/manager/controllers/template_systems_update.go
+++ b/manager/controllers/template_systems_update.go
@@ -91,8 +91,8 @@ func TemplateSystemsUpdateHandler(c *gin.Context) {
 
 	// re-evaluate systems added/removed from templates
 	if config.EnableTemplateChangeEval {
-		inventoryAIDs := kafka.InventoryIDs2InventoryAIDs(account, orgID, req.Systems)
-		kafka.RecalcSystems(inventoryAIDs)
+		evalDataList := kafka.InventoryIDs2EvalData(account, orgID, req.Systems)
+		kafka.RecalcSystems(evalDataList)
 	}
 	c.Status(http.StatusOK)
 }

--- a/manager/kafka/kafka.go
+++ b/manager/kafka/kafka.go
@@ -29,10 +29,10 @@ func runRecalcLoop() {
 	}
 }
 
-func InventoryIDs2InventoryAIDs(accountID int, inventoryIDs []string) []mqueue.EvalData {
+func InventoryIDs2InventoryAIDs(accountID int, orgID string, inventoryIDs []string) []mqueue.EvalData {
 	inventoryAIDs := make([]mqueue.EvalData, 0, len(inventoryIDs))
 	for _, v := range inventoryIDs {
-		inventoryAIDs = append(inventoryAIDs, mqueue.EvalData{InventoryID: v, RhAccountID: accountID})
+		inventoryAIDs = append(inventoryAIDs, mqueue.EvalData{InventoryID: v, RhAccountID: accountID, OrgID: &orgID})
 	}
 	return inventoryAIDs
 }

--- a/manager/kafka/kafka.go
+++ b/manager/kafka/kafka.go
@@ -29,12 +29,12 @@ func runRecalcLoop() {
 	}
 }
 
-func InventoryIDs2InventoryAIDs(accountID int, orgID string, inventoryIDs []string) []mqueue.EvalData {
-	inventoryAIDs := make([]mqueue.EvalData, 0, len(inventoryIDs))
+func InventoryIDs2EvalData(accountID int, orgID string, inventoryIDs []string) []mqueue.EvalData {
+	evalDataList := make([]mqueue.EvalData, 0, len(inventoryIDs))
 	for _, v := range inventoryIDs {
-		inventoryAIDs = append(inventoryAIDs, mqueue.EvalData{InventoryID: v, RhAccountID: accountID, OrgID: &orgID})
+		evalDataList = append(evalDataList, mqueue.EvalData{InventoryID: v, RhAccountID: accountID, OrgID: &orgID})
 	}
-	return inventoryAIDs
+	return evalDataList
 }
 
 func sendInventoryIDs(inventoryIDs mqueue.EvalDataSlice) {

--- a/manager/kafka/kafka_test.go
+++ b/manager/kafka/kafka_test.go
@@ -18,8 +18,8 @@ func testRecalcSystems(t *testing.T, accountID int, orgID string, inventoryIDs [
 
 	writerMock := mqueue.MockKafkaWriter{}
 	TryStartEvalQueue(mqueue.MockCreateKafkaWriter(&writerMock))
-	inventoryAIDs := InventoryIDs2InventoryAIDs(accountID, orgID, inventoryIDs)
-	RecalcSystems(inventoryAIDs)
+	evaldataList := InventoryIDs2EvalData(accountID, orgID, inventoryIDs)
+	RecalcSystems(evaldataList)
 	utils.AssertEqualWait(t, 1, func() (exp, act interface{}) {
 		return 1, len(writerMock.Messages)
 	})

--- a/manager/kafka/kafka_test.go
+++ b/manager/kafka/kafka_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testRecalcSystems(t *testing.T, accountID int, inventoryIDs []string) mqueue.PlatformEvent {
+func testRecalcSystems(t *testing.T, accountID int, orgID string, inventoryIDs []string) mqueue.PlatformEvent {
 	utils.SkipWithoutDB(t)
 	core.SetupTestEnvironment()
 	config.EnableTemplateChangeEval = true
 
 	writerMock := mqueue.MockKafkaWriter{}
 	TryStartEvalQueue(mqueue.MockCreateKafkaWriter(&writerMock))
-	inventoryAIDs := InventoryIDs2InventoryAIDs(accountID, inventoryIDs)
+	inventoryAIDs := InventoryIDs2InventoryAIDs(accountID, orgID, inventoryIDs)
 	RecalcSystems(inventoryAIDs)
 	utils.AssertEqualWait(t, 1, func() (exp, act interface{}) {
 		return 1, len(writerMock.Messages)
@@ -31,7 +31,7 @@ func testRecalcSystems(t *testing.T, accountID int, inventoryIDs []string) mqueu
 // Evaluate updated systems
 func TestRecalcUpdatedSystems(t *testing.T) {
 	inventoryIDs := []string{"00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000004"}
-	event := testRecalcSystems(t, 1, inventoryIDs)
+	event := testRecalcSystems(t, 1, "org_1", inventoryIDs)
 	assert.Equal(t, 2, len(event.SystemIDs))
 	assert.Equal(t, 1, event.AccountID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", event.SystemIDs[0])


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Include organization ID in template-driven system evaluation messages sent via Kafka.

New Features:
- Propagate org_id from HTTP request context into template subscription and system update handlers so it can be used in downstream processing.

Enhancements:
- Extend InventoryIDs2InventoryAIDs to attach org_id to evaluation messages and update all callers accordingly.

Tests:
- Update controller and Kafka tests to cover org_id propagation and presence in generated evaluation messages.