### PR TITLE
RHINENG-26450: replace string inventory IDs with uuid.UUID

### DIFF
--- a/base/database/query.go
+++ b/base/database/query.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -60,6 +61,13 @@ func parserForType(v reflect.Type) (AttrParser, error) {
 		}, nil
 	case reflect.Ptr:
 		return parserForType(v.Elem())
+	case reflect.Array:
+		if v == reflect.TypeOf(uuid.UUID{}) {
+			return func(s string) (i interface{}, err error) {
+				return uuid.Parse(s)
+			}, nil
+		}
+		fallthrough
 	case reflect.Struct:
 		if reflect.TypeOf(time.Time{}).AssignableTo(v) {
 			return func(s string) (i interface{}, err error) {

--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -159,11 +159,11 @@ func CheckPackagesNamesInDB(t *testing.T, filter string, packageNames ...string)
 	assert.Equal(t, int64(len(packageNames)), count)
 }
 
-func CheckSystemJustEvaluated(t *testing.T, inventoryID string, nIAll, nIEnh, nIBug, nISec,
+func CheckSystemJustEvaluated(t *testing.T, inventoryID uuid.UUID, nIAll, nIEnh, nIBug, nISec,
 	nAAll, nAEnh, nABug, nASec, nInstall, nInstallable, nApplicable int,
 	thirdParty bool) {
 	var inv models.SystemInventory
-	assert.Nil(t, DB.Where("inventory_id = ?::uuid", inventoryID).First(&inv).Error)
+	assert.Nil(t, DB.Where("inventory_id = ?", inventoryID).First(&inv).Error)
 	var patch models.SystemPatch
 	assert.Nil(t, DB.Where("rh_account_id = ? AND system_id = ?", inv.RhAccountID, inv.ID).First(&patch).Error)
 	assert.NotNil(t, patch.LastEvaluation)
@@ -427,7 +427,7 @@ func GetPackageIDs(nevras ...string) []int64 {
 	return ids
 }
 
-func CreateTemplate(t *testing.T, account int, uuid string, inventoryIDs []string) {
+func CreateTemplate(t *testing.T, account int, uuid string, inventoryIDs []uuid.UUID) {
 	template := &models.Template{
 		TemplateBase: models.TemplateBase{
 			RhAccountID: account, UUID: uuid, Name: uuid,
@@ -451,7 +451,7 @@ func CreateTemplate(t *testing.T, account int, uuid string, inventoryIDs []strin
 			SELECT id 
 			FROM system_inventory 
 			WHERE rh_account_id = ? 
-			AND inventory_id = ?::uuid
+			AND inventory_id = ?
 		)`,
 			template.ID, account, account, invID).Error
 		assert.Nil(t, err)
@@ -477,21 +477,21 @@ func DeleteTemplate(t *testing.T, account int, templateUUID string) {
 	assert.Nil(t, err)
 }
 
-func CheckTemplateSystems(t *testing.T, account int, templateUUID string, inventoryIDs []string) {
-	var dbInventoryIDs []string
+func CheckTemplateSystems(t *testing.T, account int, templateUUID string, inventoryIDs []uuid.UUID) {
+	var foundInventoryIDs []uuid.UUID
 	err := DB.Table("system_inventory si").Select("si.inventory_id as id").
 		Joins("JOIN system_patch spatch ON si.id = spatch.system_id AND si.rh_account_id = spatch.rh_account_id").
 		Joins("JOIN template tp ON tp.id = spatch.template_id AND tp.rh_account_id = spatch.rh_account_id").
 		Where("si.rh_account_id = ? AND tp.uuid = ?::uuid", account, templateUUID).
 		Order("id").
-		Find(&dbInventoryIDs).Error
+		Find(&foundInventoryIDs).Error
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, len(inventoryIDs), len(dbInventoryIDs))
-	if len(inventoryIDs) == len(dbInventoryIDs) {
+	assert.Equal(t, len(inventoryIDs), len(foundInventoryIDs))
+	if len(inventoryIDs) == len(foundInventoryIDs) {
 		for index, inventoryID := range inventoryIDs {
-			assert.Equal(t, inventoryID, dbInventoryIDs[index])
+			assert.Equal(t, inventoryID, foundInventoryIDs[index])
 		}
 	}
 }

--- a/base/database/utils.go
+++ b/base/database/utils.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -65,9 +66,9 @@ func PackageByName(tx *gorm.DB, pkgName string, joins ...join) *gorm.DB {
 	return (joinsT)(joins).apply(tx)
 }
 
-func SystemAdvisoriesByInventoryID(tx *gorm.DB, accountID int, groups map[string]string, inventoryID string,
+func SystemAdvisoriesByInventoryID(tx *gorm.DB, accountID int, groups map[string]string, inventoryID uuid.UUID,
 	joins ...join) *gorm.DB {
-	tx = SystemAdvisories(tx, accountID, groups).Where("si.inventory_id = ?::uuid", inventoryID)
+	tx = SystemAdvisories(tx, accountID, groups).Where("si.inventory_id = ?", inventoryID)
 	return (joinsT)(joins).apply(tx)
 }
 

--- a/base/inventory_views/inventory_views.go
+++ b/base/inventory_views/inventory_views.go
@@ -5,12 +5,13 @@ import (
 	"app/base/utils"
 	"time"
 
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
 type InventoryViewsHost struct {
 	// Inventory ID (UUID) of the host
-	ID   string                 `json:"id"`
+	ID   uuid.UUID              `json:"id"`
 	Data InventoryViewsHostData `json:"data"`
 }
 

--- a/base/inventory_views/inventory_views_test.go
+++ b/base/inventory_views/inventory_views_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 )
@@ -51,13 +52,13 @@ func TestMakeInventoryViewsEvent(t *testing.T) {
 	assert.Equal(t, 2, len(event.Hosts))
 
 	assert.Equal(t, InventoryViewsHost{
-		ID: "00000000-0000-0000-0000-000000000001",
+		ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 		Data: InventoryViewsHostData{2, 3, 3, 0, 2, 2, 1, 0, 0, 0, 0,
 			utils.PtrString("temp1-1"), utils.PtrString("99900000-0000-0000-0000-000000000001")},
 	}, event.Hosts[0])
 
 	assert.Equal(t, InventoryViewsHost{
-		ID: "00000000-0000-0000-0000-000000000003",
+		ID: uuid.MustParse("00000000-0000-0000-0000-000000000003"),
 		Data: InventoryViewsHostData{0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0,
 			utils.PtrString("temp2-1"), utils.PtrString("99900000-0000-0000-0000-000000000002")},
 	}, event.Hosts[1])
@@ -98,7 +99,7 @@ func TestMakeInventoryViewsEventNoTemplate(t *testing.T) {
 	assert.Equal(t, 1, len(event.Hosts))
 
 	host := event.Hosts[0]
-	assert.Equal(t, "00000000-0000-0000-0000-000000000004", host.ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000004"), host.ID)
 	// Template fields should be nil when template is not found
 	assert.Nil(t, host.Data.TemplateName)
 	assert.Nil(t, host.Data.TemplateUUID)

--- a/base/models/models.go
+++ b/base/models/models.go
@@ -54,9 +54,9 @@ func (TemplateBase) TableName() string {
 }
 
 type SystemInventory struct {
-	ID                               int64  `gorm:"primaryKey"`
-	InventoryID                      string `gorm:"unique"`
-	RhAccountID                      int    `gorm:"primaryKey"`
+	ID                               int64     `gorm:"primaryKey"`
+	InventoryID                      uuid.UUID `gorm:"unique"`
+	RhAccountID                      int       `gorm:"primaryKey"`
 	VmaasJSON                        *string
 	JSONChecksum                     *string
 	LastUpdated                      *time.Time `gorm:"default:null"` // set by trigger system_inventory_set_last_updated
@@ -94,9 +94,9 @@ func (SystemInventory) TableName() string {
 	return "system_inventory"
 }
 
-func (s *SystemInventory) GetInventoryID() string {
+func (s *SystemInventory) GetInventoryID() uuid.UUID {
 	if s == nil {
-		return ""
+		return uuid.Nil
 	}
 	return s.InventoryID
 }
@@ -133,9 +133,9 @@ type SystemPlatformV2 struct {
 	Patch     SystemPatch     `gorm:"embedded"`
 }
 
-func (v *SystemPlatformV2) GetInventoryID() string {
+func (v *SystemPlatformV2) GetInventoryID() uuid.UUID {
 	if v == nil {
-		return ""
+		return uuid.Nil
 	}
 	return v.Inventory.GetInventoryID()
 }
@@ -200,7 +200,7 @@ type PackageUpdate struct {
 }
 
 type DeletedSystem struct {
-	InventoryID string
+	InventoryID uuid.UUID
 	WhenDeleted time.Time
 }
 

--- a/base/mqueue/mqueue_test.go
+++ b/base/mqueue/mqueue_test.go
@@ -7,13 +7,14 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
-const id = "99c0ffee-0000-0000-0000-0000c0ffee99"
-const someid = "99c0ffee-0000-0000-0000-0000000050de"
+var id = uuid.MustParse("99c0ffee-0000-0000-0000-0000c0ffee99")
+var someid = uuid.MustParse("99c0ffee-0000-0000-0000-0000000050de")
 
-var msg = KafkaMessage{Value: []byte(`{"id": "` + id + `", "type": "delete"}`)}
+var msg = KafkaMessage{Value: []byte(`{"id": "` + id.String() + `", "type": "delete"}`)}
 
 func TestParseEvents(t *testing.T) {
 	reached := false

--- a/base/mqueue/payload_tracker_event.go
+++ b/base/mqueue/payload_tracker_event.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -14,7 +15,7 @@ type PayloadTrackerEvent struct {
 	Service     string                       `json:"service"`
 	OrgID       *string                      `json:"org_id,omitempty"`
 	RequestID   *string                      `json:"request_id"`
-	InventoryID string                       `json:"inventory_id"`
+	InventoryID uuid.UUID                    `json:"inventory_id"`
 	Status      string                       `json:"status"`
 	StatusMsg   string                       `json:"status_msg,omitempty"`
 	Date        *types.Rfc3339TimestampWithZ `json:"date"`

--- a/base/mqueue/platform_event.go
+++ b/base/mqueue/platform_event.go
@@ -6,23 +6,26 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
+// PlatformEvent ID is typed as uuid.UUID to match the inventory service contract:
+// https://github.com/RedHatInsights/insights-host-inventory/blob/master/swagger/host_events.spec.yaml
 type PlatformEvent struct {
-	ID          string                  `json:"id"`
+	ID          uuid.UUID               `json:"id"`
 	Type        *string                 `json:"type"`
 	Timestamp   *types.Rfc3339Timestamp `json:"timestamp"`
 	AccountID   int                     `json:"account_id"`
 	OrgID       *string                 `json:"org_id,omitempty"`
 	B64Identity *string                 `json:"b64_identity"`
 	URL         *string                 `json:"url"`
-	SystemIDs   []string                `json:"system_ids,omitempty"`
+	SystemIDs   []uuid.UUID             `json:"system_ids,omitempty"`
 	RequestIDs  []string                `json:"request_ids,omitempty"`
 }
 
 type EvalData struct {
-	InventoryID string
+	InventoryID uuid.UUID
 	RhAccountID int
 	RequestID   string
 	OrgID       *string
@@ -31,7 +34,7 @@ type EvalData struct {
 type PlatformEvents []PlatformEvent
 type EvalDataSlice []EvalData
 
-type accountInventories map[int][]string
+type accountInventories map[int][]uuid.UUID
 type accountRequests map[int][]string
 type orgIDs map[int]*string
 
@@ -69,7 +72,7 @@ func writePlatformEvents(ctx context.Context, w Writer, events ...PlatformEvent)
 	return w.WriteMessages(ctx, msgs...)
 }
 
-func batchSize(grouped map[int][]string) int {
+func batchSize(grouped map[int][]uuid.UUID) int {
 	// compute how many batches we will create
 	var batches = 0
 	for _, ev := range grouped {

--- a/base/mqueue/platform_event_test.go
+++ b/base/mqueue/platform_event_test.go
@@ -5,14 +5,15 @@ import (
 	"testing"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWriteEventsOfInventoryAccounts(t *testing.T) {
-	const (
+	var (
 		acc  = 1
-		inv2 = "00000000-0000-0000-0000-000000000002"
-		inv3 = "00000000-0000-0000-0000-000000000003"
+		inv2 = uuid.MustParse("00000000-0000-0000-0000-000000000002")
+		inv3 = uuid.MustParse("00000000-0000-0000-0000-000000000003")
 	)
 
 	var writer Writer = &MockKafkaWriter{}

--- a/base/notification/notification.go
+++ b/base/notification/notification.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -20,7 +21,7 @@ const (
 // See: https://redhat.atlassian.net/browse/RHINENG-26543
 
 type Context struct {
-	InventoryID string      `json:"inventory_id"`
+	InventoryID uuid.UUID   `json:"inventory_id"`
 	DisplayName string      `json:"display_name"`
 	HostURL     string      `json:"host_url"`
 	Tags        []SystemTag `json:"tags"`

--- a/base/rbac/rbac.go
+++ b/base/rbac/rbac.go
@@ -2,6 +2,7 @@ package rbac
 
 import (
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 )
 
 type AccessPagination struct {
@@ -26,8 +27,8 @@ type AttributeFilter struct {
 }
 
 type inventoryGroup struct {
-	ID   *string `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
+	ID   *uuid.UUID `json:"id,omitempty"`
+	Name *string    `json:"name,omitempty"`
 }
 
 type InventoryGroup []inventoryGroup

--- a/base/utils/core.go
+++ b/base/utils/core.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/joho/godotenv"
 )
 
@@ -184,7 +185,7 @@ func GetGorutineID() uint64 {
 	return n
 }
 
-func ParseInventoryGroup(id *string, name *string) (string, error) {
+func ParseInventoryGroup(id *uuid.UUID, name *string) (string, error) {
 	group := rbac.InventoryGroup{{ID: id, Name: name}}
 	groupJSON, err := sonic.Marshal(&group)
 	if err != nil {

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/jinzhu/copier"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
@@ -134,7 +135,7 @@ func confugureEvaluator() {
 	enableSatelliteFunctionality = utils.PodConfig.GetBool("satellite_functionality", true)
 }
 
-func Evaluate(ctx context.Context, event *mqueue.PlatformEvent, inventoryID, evaluationType string) error {
+func Evaluate(ctx context.Context, event *mqueue.PlatformEvent, inventoryID uuid.UUID, evaluationType string) error {
 	defer utils.ObserveSecondsSince(time.Now(), evaluationDuration.WithLabelValues(evaluationType))
 
 	utils.LogInfo("inventoryID", inventoryID, "Evaluating system")
@@ -170,7 +171,7 @@ func Evaluate(ctx context.Context, event *mqueue.PlatformEvent, inventoryID, eva
 func runEvaluate(
 	ctx context.Context,
 	event mqueue.PlatformEvent, // makes a copy to avoid races
-	inventoryID string, // coming from loop
+	inventoryID uuid.UUID, // coming from loop
 	evaluationType string,
 	ptEventIn mqueue.PayloadTrackerEvent,
 	wg *sync.WaitGroup,
@@ -202,7 +203,7 @@ func runEvaluate(
 	return ptEventOut, err
 }
 
-func evaluateInDatabase(ctx context.Context, event *mqueue.PlatformEvent, inventoryID string) (
+func evaluateInDatabase(ctx context.Context, event *mqueue.PlatformEvent, inventoryID uuid.UUID) (
 	*models.SystemPlatformV2, *vmaas.UpdatesV3Response, error) {
 	system, err := tryGetSystem(event.AccountID, inventoryID, event.Timestamp)
 	if err != nil {
@@ -380,7 +381,7 @@ func getVmaasUpdates(ctx context.Context, system *models.SystemPlatformV2) (*vma
 func tryGetVmaasRequest(system *models.SystemPlatformV2) (*vmaas.UpdatesV3Request, error) {
 	if system == nil || system.Inventory.VmaasJSON == nil {
 		evaluationCnt.WithLabelValues("error-parse-vmaas-json").Inc()
-		invID := ""
+		invID := uuid.Nil
 		if system != nil {
 			invID = system.GetInventoryID()
 		}
@@ -415,7 +416,7 @@ func tryGetVmaasRequest(system *models.SystemPlatformV2) (*vmaas.UpdatesV3Reques
 	return &updatesReq, nil
 }
 
-func tryGetSystem(accountID int, inventoryID string,
+func tryGetSystem(accountID int, inventoryID uuid.UUID,
 	requested *types.Rfc3339Timestamp) (*models.SystemPlatformV2, error) {
 	system, err := loadSystemData(accountID, inventoryID)
 	if err != nil {
@@ -668,7 +669,7 @@ func callVMaas(ctx context.Context, request *vmaas.UpdatesV3Request) (*vmaas.Upd
 	return vmaasDataPtr.(*vmaas.UpdatesV3Response), nil
 }
 
-func loadSystemData(accountID int, inventoryID string) (*models.SystemPlatformV2, error) {
+func loadSystemData(accountID int, inventoryID uuid.UUID) (*models.SystemPlatformV2, error) {
 	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("data-loading"))
 
 	var system models.SystemPlatformV2
@@ -676,7 +677,7 @@ func loadSystemData(accountID int, inventoryID string) (*models.SystemPlatformV2
 		Select("si.*, sp.*").
 		Joins("JOIN system_patch sp ON sp.system_id = si.id AND sp.rh_account_id = si.rh_account_id").
 		Where("si.rh_account_id = ?", accountID).
-		Where("si.inventory_id = ?::uuid", inventoryID).
+		Where("si.inventory_id = ?", inventoryID).
 		Find(&system).Error
 	return &system, err
 }

--- a/evaluator/evaluate_advisories.go
+++ b/evaluator/evaluate_advisories.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -131,7 +132,7 @@ func evaluateChanges(vmaasData *vmaas.UpdatesV3Response, stored SystemAdvisoryMa
 }
 
 // LazySaveAdvisories finds advisories reported by VMaaS and missing in the DB and lazy saves them.
-func lazySaveAdvisories(vmaasData *vmaas.UpdatesV3Response, inventoryID string) error {
+func lazySaveAdvisories(vmaasData *vmaas.UpdatesV3Response, inventoryID uuid.UUID) error {
 	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("advisories-lazy-save"))
 	reportedNames := getReportedAdvisories(vmaasData)
 	if len(reportedNames) < 1 {

--- a/evaluator/evaluate_advisories_test.go
+++ b/evaluator/evaluate_advisories_test.go
@@ -90,7 +90,7 @@ func TestEvaluateChanges(t *testing.T) {
 	vmaasData := vmaas.UpdatesV3Response{UpdateList: &updateList}
 
 	// advisories must be lazy saved before evaluating changes
-	err := lazySaveAdvisories(&vmaasData, inventoryID)
+	err := lazySaveAdvisories(&vmaasData, testInventoryID)
 	defer database.DeleteNewlyAddedAdvisories(t)
 	assert.Nil(t, err)
 
@@ -117,7 +117,7 @@ func TestLoadMissingNamesIDs(t *testing.T) {
 	assert.Error(t, err)
 
 	// test OK if lazy saved
-	err = lazySaveAdvisories(&vmaasData, inventoryID)
+	err = lazySaveAdvisories(&vmaasData, testInventoryID)
 	defer database.DeleteNewlyAddedAdvisories(t)
 	assert.NoError(t, err)
 	err = loadMissingNamesIDs(missingNames, extendedAdvisories)
@@ -225,9 +225,9 @@ func TestProcessAdvisories(t *testing.T) {
 	utils.SkipWithoutDB(t)
 	core.SetupTestEnvironment()
 
-	systemID := int64(2)
+	dbID := int64(2)
 	system := &models.SystemPlatformV2{
-		Inventory: models.SystemInventory{RhAccountID: 1, ID: systemID},
+		Inventory: models.SystemInventory{RhAccountID: 1, ID: dbID},
 		Patch:     models.SystemPatch{},
 	}
 	extendedAdvisories := extendedAdvisoryMap{
@@ -252,17 +252,17 @@ func TestUpsertSystemAdvisories(t *testing.T) {
 	core.SetupTestEnvironment()
 
 	// ensure consistent environment
-	database.DeleteSystemAdvisories(t, systemID, []int64{3, 4})
-	database.CreateSystemAdvisories(t, rhAccountID, systemID, []int64{3})
+	database.DeleteSystemAdvisories(t, testDBID, []int64{3, 4})
+	database.CreateSystemAdvisories(t, rhAccountID, testDBID, []int64{3})
 
 	// mock data: the system advisory with ID=3 exists and will be updated,
 	// the system advisory with ID=4 will be created
 	advisoryObjs := models.SystemAdvisoriesSlice{
-		models.SystemAdvisories{SystemID: systemID, RhAccountID: rhAccountID,
+		models.SystemAdvisories{SystemID: testDBID, RhAccountID: rhAccountID,
 			AdvisoryID: int64(3),
 			StatusID:   APPLICABLE,
 		},
-		models.SystemAdvisories{SystemID: systemID, RhAccountID: rhAccountID,
+		models.SystemAdvisories{SystemID: testDBID, RhAccountID: rhAccountID,
 			AdvisoryID: int64(4),
 		},
 	}
@@ -270,7 +270,7 @@ func TestUpsertSystemAdvisories(t *testing.T) {
 	// check insert
 	err := upsertSystemAdvisories(database.DB, advisoryObjs)
 	assert.Nil(t, err)
-	database.CheckSystemAdvisories(t, systemID, []int64{3, 4})
+	database.CheckSystemAdvisories(t, testDBID, []int64{3, 4})
 
 	// check update
 	var updatedAdvisory models.SystemAdvisories
@@ -279,12 +279,12 @@ func TestUpsertSystemAdvisories(t *testing.T) {
 	assert.Equal(t, APPLICABLE, updatedAdvisory.StatusID)
 
 	// cleanup
-	database.DeleteSystemAdvisories(t, systemID, []int64{3, 4})
+	database.DeleteSystemAdvisories(t, testDBID, []int64{3, 4})
 }
 
 func TestCalcAdvisoryChanges(t *testing.T) {
 	system := &models.SystemPlatformV2{
-		Inventory: models.SystemInventory{ID: systemID, RhAccountID: rhAccountID},
+		Inventory: models.SystemInventory{ID: testDBID, RhAccountID: rhAccountID},
 		Patch:     models.SystemPatch{},
 	}
 	advisoriesByName := extendedAdvisoryMap{

--- a/evaluator/evaluate_packages.go
+++ b/evaluator/evaluate_packages.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -139,7 +140,7 @@ func loadPackages(system *models.SystemPlatformV2, vmaasData *vmaas.UpdatesV3Res
 	return packages, installed, installable, applicable, nil
 }
 
-func packagesFromUpdateList(inventoryID string, vmaasData *vmaas.UpdatesV3Response) (
+func packagesFromUpdateList(inventoryID uuid.UUID, vmaasData *vmaas.UpdatesV3Response) (
 	map[string]namedPackage, int, int, int) {
 	installed := 0
 	installable := 0

--- a/evaluator/evaluate_test.go
+++ b/evaluator/evaluate_test.go
@@ -13,12 +13,15 @@ import (
 	"testing"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
-var systemID = int64(12)
 var rhAccountID = 3
 var orgID = "org_3"
+var testDBID = int64(12)
+var testInventoryID = uuid.MustParse("00000000-0000-0000-0000-000000000012")
+var testInventoryID2 = uuid.MustParse("00000000-0000-0000-0000-000000000011")
 
 func TestInit(_ *testing.T) {
 	utils.TestLoadEnv("conf/evaluator_common.env", "conf/evaluator_upload.env")
@@ -47,49 +50,49 @@ func TestEvaluate(t *testing.T) {
 	expectedPackageIDs := []int64{1, 2}
 	systemRepoIDs := []int64{1, 2}
 
-	database.DeleteSystemAdvisories(t, systemID, expectedAdvisoryIDs)
-	database.DeleteSystemAdvisories(t, systemID, patchingSystemAdvisoryIDs)
+	database.DeleteSystemAdvisories(t, testDBID, expectedAdvisoryIDs)
+	database.DeleteSystemAdvisories(t, testDBID, patchingSystemAdvisoryIDs)
 	database.DeleteAdvisoryAccountData(t, rhAccountID, expectedAdvisoryIDs)
 	database.DeleteAdvisoryAccountData(t, rhAccountID, patchingSystemAdvisoryIDs)
-	database.DeleteSystemPackages(t, rhAccountID, systemID, expectedPackageIDs...)
-	database.DeleteSystemRepos(t, rhAccountID, systemID, systemRepoIDs)
-	database.CreateSystemAdvisories(t, rhAccountID, systemID, oldSystemAdvisoryIDs)
+	database.DeleteSystemPackages(t, rhAccountID, testDBID, expectedPackageIDs...)
+	database.DeleteSystemRepos(t, rhAccountID, testDBID, systemRepoIDs)
+	database.CreateSystemAdvisories(t, rhAccountID, testDBID, oldSystemAdvisoryIDs)
 	database.CreateAdvisoryAccountData(t, rhAccountID, oldSystemAdvisoryIDs, 1)
-	database.CreateSystemRepos(t, rhAccountID, systemID, systemRepoIDs)
+	database.CreateSystemRepos(t, rhAccountID, testDBID, systemRepoIDs)
 	database.CheckCachesValid(t)
 
 	// do evaluate the system
 	err := evaluateHandler(mqueue.PlatformEvent{
-		SystemIDs:  []string{"00000000-0000-0000-0000-000000000012", "00000000-0000-0000-0000-000000000011"},
+		SystemIDs:  []uuid.UUID{testInventoryID, testInventoryID2},
 		RequestIDs: []string{"request-1", "request-2"},
 		OrgID:      &orgID,
 		AccountID:  rhAccountID})
 	assert.NoError(t, err)
 
 	advisoryIDs := database.CheckAdvisoriesInDB(t, expectedAddedAdvisories)
-	database.CheckSystemAdvisories(t, systemID, advisoryIDs)
-	database.CheckSystemPackages(t, rhAccountID, systemID, len(expectedPackageIDs), expectedPackageIDs...)
-	database.CheckSystemJustEvaluated(t, "00000000-0000-0000-0000-000000000012", 3, 1, 1, 0,
+	database.CheckSystemAdvisories(t, testDBID, advisoryIDs)
+	database.CheckSystemPackages(t, rhAccountID, testDBID, len(expectedPackageIDs), expectedPackageIDs...)
+	database.CheckSystemJustEvaluated(t, testInventoryID, 3, 1, 1, 0,
 		3, 1, 1, 0, 2, 2, 2, false)
 	database.CheckCachesValid(t)
 
 	// test evaluation with third party repos
 	thirdPartySystemRepoIDs := []int64{1, 2, 4}
-	database.DeleteSystemRepos(t, rhAccountID, systemID, systemRepoIDs)
-	database.CreateSystemRepos(t, rhAccountID, systemID, thirdPartySystemRepoIDs)
+	database.DeleteSystemRepos(t, rhAccountID, testDBID, systemRepoIDs)
+	database.CreateSystemRepos(t, rhAccountID, testDBID, thirdPartySystemRepoIDs)
 	err = evaluateHandler(mqueue.PlatformEvent{
-		SystemIDs:  []string{"00000000-0000-0000-0000-000000000012"},
+		SystemIDs:  []uuid.UUID{testInventoryID},
 		RequestIDs: []string{"request-1"},
 		OrgID:      &orgID,
 		AccountID:  rhAccountID})
 	assert.NoError(t, err)
-	database.CheckSystemJustEvaluated(t, "00000000-0000-0000-0000-000000000012", 3, 1, 1, 0,
+	database.CheckSystemJustEvaluated(t, testInventoryID, 3, 1, 1, 0,
 		3, 1, 1, 0, 2, 2, 2, true)
 
-	database.DeleteSystemAdvisories(t, systemID, advisoryIDs)
+	database.DeleteSystemAdvisories(t, testDBID, advisoryIDs)
 	database.DeleteAdvisoryAccountData(t, rhAccountID, advisoryIDs)
 	database.DeleteAdvisoryAccountData(t, rhAccountID, oldSystemAdvisoryIDs)
-	database.DeleteSystemRepos(t, rhAccountID, systemID, thirdPartySystemRepoIDs)
+	database.DeleteSystemRepos(t, rhAccountID, testDBID, thirdPartySystemRepoIDs)
 
 	assert.Equal(t, 2, len(mockWriter.Messages))
 }
@@ -101,10 +104,8 @@ func TestEvaluateYum(t *testing.T) {
 	configure()
 	loadCache()
 
-	const (
-		ID    = "00000000-0000-0000-0000-000000000015"
-		sysID = 15
-	)
+	testDBID := int64(15)
+	testInventoryID := uuid.MustParse("00000000-0000-0000-0000-000000000015")
 
 	mockWriter := mqueue.MockKafkaWriter{}
 	remediationsPublisher = &mockWriter
@@ -117,25 +118,25 @@ func TestEvaluateYum(t *testing.T) {
 		"kernel-5.6.13-200.fc31.x86_64", "firefox-76.0.1-1.fc31.x86_64", "suricata-6.0.3-2.fc35.i686",
 	}
 
-	database.DeleteSystemAdvisories(t, sysID, expectedAdvisoryIDs)
+	database.DeleteSystemAdvisories(t, testDBID, expectedAdvisoryIDs)
 	database.DeleteAdvisoryAccountData(t, rhAccountID, expectedAdvisoryIDs)
-	database.CreateSystemAdvisories(t, rhAccountID, sysID, oldSystemAdvisoryIDs)
+	database.CreateSystemAdvisories(t, rhAccountID, testDBID, oldSystemAdvisoryIDs)
 	database.CreateAdvisoryAccountData(t, rhAccountID, oldSystemAdvisoryIDs, 1)
 	database.CheckCachesValid(t)
 
 	err := evaluateHandler(mqueue.PlatformEvent{
-		SystemIDs: []string{ID},
+		SystemIDs: []uuid.UUID{testInventoryID},
 		OrgID:     &orgID,
 		AccountID: rhAccountID})
 	assert.NoError(t, err)
 
 	expectedPackageIDs := database.GetPackageIDs(expectedPackages...)
 	advisoryIDs := database.CheckAdvisoriesInDB(t, expectedAddedAdvisories)
-	database.CheckSystemPackages(t, rhAccountID, sysID, len(expectedPackages), expectedPackageIDs...)
-	database.CheckSystemJustEvaluated(t, ID, 4, 1, 1, 1, 4, 1, 1, 1, 3, 3, 3, false)
+	database.CheckSystemPackages(t, rhAccountID, testDBID, len(expectedPackages), expectedPackageIDs...)
+	database.CheckSystemJustEvaluated(t, testInventoryID, 4, 1, 1, 1, 4, 1, 1, 1, 3, 3, 3, false)
 
-	database.DeleteSystemPackages(t, rhAccountID, sysID, expectedPackageIDs...)
-	database.DeleteSystemAdvisories(t, sysID, advisoryIDs)
+	database.DeleteSystemPackages(t, rhAccountID, testDBID, expectedPackageIDs...)
+	database.DeleteSystemAdvisories(t, testDBID, advisoryIDs)
 	database.DeleteAdvisoryAccountData(t, rhAccountID, advisoryIDs)
 	database.DeleteAdvisoryAccountData(t, rhAccountID, oldSystemAdvisoryIDs)
 
@@ -318,7 +319,7 @@ func TestSatelliteSystemAdvisories(t *testing.T) {
 
 	system := &models.SystemPlatformV2{
 		Inventory: models.SystemInventory{
-			InventoryID:      "99999999-0000-0000-0000-000000000015",
+			InventoryID:      uuid.MustParse("99999999-0000-0000-0000-000000000015"),
 			JSONChecksum:     &vmaasJSONChecksum,
 			VmaasJSON:        &vmaasJSON,
 			YumUpdates:       yumUpdatesRaw,

--- a/evaluator/notifications.go
+++ b/evaluator/notifications.go
@@ -100,7 +100,7 @@ func publishNewAdvisoriesNotification(tx *gorm.DB, system *models.SystemPlatform
 		return errors.Wrap(err, "creating notification failed")
 	}
 
-	msg, err := mqueue.MessageFromJSON(system.GetInventoryID(), notif, nil)
+	msg, err := mqueue.MessageFromJSON(system.GetInventoryID().String(), notif, nil)
 	if err != nil {
 		return errors.Wrap(err, "creating message from notification failed")
 	}

--- a/evaluator/notifications_test.go
+++ b/evaluator/notifications_test.go
@@ -12,11 +12,8 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-)
-
-const (
-	inventoryID = "00000000-0000-0000-0000-000000000012"
 )
 
 func checkNotificationPayload(t *testing.T, notification ntf.Notification, name, advType, synopsis string) {
@@ -52,9 +49,9 @@ func TestAdvisoriesNotificationPublish(t *testing.T) {
 	expectedAdvisoryIDs := []int64{1, 2}     // advisories expected to be paired to the system after evaluation
 	oldSystemAdvisoryIDs := []int64{1, 3, 4} // old advisories paired with the system
 
-	database.DeleteSystemAdvisories(t, systemID, expectedAdvisoryIDs)
+	database.DeleteSystemAdvisories(t, testDBID, expectedAdvisoryIDs)
 	database.DeleteAdvisoryAccountData(t, rhAccountID, expectedAdvisoryIDs)
-	database.CreateSystemAdvisories(t, rhAccountID, systemID, oldSystemAdvisoryIDs)
+	database.CreateSystemAdvisories(t, rhAccountID, testDBID, oldSystemAdvisoryIDs)
 	database.CreateAdvisoryAccountData(t, rhAccountID, oldSystemAdvisoryIDs, 1)
 	database.CheckCachesValid(t)
 	database.CheckAdvisoriesAccountDataNotified(t, rhAccountID, oldSystemAdvisoryIDs, false)
@@ -62,7 +59,7 @@ func TestAdvisoriesNotificationPublish(t *testing.T) {
 	orgID := "1234567"
 	// do evaluate the system
 	err := evaluateHandler(mqueue.PlatformEvent{
-		SystemIDs:  []string{"00000000-0000-0000-0000-000000000012"},
+		SystemIDs:  []uuid.UUID{testInventoryID},
 		RequestIDs: []string{"request-2"},
 		AccountID:  rhAccountID,
 		OrgID:      &orgID})
@@ -82,7 +79,7 @@ func TestAdvisoriesNotificationPublish(t *testing.T) {
 	assert.True(t, events[0].Payload.(map[string]interface{})["advisory_name"].(string) <
 		events[1].Payload.(map[string]interface{})["advisory_name"].(string))
 
-	database.DeleteSystemAdvisories(t, systemID, advisoryIDs)
+	database.DeleteSystemAdvisories(t, testDBID, advisoryIDs)
 	database.DeleteAdvisoryAccountData(t, rhAccountID, advisoryIDs)
 	database.DeleteAdvisoryAccountData(t, rhAccountID, oldSystemAdvisoryIDs)
 }
@@ -99,25 +96,25 @@ func TestAdvisoriesNotificationMessage(t *testing.T) {
 
 	displayName := "display-name"
 	inv := &models.SystemInventory{
-		InventoryID: inventoryID,
+		InventoryID: testInventoryID,
 		DisplayName: displayName,
 	}
 	tags := []ntf.SystemTag{{Key: "key", Namespace: "namespace", Value: "value"}}
 
 	orgID := "1234567"
-	url := fmt.Sprintf("https://localhost/insights/inventory/%s", inventoryID)
+	url := fmt.Sprintf("https://localhost/insights/inventory/%s", testInventoryID.String())
 
 	notification, err := ntf.MakeNotification(inv, tags, orgID, NewAdvisoryEvent, events)
 	assert.Nil(t, err)
 	assert.Equal(t, orgID, notification.OrgID)
 	assert.Equal(t, url, notification.Context.HostURL)
-	assert.Equal(t, inventoryID, notification.Context.InventoryID)
+	assert.Equal(t, testInventoryID, notification.Context.InventoryID)
 	assert.Equal(t, displayName, notification.Context.DisplayName)
 	assert.Equal(t, tags, notification.Context.Tags)
 
-	msg, err := mqueue.MessageFromJSON(inventoryID, notification, nil)
+	msg, err := mqueue.MessageFromJSON(testInventoryID.String(), notification, nil)
 	assert.Nil(t, err)
-	assert.Equal(t, inventoryID, string(msg.Key))
+	assert.Equal(t, testInventoryID.String(), string(msg.Key))
 
 	notificationJSON, err := sonic.Marshal(notification)
 	assert.Nil(t, err)
@@ -133,7 +130,7 @@ func TestGetSystemTags(t *testing.T) {
 		Inventory: models.SystemInventory{
 			ID:          1,
 			RhAccountID: 1,
-			InventoryID: "00000000-0000-0000-0000-000000000001",
+			InventoryID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 			DisplayName: "display name",
 		},
 		Patch: models.SystemPatch{},
@@ -179,7 +176,7 @@ func TestAdvisoriesNotificationAlreadyNotified(t *testing.T) {
 		Inventory: models.SystemInventory{
 			ID:          1,
 			RhAccountID: rhAccountID,
-			InventoryID: "00000000-0000-0000-0000-000000000001",
+			InventoryID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 			DisplayName: "display name",
 		},
 		Patch: models.SystemPatch{},
@@ -209,7 +206,7 @@ func TestAdvisoriesNotificationEmptyAdvisoryMap(t *testing.T) {
 		Inventory: models.SystemInventory{
 			ID:          1,
 			RhAccountID: rhAccountID,
-			InventoryID: "00000000-0000-0000-0000-000000000001",
+			InventoryID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 			DisplayName: "display name",
 		},
 		Patch: models.SystemPatch{},

--- a/evaluator/remediations.go
+++ b/evaluator/remediations.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -22,11 +23,11 @@ func configureRemediations() {
 }
 
 type RemediationsState struct {
-	HostID string   `json:"host_id"`
-	Issues []string `json:"issues"`
+	HostID uuid.UUID `json:"host_id"`
+	Issues []string  `json:"issues"`
 }
 
-func createRemediationsStateMsg(id string, response *vmaas.UpdatesV3Response) *RemediationsState {
+func createRemediationsStateMsg(id uuid.UUID, response *vmaas.UpdatesV3Response) *RemediationsState {
 	advisories := getReportedAdvisories(response)
 	packages := getReportedPackageUpdates(response)
 	var state RemediationsState
@@ -86,7 +87,7 @@ func publishRemediationsState(system *models.SystemPlatformV2, response *vmaas.U
 	}
 
 	state := createRemediationsStateMsg(system.GetInventoryID(), response)
-	msg, err := mqueue.MessageFromJSON(system.GetInventoryID(), state, nil)
+	msg, err := mqueue.MessageFromJSON(system.GetInventoryID().String(), state, nil)
 	if err != nil {
 		return errors.Wrap(err, "formatting message")
 	}

--- a/evaluator/remediations_test.go
+++ b/evaluator/remediations_test.go
@@ -36,10 +36,9 @@ var testVmaasResponse = vmaas.UpdatesV3Response{
 }
 
 func TestCreateRemediationsState(t *testing.T) {
-	id := "00000000-0000-0000-0000-000000000012"
-	state := createRemediationsStateMsg(id, &testVmaasResponse)
+	state := createRemediationsStateMsg(testInventoryID, &testVmaasResponse)
 	assert.NotNil(t, state)
-	assert.Equal(t, state.HostID, id)
+	assert.Equal(t, state.HostID, testInventoryID)
 	assert.Equal(t, state.Issues, []string{"patch:RH-1", "patch:RH-100", "patch:RH-2",
 		"patch:firefox-0:77.0.1-1.fc31.x86_64", "patch:firefox-1:76.0.1-1.fc31.x86_64",
 		"patch:kernel-5.6.13-201.fc31.x86_64"})

--- a/listener/common_test.go
+++ b/listener/common_test.go
@@ -14,12 +14,15 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-const id = "99c0ffee-0000-0000-0000-0000c0ffee99"
+var testInventoryID = uuid.MustParse("99c0ffee-0000-0000-0000-0000c0ffee99")
+var testOrgID = "12345678"
+var testWorkspaceID = "00000000-0000-0000-0000-000000000003"
 
 var s3URL = "http://platform:9001/yum_updates"
 
@@ -30,7 +33,7 @@ func TestInit(_ *testing.T) {
 func deleteData(t *testing.T) {
 	// Delete test data from previous run
 	assert.Nil(t, database.DB.Unscoped().Exec("DELETE FROM advisory_account_data aad "+
-		"USING rh_account ra WHERE ra.id = aad.rh_account_id AND ra.name = ?", id).Error)
+		"USING rh_account ra WHERE ra.id = aad.rh_account_id AND ra.name = ?", testOrgID).Error)
 	assert.Nil(t, database.DB.Unscoped().Where("first_reported > timestamp '2020-01-01'").
 		Delete(&models.SystemAdvisories{}).Error)
 	assert.Nil(t, database.DB.Unscoped().Where("repo_id NOT IN (1, 2) OR system_id NOT IN (2, 3, 17)").
@@ -39,13 +42,14 @@ func deleteData(t *testing.T) {
 		Delete(&models.Repo{}).Error)
 	assert.Nil(t, database.DB.Unscoped().Exec(
 		"DELETE FROM system_patch WHERE (rh_account_id, system_id) IN "+
-			"(SELECT rh_account_id, id FROM system_inventory WHERE inventory_id = ?::uuid)", id).Error)
-	assert.Nil(t, database.DB.Unscoped().Where("inventory_id = ?::uuid", id).Delete(&models.SystemInventory{}).Error)
-	assert.Nil(t, database.DB.Unscoped().Where("name = ?", id).Delete(&models.RhAccount{}).Error)
-	assert.Nil(t, database.DB.Unscoped().Where("inventory_id = ?", id).Delete(&models.DeletedSystem{}).Error)
+			"(SELECT rh_account_id, id FROM system_inventory WHERE inventory_id = ?)", testInventoryID).Error)
+	assert.Nil(t, database.DB.Unscoped().
+		Where("inventory_id = ?", testInventoryID).Delete(&models.SystemInventory{}).Error)
+	assert.Nil(t, database.DB.Unscoped().Where("name = ?", testOrgID).Delete(&models.RhAccount{}).Error)
+	assert.Nil(t, database.DB.Unscoped().Where("inventory_id = ?", testInventoryID).Delete(&models.DeletedSystem{}).Error)
 }
 
-func createTestSystemInDB(t *testing.T, inventoryID string, rhAccountID int, displayName string) {
+func createTestSystemInDB(t *testing.T, inventoryID uuid.UUID, rhAccountID int, displayName string) {
 	t.Helper()
 	inv := models.SystemInventory{
 		InventoryID: inventoryID,
@@ -62,17 +66,17 @@ func createTestSystemInDB(t *testing.T, inventoryID string, rhAccountID int, dis
 }
 
 // nolint: unparam
-func assertSystemInDB(t *testing.T, inventoryID string, rhAccountID *int, reporterID *int) {
+func assertSystemInDB(t *testing.T, inventoryID uuid.UUID, rhAccountID *int, reporterID *int) {
 	var system models.SystemInventory
-	assert.NoError(t, database.DB.Where("inventory_id = ?::uuid", inventoryID).Find(&system).Error)
+	assert.NoError(t, database.DB.Where("inventory_id = ?", inventoryID).Find(&system).Error)
 	assert.Equal(t, system.InventoryID, inventoryID)
 
 	var account models.RhAccount
 	assert.NoError(t, database.DB.Where("id = ?", system.RhAccountID).Find(&account).Error)
 	if account.Name == nil || *account.Name == "" {
-		assert.Equal(t, inventoryID, *account.OrgID)
+		assert.Equal(t, testOrgID, *account.OrgID)
 	} else {
-		assert.Equal(t, inventoryID, *account.Name)
+		assert.Equal(t, testOrgID, *account.Name)
 	}
 	if rhAccountID != nil {
 		assert.Equal(t, system.RhAccountID, *rhAccountID)
@@ -87,11 +91,11 @@ func assertSystemInDB(t *testing.T, inventoryID string, rhAccountID *int, report
 
 // assertSystemInventoryProfileMatchesHost checks host-derived system_inventory columns written by
 // storeOrUpdateSysPlatform (must stay in sync on ON CONFLICT DO UPDATE, not only on first insert).
-// nolint: unparam
-func assertSystemInventoryProfileMatchesHost(t *testing.T, inventoryID string, host *Host) {
+// nolint: unparam, funlen
+func assertSystemInventoryProfileMatchesHost(t *testing.T, inventoryID uuid.UUID, host *Host) {
 	t.Helper()
 	var inv models.SystemInventory
-	require.NoError(t, database.DB.Where("inventory_id = ?::uuid", inventoryID).First(&inv).Error)
+	require.NoError(t, database.DB.Where("inventory_id = ?", inventoryID).First(&inv).Error)
 
 	assert.JSONEq(t, string(utils.MarshalNilToJSONB(host.Tags)), string(inv.Tags))
 
@@ -150,7 +154,7 @@ func assertSystemInventoryProfileMatchesHost(t *testing.T, inventoryID string, h
 func assertSystemNotInDB(t *testing.T) {
 	var systemCount int64
 	assert.Nil(t, database.DB.Model(models.SystemInventory{}).
-		Where("inventory_id = ?::uuid", id).Count(&systemCount).Error)
+		Where("inventory_id = ?", testInventoryID).Count(&systemCount).Error)
 
 	assert.Equal(t, 0, int(systemCount))
 }
@@ -160,19 +164,20 @@ func assertSystemCulled(t *testing.T) {
 	now := time.Now()
 	assert.Nil(t, database.DB.Model(models.SystemInventory{}).
 		Where("culled_timestamp < ?", now).
-		Where("inventory_id = ?::uuid", id).Count(&systemCount).Error)
+		Where("inventory_id = ?", testInventoryID).Count(&systemCount).Error)
 
 	assert.Equal(t, 1, int(systemCount))
 }
 
 func getOrCreateTestAccount(t *testing.T) int {
-	accountID, err := middlewares.GetOrCreateAccount(id)
+	accountID, err := middlewares.GetOrCreateAccount(testOrgID)
 	assert.Nil(t, err)
 	return accountID
 }
 
 // nolint: unparam
-func createTestUploadEvent(orgID, inventoryID, reporter string, packages, yum bool, eventType string) HostEvent {
+func createTestUploadEvent(orgID string, inventoryID uuid.UUID, reporter string,
+	packages, yum bool, eventType string) HostEvent {
 	now := time.Now()
 	ev := HostEvent{
 		Type: eventType,
@@ -228,7 +233,7 @@ func createTestUploadEvent(orgID, inventoryID, reporter string, packages, yum bo
 	return ev
 }
 
-func createTestDeleteEvent(inventoryID string) mqueue.PlatformEvent {
+func createTestDeleteEvent(inventoryID uuid.UUID) mqueue.PlatformEvent {
 	typ := "delete"
 	return mqueue.PlatformEvent{
 		ID:   inventoryID,
@@ -256,9 +261,9 @@ func assertSystemReposInDB(t *testing.T, systemID int64, repos []string) {
 }
 
 // nolint: unparam
-func assertYumUpdatesInDB(t *testing.T, inventoryID string, yumUpdates *YumUpdates) {
+func assertYumUpdatesInDB(t *testing.T, inventoryID uuid.UUID, yumUpdates *YumUpdates) {
 	var system models.SystemInventory
-	assert.NoError(t, database.DB.Where("inventory_id = ?::uuid", inventoryID).Find(&system).Error)
+	assert.NoError(t, database.DB.Where("inventory_id = ?", inventoryID).Find(&system).Error)
 	assert.Equal(t, system.InventoryID, inventoryID)
 	var systemYumUpdatesParsed vmaas.UpdatesV3Response
 	var yumUpdatesParsed vmaas.UpdatesV3Response

--- a/listener/event_buffers.go
+++ b/listener/event_buffers.go
@@ -6,6 +6,8 @@ import (
 	"app/base/utils"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type eventBuffer struct {
@@ -31,7 +33,7 @@ func (b *eventBuffer) initEventBuffer(evalWriter, ptWriter *mqueue.Writer) {
 
 // send events after full buffer or timeout
 func (b *eventBuffer) bufferEvalEvents(
-	inventoryID string,
+	inventoryID uuid.UUID,
 	rhAccountID int,
 	ptEvent *mqueue.PayloadTrackerEvent,
 ) {

--- a/listener/events.go
+++ b/listener/events.go
@@ -64,6 +64,7 @@ func EventsMessageHandler(m mqueue.KafkaMessage) error {
 
 func HandleDelete(event mqueue.PlatformEvent) error {
 	defer utils.ObserveSecondsSince(time.Now(), messageHandlingDuration.WithLabelValues(EventDelete))
+
 	// TODO: Do we need locking here ?
 	err := database.OnConflictUpdate(database.DB, "inventory_id", "when_deleted").
 		Create(models.DeletedSystem{
@@ -78,7 +79,7 @@ func HandleDelete(event mqueue.PlatformEvent) error {
 	}
 
 	// mark system as stale and let system_culling job remove it later
-	query := database.DB.Model(&models.SystemInventory{}).Where("inventory_id = ?::uuid", event.ID).
+	query := database.DB.Model(&models.SystemInventory{}).Where("inventory_id = ?", event.ID).
 		Updates(map[string]interface{}{
 			"culled_timestamp": gorm.Expr("NOW()"),
 		})

--- a/listener/events_test.go
+++ b/listener/events_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
-const notexistid = "99c0ffee-0000-0000-0000-999999999999"
+var notexistid = uuid.MustParse("99c0ffee-0000-0000-0000-999999999999")
 
 func TestUpdateSystem(t *testing.T) {
 	utils.SkipWithoutDB(t)
@@ -21,25 +22,25 @@ func TestUpdateSystem(t *testing.T) {
 	configure()
 
 	deleteData(t)
-	createTestSystemInDB(t, id, 1, id)
+	createTestSystemInDB(t, testInventoryID, 1, testInventoryID.String())
 
-	ev := createTestUploadEvent("1", id, "puptoo", false, false, "created")
+	ev := createTestUploadEvent("1", testInventoryID, "puptoo", false, false, "created")
 	name := "TEST_NAME"
 	ev.Host.DisplayName = &name
 	ev.Host.SystemProfile.InstalledPackages = &[]string{"kernel-0:4.18.0-193.1.2.el8_2.x86_64"}
 	assert.NoError(t, HandleUpload(ev))
 
 	var system models.SystemInventory
-	assert.NoError(t, database.DB.Order("ID DESC").Find(&system, "inventory_id = ?::uuid", id).Error)
+	assert.NoError(t, database.DB.Order("ID DESC").Find(&system, "inventory_id = ?", testInventoryID).Error)
 
 	assert.Equal(t, name, system.DisplayName)
 }
 
 func TestDeleteSystem(t *testing.T) {
 	deleteData(t)
-	createTestSystemInDB(t, id, 1, id)
+	createTestSystemInDB(t, testInventoryID, 1, testInventoryID.String())
 
-	deleteEvent := createTestDeleteEvent(id)
+	deleteEvent := createTestDeleteEvent(testInventoryID)
 	err := HandleDelete(deleteEvent)
 	assert.NoError(t, err)
 	assertSystemCulled(t)
@@ -49,7 +50,7 @@ func TestDeleteSystem(t *testing.T) {
 func TestDeleteSystemWarn1(t *testing.T) {
 	logHook := utils.NewTestLogHook()
 	log.AddHook(logHook)
-	deleteEvent := createTestDeleteEvent(id)
+	deleteEvent := createTestDeleteEvent(testInventoryID)
 	deleteEvent.Type = nil
 
 	data, err := sonic.Marshal(deleteEvent)
@@ -64,7 +65,7 @@ func TestDeleteSystemWarn1(t *testing.T) {
 func TestDeleteSystemWarn2(t *testing.T) {
 	logHook := utils.NewTestLogHook()
 	log.AddHook(logHook)
-	deleteEvent := createTestDeleteEvent(id)
+	deleteEvent := createTestDeleteEvent(testInventoryID)
 	nonDeleteType := "no-delete"
 	deleteEvent.Type = &nonDeleteType
 
@@ -99,12 +100,12 @@ func TestUploadAfterDelete(t *testing.T) {
 	deleteData(t)
 
 	// system is not in database and the first event is delete
-	deleteEvent := createTestDeleteEvent(id)
+	deleteEvent := createTestDeleteEvent(testInventoryID)
 	err := HandleDelete(deleteEvent)
 	assert.NoError(t, err)
 
 	// upload will be skipped and system won't be created
-	uploadEvent := createTestUploadEvent("1", id, "puptoo", true, false, "created")
+	uploadEvent := createTestUploadEvent("1", testInventoryID, "puptoo", true, false, "created")
 	err = HandleUpload(uploadEvent)
 	assert.NoError(t, err)
 	assertSystemNotInDB(t)
@@ -118,14 +119,14 @@ func TestCreateDeleteUpload(t *testing.T) {
 	configure()
 	deleteData(t)
 
-	uploadEvent := createTestUploadEvent("1", id, "puptoo", true, false, "created")
+	uploadEvent := createTestUploadEvent("1", testInventoryID, "puptoo", true, false, "created")
 	originalName := "UPLOADED"
 	uploadEvent.Host.DisplayName = &originalName
 	err := HandleUpload(uploadEvent)
 	assert.NoError(t, err)
 
 	// delete marks the system but not physically delete it
-	deleteEvent := createTestDeleteEvent(id)
+	deleteEvent := createTestDeleteEvent(testInventoryID)
 	err = HandleDelete(deleteEvent)
 	assert.NoError(t, err)
 	assertSystemCulled(t)
@@ -137,7 +138,7 @@ func TestCreateDeleteUpload(t *testing.T) {
 	assert.NoError(t, err)
 
 	var system models.SystemInventory
-	assert.NoError(t, database.DB.Order("ID DESC").Find(&system, "inventory_id = ?::uuid", id).Error)
+	assert.NoError(t, database.DB.Order("ID DESC").Find(&system, "inventory_id = ?", testInventoryID).Error)
 	assert.Equal(t, originalName, system.DisplayName)
 
 	deleteData(t)

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/lib/pq"
 
 	stdErrors "errors"
@@ -81,7 +82,7 @@ var (
 )
 
 type Host struct {
-	ID                    string                                 `json:"id,omitempty"`
+	ID                    uuid.UUID                              `json:"id,omitempty"`
 	DisplayName           *string                                `json:"display_name,omitempty"`
 	OrgID                 *string                                `json:"org_id,omitempty"`
 	StaleTimestamp        *types.Rfc3339Timestamp                `json:"stale_timestamp,omitempty"`
@@ -348,7 +349,7 @@ func updateSystemPlatform(tx *gorm.DB, accountID int, host *Host,
 		"mssql_workload_version",
 	}
 
-	displayName := inventoryID
+	displayName := inventoryID.String()
 	if host.DisplayName != nil && strings.TrimSpace(*host.DisplayName) != "" {
 		displayName = *host.DisplayName
 	}
@@ -404,7 +405,7 @@ func updateSystemPlatform(tx *gorm.DB, accountID int, host *Host,
 	// Lock the system_inventory row and read prior json_checksum / yum_checksum for incremental updates.
 	tx.Clauses(clause.Locking{Strength: "UPDATE"}).
 		Model(&models.SystemInventory{}).
-		Where("rh_account_id = ? AND inventory_id = ?::uuid", accountID, inventoryID).
+		Where("rh_account_id = ? AND inventory_id = ?", accountID, inventoryID).
 		Select("json_checksum, yum_checksum").
 		First(&oldChecksums)
 
@@ -453,7 +454,7 @@ func storeOrUpdateSysPlatform(
 	// Resolve system_inventory.id by account + inventory UUID
 	var existingID int64
 	if err := tx.Model(&models.SystemInventory{}).
-		Where("rh_account_id = ? AND inventory_id = ?::uuid", system.Inventory.RhAccountID, system.Inventory.InventoryID).
+		Where("rh_account_id = ? AND inventory_id = ?", system.Inventory.RhAccountID, system.Inventory.InventoryID).
 		Select("id").
 		Scan(&existingID).Error; err != nil {
 		utils.LogWarn("err", err, "couldn't find system for update")
@@ -779,7 +780,7 @@ func processUpload(host *Host, yumUpdates *YumUpdates) (*models.SystemPlatformV2
 	}
 
 	// If the system was deleted in last hour, don't register this upload
-	if deleted.InventoryID != "" && deleted.WhenDeleted.After(time.Now().Add(-deletionThreshold)) {
+	if deleted.InventoryID != uuid.Nil && deleted.WhenDeleted.After(time.Now().Add(-deletionThreshold)) {
 		utils.LogInfo("inventoryID", host.ID, "Received recently deleted system")
 		return nil, nil
 	}

--- a/listener/upload_test.go
+++ b/listener/upload_test.go
@@ -47,7 +47,7 @@ func createTestInvHost(t *testing.T) *Host {
 
 	now := time.Now()
 	host := Host{
-		ID:             id,
+		ID:             testInventoryID,
 		StaleTimestamp: &correctTime,
 		Reporter:       "puptoo",
 		Groups:         []inventory.Group{{ID: database.TestWorkspace1ID, Name: "group1"}},
@@ -64,7 +64,7 @@ func createTestHostWithEnv(reporter, consumer, baseURL string) *Host {
 		consumerUUID = uuid.Nil
 	}
 	return &Host{
-		ID:       id,
+		ID:       testInventoryID,
 		Reporter: reporter,
 		Groups:   []inventory.Group{{ID: database.TestWorkspace1ID, Name: "group1"}},
 		SystemProfile: inventory.SystemProfile{
@@ -99,7 +99,7 @@ func TestUpdateSystemPlatform(t *testing.T) {
 	assert.Nil(t, err)
 
 	reporterID1 := 1
-	assertSystemInDB(t, id, &accountID1, &reporterID1)
+	assertSystemInDB(t, testInventoryID, &accountID1, &reporterID1)
 	assertReposInDB(t, req.RepositoryList)
 
 	host2 := createTestInvHost(t)
@@ -109,7 +109,7 @@ func TestUpdateSystemPlatform(t *testing.T) {
 	assert.Nil(t, err)
 
 	reporterID2 := 3
-	assertSystemInDB(t, id, &accountID2, &reporterID2)
+	assertSystemInDB(t, testInventoryID, &accountID2, &reporterID2)
 
 	assert.Equal(t, sys1.Inventory.ID, sys2.Inventory.ID)
 	assert.Equal(t, sys1.Inventory.InventoryID, sys2.Inventory.InventoryID)
@@ -142,26 +142,26 @@ func TestUpdateSystemPlatformUpdatesSubscriptionManagerIDWhenOwnerIDChanges(t *t
 		Basearch:       utils.PtrString("x86_64"),
 	}
 
-	ev := createTestUploadEvent(id, id, "puptoo", true, false, "created")
+	ev := createTestUploadEvent(testOrgID, testInventoryID, "puptoo", true, false, "created")
 	ev.Host.StaleTimestamp = &correctTime
 	ownerID1 := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 	ev.Host.SystemProfile.OwnerID = &ownerID1
 
 	_, err = updateSystemPlatform(database.DB, acc, &ev.Host, nil, &reqProfile)
 	require.NoError(t, err)
-	assertSystemInventoryProfileMatchesHost(t, id, &ev.Host)
+	assertSystemInventoryProfileMatchesHost(t, testInventoryID, &ev.Host)
 
 	ownerID2 := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 	ev.Host.SystemProfile.OwnerID = &ownerID2
 
 	_, err = updateSystemPlatform(database.DB, acc, &ev.Host, nil, &reqProfile)
 	require.NoError(t, err)
-	assertSystemInventoryProfileMatchesHost(t, id, &ev.Host)
+	assertSystemInventoryProfileMatchesHost(t, testInventoryID, &ev.Host)
 
 	ev.Host.SystemProfile.OwnerID = nil
 	_, err = updateSystemPlatform(database.DB, acc, &ev.Host, nil, &reqProfile)
 	require.NoError(t, err)
-	assertSystemInventoryProfileMatchesHost(t, id, &ev.Host)
+	assertSystemInventoryProfileMatchesHost(t, testInventoryID, &ev.Host)
 
 	deleteData(t)
 }
@@ -184,11 +184,11 @@ func TestUpdateSystemPlatformRefreshesInventoryProfileOnConflict(t *testing.T) {
 		Releasever:     utils.PtrString("7Server"),
 		Basearch:       utils.PtrString("x86_64"),
 	}
-	ev := createTestUploadEvent(id, id, "puptoo", true, false, "created")
+	ev := createTestUploadEvent(testOrgID, testInventoryID, "puptoo", true, false, "created")
 	ev.Host.StaleTimestamp = &correctTime
 	_, err = updateSystemPlatform(database.DB, acc, &ev.Host, nil, &reqProfile)
 	require.NoError(t, err)
-	assertSystemInventoryProfileMatchesHost(t, id, &ev.Host)
+	assertSystemInventoryProfileMatchesHost(t, testInventoryID, &ev.Host)
 
 	ev.Host.Tags = []byte(`{"namespace": "insights-client","key": "env","value": "staging"}`)
 	ev.Host.SystemProfile.OperatingSystem.Minor = 5
@@ -199,7 +199,7 @@ func TestUpdateSystemPlatformRefreshesInventoryProfileOnConflict(t *testing.T) {
 
 	_, err = updateSystemPlatform(database.DB, acc, &ev.Host, nil, &reqProfile)
 	require.NoError(t, err)
-	assertSystemInventoryProfileMatchesHost(t, id, &ev.Host)
+	assertSystemInventoryProfileMatchesHost(t, testInventoryID, &ev.Host)
 
 	deleteData(t)
 }
@@ -215,7 +215,7 @@ func TestUploadHandlerCreatedSystem(t *testing.T) {
 			deleteData(t)
 
 			_ = getOrCreateTestAccount(t)
-			event := createTestUploadEvent(id, id, "puptoo", true, false, eventType)
+			event := createTestUploadEvent(testOrgID, testInventoryID, "puptoo", true, false, eventType)
 
 			event.Host.SystemProfile.OperatingSystem = inventory.OperatingSystem{Major: 8}
 			repos := append(event.Host.SystemProfile.GetYumRepos(), inventory.YumRepo{ID: "epel", Enabled: true})
@@ -225,10 +225,10 @@ func TestUploadHandlerCreatedSystem(t *testing.T) {
 			assert.NoError(t, err)
 
 			reporterID := 1
-			assertSystemInDB(t, id, nil, &reporterID)
+			assertSystemInDB(t, testInventoryID, nil, &reporterID)
 
 			var inv models.SystemInventory
-			assert.NoError(t, database.DB.Where("inventory_id = ?::uuid", id).First(&inv).Error)
+			assert.NoError(t, database.DB.Where("inventory_id = ?", testInventoryID).First(&inv).Error)
 			var patch models.SystemPatch
 			assert.NoError(t, database.DB.Where("rh_account_id = ? AND system_id = ?", inv.RhAccountID, inv.ID).
 				First(&patch).Error)
@@ -252,7 +252,7 @@ func TestUploadHandlerWarn(t *testing.T) {
 	configure()
 	logHook := utils.NewTestLogHook()
 	log.AddHook(logHook)
-	noPkgsEvent := createTestUploadEvent("1", id, "puptoo", false, false, "created")
+	noPkgsEvent := createTestUploadEvent("1", testInventoryID, "puptoo", false, false, "created")
 	err := HandleUpload(noPkgsEvent)
 	if assert.Error(t, err) {
 		assert.ErrorIs(t, err, ErrNoPackages)
@@ -265,7 +265,7 @@ func TestUploadHandlerWarnSkipReporter(t *testing.T) {
 	configure()
 	logHook := utils.NewTestLogHook()
 	log.AddHook(logHook)
-	noPkgsEvent := createTestUploadEvent("1", id, "yupana", false, false, "created")
+	noPkgsEvent := createTestUploadEvent("1", testInventoryID, "yupana", false, false, "created")
 	err := HandleUpload(noPkgsEvent)
 	if assert.Error(t, err) {
 		assert.ErrorIs(t, err, ErrReporter)
@@ -278,7 +278,7 @@ func TestUploadHandlerWarnSkipHostType(t *testing.T) {
 	configure()
 	logHook := utils.NewTestLogHook()
 	log.AddHook(logHook)
-	event := createTestUploadEvent("1", id, "puptoo", true, false, "created")
+	event := createTestUploadEvent("1", testInventoryID, "puptoo", true, false, "created")
 	event.Host.SystemProfile.HostType = "edge"
 	err := HandleUpload(event)
 	if assert.Error(t, err) {
@@ -293,7 +293,7 @@ func TestUploadHandlerError1(t *testing.T) {
 	configure()
 	logHook := utils.NewTestLogHook()
 	log.AddHook(logHook)
-	event := createTestUploadEvent("1", id, "puptoo", true, false, "created")
+	event := createTestUploadEvent("1", testInventoryID, "puptoo", true, false, "created")
 	*event.Host.OrgID = ""
 	err := HandleUpload(event)
 	if assert.Error(t, err) {
@@ -319,7 +319,7 @@ func TestUploadHandlerError2(t *testing.T) {
 	logHook := utils.NewTestLogHook()
 	log.AddHook(logHook)
 	_ = getOrCreateTestAccount(t)
-	event := createTestUploadEvent("1", id, "puptoo", true, false, "created")
+	event := createTestUploadEvent("1", testInventoryID, "puptoo", true, false, "created")
 	err := HandleUpload(event)
 	assert.Nil(t, err)
 	time.Sleep(2 * uploadEvalTimeout)
@@ -417,7 +417,7 @@ func TestUpdateSystemPlatformYumUpdates(t *testing.T) {
 		HTTPClient: &http.Client{},
 		Debug:      true,
 	}
-	hostEvent := createTestUploadEvent("1", id, "puptoo", false, true, "created")
+	hostEvent := createTestUploadEvent("1", testInventoryID, "puptoo", false, true, "created")
 	yumUpdates, err := getYumUpdates(hostEvent, httpClient)
 	assert.Nil(t, err)
 
@@ -427,17 +427,17 @@ func TestUpdateSystemPlatformYumUpdates(t *testing.T) {
 	assert.Nil(t, err)
 
 	reporterID1 := 1
-	assertSystemInDB(t, id, &accountID1, &reporterID1)
+	assertSystemInDB(t, testInventoryID, &accountID1, &reporterID1)
 	assertReposInDB(t, req.RepositoryList)
-	assertYumUpdatesInDB(t, id, yumUpdates)
-	assertSystemInventoryProfileMatchesHost(t, id, &hostEvent.Host)
+	assertYumUpdatesInDB(t, testInventoryID, yumUpdates)
+	assertSystemInventoryProfileMatchesHost(t, testInventoryID, &hostEvent.Host)
 
 	// check that yumUpdates has been updated (keep the same Host so profile columns are not wiped)
 	yumUpdates.RawParsed = []byte("{}")
 	_, err = updateSystemPlatform(database.DB, accountID1, &hostEvent.Host, yumUpdates, &req)
 	assert.Nil(t, err)
-	assertYumUpdatesInDB(t, id, yumUpdates)
-	assertSystemInventoryProfileMatchesHost(t, id, &hostEvent.Host)
+	assertYumUpdatesInDB(t, testInventoryID, yumUpdates)
+	assertSystemInventoryProfileMatchesHost(t, testInventoryID, &hostEvent.Host)
 
 	hostEvent.Host.Tags = []byte(`{"namespace": "insights-client","key": "env","value": "staging"}`)
 	hostEvent.Host.SystemProfile.OperatingSystem.Minor = 6
@@ -447,8 +447,8 @@ func TestUpdateSystemPlatformYumUpdates(t *testing.T) {
 	hostEvent.Host.SystemProfile.Workloads.Mssql.Version = "17.0"
 	_, err = updateSystemPlatform(database.DB, accountID1, &hostEvent.Host, yumUpdates, &req)
 	assert.Nil(t, err)
-	assertYumUpdatesInDB(t, id, yumUpdates)
-	assertSystemInventoryProfileMatchesHost(t, id, &hostEvent.Host)
+	assertYumUpdatesInDB(t, testInventoryID, yumUpdates)
+	assertSystemInventoryProfileMatchesHost(t, testInventoryID, &hostEvent.Host)
 
 	// Clear workload-related profile fields and verify ON CONFLICT updates clear them in DB.
 	hostEvent.Host.SystemProfile.Rhsm.Version = ""
@@ -458,8 +458,8 @@ func TestUpdateSystemPlatformYumUpdates(t *testing.T) {
 	hostEvent.Host.SystemProfile.Workloads.Mssql.Version = ""
 	_, err = updateSystemPlatform(database.DB, accountID1, &hostEvent.Host, yumUpdates, &req)
 	assert.Nil(t, err)
-	assertYumUpdatesInDB(t, id, yumUpdates)
-	assertSystemInventoryProfileMatchesHost(t, id, &hostEvent.Host)
+	assertYumUpdatesInDB(t, testInventoryID, yumUpdates)
+	assertSystemInventoryProfileMatchesHost(t, testInventoryID, &hostEvent.Host)
 
 	deleteData(t)
 }
@@ -478,11 +478,11 @@ func TestStoreOrUpdateSysPlatform(t *testing.T) {
 	colsToUpdate := []string{"vmaas_json", "json_checksum", "reporter_id", "satellite_managed"}
 	vmaasJSON := "this_is_json"
 	// insert new row
-	hostEvent := createTestUploadEvent("1", id, "puptoo", false, true, "created")
+	hostEvent := createTestUploadEvent("1", testInventoryID, "puptoo", false, true, "created")
 	hostWorkspaces := inventory.Groups(hostEvent.Host.Groups)
 	inStore := &models.SystemPlatformV2{
 		Inventory: models.SystemInventory{
-			InventoryID:                      "99990000-0000-0000-0000-000000000001",
+			InventoryID:                      uuid.MustParse("99990000-0000-0000-0000-000000000001"),
 			RhAccountID:                      1,
 			VmaasJSON:                        &vmaasJSON,
 			DisplayName:                      "display_name",

--- a/manager/controllers/advisory_systems.go
+++ b/manager/controllers/advisory_systems.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -23,7 +24,7 @@ type AdvisorySystemsResponse struct {
 
 type AdvisorySystemItem struct {
 	Attributes AdvisorySystemItemAttributes `json:"attributes"`
-	ID         string                       `json:"id"`
+	ID         uuid.UUID                    `json:"id"`
 	Type       string                       `json:"type"`
 }
 
@@ -197,8 +198,8 @@ func systemsIDsStatus(c *gin.Context, systems []SystemsStatusID, meta *ListMeta)
 	ids := make([]string, len(systems))
 	data := make([]IDStatus, len(systems))
 	for i, x := range systems {
-		ids[i] = x.ID
-		data[i] = IDStatus{x.ID, x.Status}
+		ids[i] = x.ID.String()
+		data[i] = IDStatus{x.ID.String(), x.Status}
 	}
 	resp.IDs = ids
 	resp.Data = data

--- a/manager/controllers/advisory_systems_export_test.go
+++ b/manager/controllers/advisory_systems_export_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,7 +18,7 @@ func TestAdvisorySystemsExportJSON(t *testing.T) {
 	var output []SystemDBLookupExtended
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 6, len(output))
-	assert.Equal(t, output[0].ID, "00000000-0000-0000-0000-000000000001")
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output[0].ID)
 	assert.Equal(t, SystemTagsList{{"k1", "ns1", "val1"}, {"k2", "ns1", "val2"}}, output[0].SystemItemAttributes.Tags)
 }
 

--- a/manager/controllers/advisory_systems_test.go
+++ b/manager/controllers/advisory_systems_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +19,7 @@ func TestAdvisorySystemsDefault(t *testing.T) {
 	var output AdvisorySystemsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 6, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output.Data[0].ID)
 	assert.Equal(t, "system", output.Data[0].Type)
 	assert.Equal(t, "2020-09-22 16:00:00 +0000 UTC", output.Data[0].Attributes.LastUpload.String())
 	assert.False(t, output.Data[0].Attributes.Stale)
@@ -63,7 +64,7 @@ func TestAdvisorySystemsOffsetLimit(t *testing.T) {
 	var output AdvisorySystemsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 1, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000006", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000006"), output.Data[0].ID)
 	assert.Equal(t, "system", output.Data[0].Type)
 	assert.Equal(t, "2018-08-26 16:00:00 +0000 UTC", output.Data[0].Attributes.LastUpload.String())
 }
@@ -121,7 +122,7 @@ func TestAdvisorySystemsTagsMultiple(t *testing.T) {
 	var output AdvisorySystemsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 1, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000003", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000003"), output.Data[0].ID)
 }
 
 func TestAdvisorySystemsTagsInvalid(t *testing.T) {

--- a/manager/controllers/common_attributes.go
+++ b/manager/controllers/common_attributes.go
@@ -1,7 +1,11 @@
 // nolint:lll
 package controllers
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 type MetaTotalHelper struct {
 	// a helper to get total number of systems
@@ -65,7 +69,7 @@ type SystemStale struct {
 }
 
 type SystemIDAttribute struct {
-	ID string `json:"id" csv:"id" query:"si.inventory_id" gorm:"column:inventory_id"`
+	ID uuid.UUID `json:"id" csv:"id" query:"si.inventory_id" gorm:"column:inventory_id"`
 }
 
 type SystemAdvisoryStatus struct {

--- a/manager/controllers/package_systems_export_test.go
+++ b/manager/controllers/package_systems_export_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,7 +19,7 @@ func TestPackageSystemsExportHandlerJSON(t *testing.T) {
 	var output []PackageSystemItem
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 3, len(output))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000012", output[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000012"), output[0].ID)
 	assert.Equal(t, "5.6.13-200.fc31.x86_64", output[0].InstalledEVRA)
 	assert.Equal(t, "5.6.13-201.fc31.x86_64", output[0].AvailableEVRA)
 	assert.Equal(t, SystemTagsList{{"k1", "ns1", "val1"}}, output[0].Tags)

--- a/manager/controllers/package_systems_test.go
+++ b/manager/controllers/package_systems_test.go
@@ -7,13 +7,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPackageSystems(t *testing.T) {
 	output := testPackageSystems(t, "kernel", "?sort=id", 3)
 	assert.Equal(t, 3, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000012", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000012"), output.Data[0].ID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000012", output.Data[0].DisplayName)
 	assert.Equal(t, "5.6.13-200.fc31.x86_64", output.Data[0].InstalledEVRA)
 	assert.Equal(t, "5.6.13-201.fc31.x86_64", output.Data[0].AvailableEVRA)

--- a/manager/controllers/structures.go
+++ b/manager/controllers/structures.go
@@ -33,6 +33,10 @@ type ListMeta struct {
 	HasSystems *bool `json:"has_systems,omitempty"`
 }
 
+// IDPlain, IDStatus, and IDSatelliteManaged use string IDs because they serve both
+// system endpoints (uuid.UUID) and advisory endpoints (names like "RHSA-2024-1234")
+// System callers must convert uuid.UUID to string via .String()
+
 type IDPlain struct {
 	ID string `json:"id"`
 }

--- a/manager/controllers/system_advisories.go
+++ b/manager/controllers/system_advisories.go
@@ -13,6 +13,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -74,15 +75,10 @@ func systemAdvisoriesCommon(c *gin.Context) (*gorm.DB, *ListMeta, []string, erro
 	account := c.GetInt(utils.KeyAccount)
 	groups := c.GetStringMapString(utils.KeyInventoryGroups)
 
-	inventoryID := c.Param("inventory_id")
-	if inventoryID == "" {
-		c.JSON(http.StatusBadRequest, utils.ErrorResponse{Error: "inventory_id param not found"})
-		return nil, nil, nil, errors.New("inventory_id param not found")
-	}
-
-	if !utils.IsValidUUID(inventoryID) {
-		utils.LogAndRespBadRequest(c, errors.New("bad request"), "incorrect inventory_id format")
-		return nil, nil, nil, errors.New("incorrect inventory_id format")
+	inventoryID, err := uuid.Parse(c.Param("inventory_id"))
+	if err != nil {
+		utils.LogAndRespBadRequest(c, err, "incorrect inventory_id format")
+		return nil, nil, nil, err
 	}
 
 	filters, err := ParseAllFilters(c, SystemAdvisoriesOpts)
@@ -92,7 +88,7 @@ func systemAdvisoriesCommon(c *gin.Context) (*gorm.DB, *ListMeta, []string, erro
 
 	db := middlewares.DBFromContext(c)
 	var exists int64
-	err = db.Model(&models.SystemInventory{}).Where("inventory_id = ?::uuid ", inventoryID).
+	err = db.Model(&models.SystemInventory{}).Where("inventory_id = ?", inventoryID).
 		Count(&exists).Error
 
 	if err != nil {
@@ -200,7 +196,7 @@ func SystemAdvisoriesIDsHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, &resp)
 }
 
-func buildSystemAdvisoriesQuery(db *gorm.DB, account int, groups map[string]string, inventoryID string) *gorm.DB {
+func buildSystemAdvisoriesQuery(db *gorm.DB, account int, groups map[string]string, inventoryID uuid.UUID) *gorm.DB {
 	query := database.SystemAdvisoriesByInventoryID(db, account, groups, inventoryID,
 		database.JoinAdvisoryMetadata, database.JoinAdvisoryType).
 		Joins("JOIN status ON sa.status_id = status.id").

--- a/manager/controllers/system_advisories_export.go
+++ b/manager/controllers/system_advisories_export.go
@@ -4,9 +4,9 @@ import (
 	"app/base/models"
 	"app/base/utils"
 	"app/manager/middlewares"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -36,20 +36,15 @@ func SystemAdvisoriesExportHandler(c *gin.Context) {
 	account := c.GetInt(utils.KeyAccount)
 	groups := c.GetStringMapString(utils.KeyInventoryGroups)
 
-	inventoryID := c.Param("inventory_id")
-	if inventoryID == "" {
-		c.JSON(http.StatusBadRequest, utils.ErrorResponse{Error: "inventory_id param not found"})
-		return
-	}
-
-	if !utils.IsValidUUID(inventoryID) {
-		utils.LogAndRespBadRequest(c, errors.New("bad request"), "incorrect inventory_id format")
+	inventoryID, err := uuid.Parse(c.Param("inventory_id"))
+	if err != nil {
+		utils.LogAndRespBadRequest(c, err, "incorrect inventory_id format")
 		return
 	}
 
 	db := middlewares.DBFromContext(c)
 	var exists int64
-	err := db.Model(&models.SystemInventory{}).Where("inventory_id = ?::uuid ", inventoryID).
+	err = db.Model(&models.SystemInventory{}).Where("inventory_id = ?", inventoryID).
 		Count(&exists).Error
 
 	if err != nil {

--- a/manager/controllers/system_detail.go
+++ b/manager/controllers/system_detail.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -46,14 +47,9 @@ func SystemDetailHandler(c *gin.Context) {
 	account := c.GetInt(utils.KeyAccount)
 	groups := c.GetStringMapString(utils.KeyInventoryGroups)
 
-	inventoryID := c.Param("inventory_id")
-	if inventoryID == "" {
-		c.JSON(http.StatusBadRequest, utils.ErrorResponse{Error: "inventory_id param not found"})
-		return
-	}
-
-	if !utils.IsValidUUID(inventoryID) {
-		utils.LogAndRespBadRequest(c, errors.New("bad request"), "incorrect inventory_id format")
+	inventoryID, err := uuid.Parse(c.Param("inventory_id"))
+	if err != nil {
+		utils.LogAndRespBadRequest(c, err, "incorrect inventory_id format")
 		return
 	}
 
@@ -65,9 +61,9 @@ func SystemDetailHandler(c *gin.Context) {
 	db := middlewares.DBFromContext(c)
 	query := database.Systems(db, account, groups, database.JoinTemplates).
 		Select(database.MustGetSelect(&systemDetail)).
-		Where("si.inventory_id = ?::uuid", inventoryID)
+		Where("si.inventory_id = ?", inventoryID)
 
-	err := query.Take(&systemDetail).Error
+	err = query.Take(&systemDetail).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		utils.LogAndRespNotFound(c, err, "inventory not found")
 		return
@@ -156,14 +152,9 @@ func systemJSONsCommon(c *gin.Context, column string) *models.SystemInventory {
 	account := c.GetInt(utils.KeyAccount)
 	groups := c.GetStringMapString(utils.KeyInventoryGroups)
 
-	inventoryID := c.Param("inventory_id")
-	if inventoryID == "" {
-		c.JSON(http.StatusBadRequest, utils.ErrorResponse{Error: "inventory_id param not found"})
-		return nil
-	}
-
-	if !utils.IsValidUUID(inventoryID) {
-		utils.LogAndRespBadRequest(c, errors.New("bad request"), "incorrect inventory_id format")
+	inventoryID, err := uuid.Parse(c.Param("inventory_id"))
+	if err != nil {
+		utils.LogAndRespBadRequest(c, err, "incorrect inventory_id format")
 		return nil
 	}
 
@@ -175,9 +166,9 @@ func systemJSONsCommon(c *gin.Context, column string) *models.SystemInventory {
 	db := middlewares.DBFromContext(c)
 	query := database.Systems(db, account, groups).
 		Select(column).
-		Where("si.inventory_id = ?::uuid", inventoryID)
+		Where("si.inventory_id = ?", inventoryID)
 
-	err := query.Take(&system).Error
+	err = query.Take(&system).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		utils.LogAndRespNotFound(c, err, "inventory not found")
 		return nil

--- a/manager/controllers/system_detail_test.go
+++ b/manager/controllers/system_detail_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +17,7 @@ func TestSystemDetailDefault1(t *testing.T) {
 
 	var output SystemDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data.ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output.Data.ID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data.Attributes.DisplayName)
 	assert.Equal(t, "system", output.Data.Type)
 	assert.Equal(t, "2018-09-22 16:00:00 +0000 UTC", output.Data.Attributes.LastEvaluation.String())
@@ -54,7 +55,7 @@ func TestSystemDetailNoIdProvided(t *testing.T) {
 
 	var errResp utils.ErrorResponse
 	CheckResponse(t, w, http.StatusBadRequest, &errResp)
-	assert.Equal(t, "inventory_id param not found", errResp.Error)
+	assert.Equal(t, "incorrect inventory_id format", errResp.Error)
 }
 
 func TestSystemDetailNotFound(t *testing.T) {
@@ -74,7 +75,7 @@ func TestSystemsNoRHSM(t *testing.T) {
 
 	var output SystemDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
-	assert.Equal(t, "00000000-0000-0000-0000-000000000014", output.Data.ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000014"), output.Data.ID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000014", output.Data.Attributes.DisplayName)
 	assert.Equal(t, "", output.Data.Attributes.Rhsm)
 }
@@ -86,7 +87,7 @@ func TestRHSMLessThanOS(t *testing.T) {
 
 	var output SystemDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
-	assert.Equal(t, "00000000-0000-0000-0000-000000000003", output.Data.ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000003"), output.Data.ID)
 	assert.Equal(t, "8.0", output.Data.Attributes.Rhsm)
 	assert.Equal(t, "8", output.Data.Attributes.OSMajor)
 	assert.Equal(t, "1", output.Data.Attributes.OSMinor)
@@ -99,7 +100,7 @@ func TestRHSMGreaterThanOS(t *testing.T) {
 
 	var output SystemDetailResponse
 	CheckResponse(t, w, http.StatusOK, &output)
-	assert.Equal(t, "00000000-0000-0000-0000-000000000004", output.Data.ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000004"), output.Data.ID)
 	assert.Equal(t, "8.3", output.Data.Attributes.Rhsm)
 	assert.Equal(t, "8", output.Data.Attributes.OSMajor)
 	assert.Equal(t, "2", output.Data.Attributes.OSMinor)

--- a/manager/controllers/system_packages.go
+++ b/manager/controllers/system_packages.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -56,12 +57,12 @@ type SystemPackageDBLoad struct {
 	MetaTotalHelper
 }
 
-func systemPackageQuery(db *gorm.DB, account int, groups map[string]string, inventoryID string) *gorm.DB {
+func systemPackageQuery(db *gorm.DB, account int, groups map[string]string, inventoryID uuid.UUID) *gorm.DB {
 	query := database.SystemPackages(db, account, groups, database.JoinInstallableApplicablePackages).
 		Joins("LEFT JOIN strings AS descr ON p.description_hash = descr.id").
 		Joins("LEFT JOIN strings AS sum ON p.summary_hash = sum.id").
 		Select(SystemPackagesSelect).
-		Where("si.inventory_id = ?::uuid", inventoryID)
+		Where("si.inventory_id = ?", inventoryID)
 
 	return query
 }
@@ -91,14 +92,9 @@ func SystemPackagesHandler(c *gin.Context) {
 	account := c.GetInt(utils.KeyAccount)
 	groups := c.GetStringMapString(utils.KeyInventoryGroups)
 
-	inventoryID := c.Param("inventory_id")
-	if inventoryID == "" {
-		c.JSON(http.StatusBadRequest, utils.ErrorResponse{Error: "inventory_id param not found"})
-		return
-	}
-
-	if !utils.IsValidUUID(inventoryID) {
-		utils.LogAndRespBadRequest(c, errors.New("bad request"), "incorrect inventory_id format")
+	inventoryID, err := uuid.Parse(c.Param("inventory_id"))
+	if err != nil {
+		utils.LogAndRespBadRequest(c, err, "incorrect inventory_id format")
 		return
 	}
 	filters, err := ParseAllFilters(c, SystemPackagesOpts)

--- a/manager/controllers/system_packages_export.go
+++ b/manager/controllers/system_packages_export.go
@@ -4,9 +4,9 @@ import (
 	"app/base/utils"
 	"app/manager/middlewares"
 	"errors"
-	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -39,21 +39,16 @@ func SystemPackagesExportHandler(c *gin.Context) {
 	account := c.GetInt(utils.KeyAccount)
 	groups := c.GetStringMapString(utils.KeyInventoryGroups)
 
-	inventoryID := c.Param("inventory_id")
-	if inventoryID == "" {
-		c.JSON(http.StatusBadRequest, utils.ErrorResponse{Error: "inventory_id param not found"})
-		return
-	}
-
-	if !utils.IsValidUUID(inventoryID) {
-		utils.LogAndRespBadRequest(c, errors.New("bad request"), "incorrect inventory_id format")
+	inventoryID, err := uuid.Parse(c.Param("inventory_id"))
+	if err != nil {
+		utils.LogAndRespBadRequest(c, err, "incorrect inventory_id format")
 		return
 	}
 
 	var loaded []SystemPackageDBLoad
 	db := middlewares.DBFromContext(c)
 	q := systemPackageQuery(db, account, groups, inventoryID)
-	q, err := ExportListCommon(q, c, SystemPackagesOpts)
+	q, err = ExportListCommon(q, c, SystemPackagesOpts)
 	if err != nil {
 		// Error handling and setting of result code & content is done in ListCommon
 		return

--- a/manager/controllers/systems.go
+++ b/manager/controllers/systems.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -33,12 +34,12 @@ var SystemOpts = ListOpts{
 }
 
 type SystemsID struct {
-	ID string `query:"si.inventory_id" gorm:"column:inventory_id"`
+	ID uuid.UUID `query:"si.inventory_id" gorm:"column:inventory_id"`
 	MetaTotalHelper
 }
 
 type SystemsSatelliteManagedID struct {
-	ID string `query:"si.inventory_id" gorm:"column:inventory_id"`
+	ID uuid.UUID `query:"si.inventory_id" gorm:"column:inventory_id"`
 	SystemSatelliteManaged
 	MetaTotalHelper
 }
@@ -166,13 +167,13 @@ func SystemJSONBItemScan[T SystemJSONBItemType](v *T, value interface{}) error {
 
 type SystemItemExtended struct {
 	Attributes SystemItemAttributesExtended `json:"attributes"`
-	ID         string                       `json:"id"`
+	ID         uuid.UUID                    `json:"id"`
 	Type       string                       `json:"type"`
 }
 
 type SystemItem struct {
 	Attributes SystemItemAttributes `json:"attributes"`
-	ID         string               `json:"id"`
+	ID         uuid.UUID            `json:"id"`
 	Type       string               `json:"type"`
 }
 
@@ -189,7 +190,7 @@ type SystemsListPostRequest struct {
 
 func validateSystemsListIDs(ids []string) error {
 	for _, id := range ids {
-		if !utils.IsValidUUID(id) {
+		if _, err := uuid.Parse(id); err != nil {
 			return fmt.Errorf("'%s' is not a valid UUID", id)
 		}
 	}

--- a/manager/controllers/systems_advisories_view.go
+++ b/manager/controllers/systems_advisories_view.go
@@ -8,11 +8,12 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
 type AdvisoryName string
-type SystemID string
+type SystemID = uuid.UUID
 
 type SystemsAdvisoriesRequest struct {
 	Systems    []SystemID     `json:"systems"`
@@ -157,7 +158,7 @@ func advisoriesSystemsQuery(c *gin.Context, db *gorm.DB, acc int, groups map[str
 		Distinct(systemsAdvisoriesSelect).
 		Joins("LEFT JOIN system_advisories sa ON am.id = sa.advisory_id AND sa.rh_account_id = ? AND sa.status_id = 0", acc)
 	if len(systems) > 0 {
-		query = query.Joins(fmt.Sprintf("%s AND si.inventory_id in (?::uuid)", siJoin), systems)
+		query = query.Joins(fmt.Sprintf("%s AND si.inventory_id in (?)", siJoin), systems)
 	} else {
 		query = query.Joins(siJoin)
 	}
@@ -290,11 +291,11 @@ func PostAdvisoriesSystems(c *gin.Context) {
 	}
 
 	for _, i := range data {
-		if _, has := response.Data[i.AdvisoryID]; has && i.SystemID == "" {
+		if _, has := response.Data[i.AdvisoryID]; has && i.SystemID == uuid.Nil {
 			// don't append empty values to slices with len > 1
 			continue
 		}
-		if _, has := response.Data[i.AdvisoryID]; !has && i.SystemID == "" {
+		if _, has := response.Data[i.AdvisoryID]; !has && i.SystemID == uuid.Nil {
 			response.Data[i.AdvisoryID] = []SystemID{}
 			continue
 		}

--- a/manager/controllers/systems_advisories_view_test.go
+++ b/manager/controllers/systems_advisories_view_test.go
@@ -16,7 +16,7 @@ import (
 func doTestView(t *testing.T, handler gin.HandlerFunc, q string, limit, offset *int) *httptest.ResponseRecorder {
 	core.SetupTest(t)
 	body := SystemsAdvisoriesRequest{
-		Systems:    []SystemID{"00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"},
+		Systems:    []SystemID{testInventoryID1, testInventoryID2},
 		Advisories: []AdvisoryName{"RH-1", "RH-3"},
 		Limit:      limit,
 		Offset:     offset,
@@ -34,33 +34,33 @@ func TestSystemsAdvisoriesView(t *testing.T) {
 	w := doTestView(t, PostSystemsAdvisories, "", nil, nil)
 	var output SystemsAdvisoriesResponse
 	CheckResponse(t, w, http.StatusOK, &output)
-	assert.Equal(t, output.Data["00000000-0000-0000-0000-000000000001"][0], AdvisoryName("RH-1"))
-	assert.Equal(t, output.Data["00000000-0000-0000-0000-000000000001"][1], AdvisoryName("RH-3"))
-	assert.Equal(t, 0, len(output.Data["00000000-0000-0000-0000-000000000002"]))
+	assert.Equal(t, output.Data[testInventoryID1][0], AdvisoryName("RH-1"))
+	assert.Equal(t, output.Data[testInventoryID1][1], AdvisoryName("RH-3"))
+	assert.Equal(t, 0, len(output.Data[testInventoryID2]))
 }
 
 func TestAdvisoriesSystemsView(t *testing.T) {
 	w := doTestView(t, PostAdvisoriesSystems, "", nil, nil)
 	var output AdvisoriesSystemsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
-	assert.Equal(t, output.Data["RH-1"][0], SystemID("00000000-0000-0000-0000-000000000001"))
-	assert.Equal(t, output.Data["RH-3"][0], SystemID("00000000-0000-0000-0000-000000000001"))
+	assert.Equal(t, output.Data["RH-1"][0], testInventoryID1)
+	assert.Equal(t, output.Data["RH-3"][0], testInventoryID1)
 }
 
 func TestSystemsAdvisoriesViewTags(t *testing.T) {
 	w := doTestView(t, PostSystemsAdvisories, "?filter[system_profile][sap_sids]=DEF", nil, nil)
 	var output SystemsAdvisoriesResponse
 	CheckResponse(t, w, http.StatusOK, &output)
-	assert.Equal(t, output.Data["00000000-0000-0000-0000-000000000001"][0], AdvisoryName("RH-1"))
-	assert.Equal(t, output.Data["00000000-0000-0000-0000-000000000001"][1], AdvisoryName("RH-3"))
+	assert.Equal(t, output.Data[testInventoryID1][0], AdvisoryName("RH-1"))
+	assert.Equal(t, output.Data[testInventoryID1][1], AdvisoryName("RH-3"))
 }
 
 func TestAdvisoriesSystemsViewTags(t *testing.T) {
 	w := doTestView(t, PostAdvisoriesSystems, "?filter[system_profile][sap_sids]=DEF", nil, nil)
 	var output AdvisoriesSystemsResponse
 	CheckResponse(t, w, http.StatusOK, &output)
-	assert.Equal(t, output.Data["RH-1"][0], SystemID("00000000-0000-0000-0000-000000000001"))
-	assert.Equal(t, output.Data["RH-3"][0], SystemID("00000000-0000-0000-0000-000000000001"))
+	assert.Equal(t, output.Data["RH-1"][0], testInventoryID1)
+	assert.Equal(t, output.Data["RH-3"][0], testInventoryID1)
 }
 func TestSystemAdvisoriesViewOffsetLimit(t *testing.T) {
 	limit := 3
@@ -71,7 +71,7 @@ func TestSystemAdvisoriesViewOffsetLimit(t *testing.T) {
 	assert.Equal(t, 2, len(output.Data))
 	assert.Equal(t, limit, output.Meta.Limit)
 	assert.Equal(t, offset, output.Meta.Offset)
-	_, has := output.Data["00000000-0000-0000-0000-000000000001"]
+	_, has := output.Data[testInventoryID1]
 	assert.True(t, has)
 }
 

--- a/manager/controllers/systems_export_test.go
+++ b/manager/controllers/systems_export_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,7 +32,7 @@ func TestSystemsExportJSON(t *testing.T) {
 	var output []SystemDBLookup
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 10, len(output))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output[0].ID)
 	assert.Equal(t, 2, output[0].SystemItemAttributes.RhsaCount)
 	assert.Equal(t, 2, output[0].SystemItemAttributes.RhbaCount)
 	assert.Equal(t, 1, output[0].SystemItemAttributes.RheaCount)
@@ -90,7 +91,7 @@ func TestExportSystemsTags(t *testing.T) {
 	var output []SystemDBLookup
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 2, len(output))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output[0].ID)
 }
 
 func TestExportSystemsTagsInvalid(t *testing.T) {
@@ -111,7 +112,7 @@ func TestSystemsExportWorkloads(t *testing.T) {
 	var output []SystemDBLookup
 	CheckResponse(t, w, http.StatusOK, &output)
 	assert.Equal(t, 2, len(output))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output[0].ID)
 }
 
 func TestSystemsExportFilterPartialOS(t *testing.T) {

--- a/manager/controllers/systems_ids_test.go
+++ b/manager/controllers/systems_ids_test.go
@@ -100,28 +100,28 @@ func TestSystemsIDsFilterAdvCount1(t *testing.T) {
 	outputIDs := testSystemsIDs(t, "?filter[rhba_count]=2", 1)
 	output := testSystems(t, "?filter[rhba_count]=2", 1)
 	assert.Equal(t, 1, len(outputIDs.IDs))
-	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
+	assert.Equal(t, output.Data[0].ID.String(), outputIDs.IDs[0])
 }
 
 func TestSystemsIDsFilterAdvCount2(t *testing.T) {
 	outputIDs := testSystemsIDs(t, "?filter[rhea_count]=1", 1)
 	output := testSystems(t, "?filter[rhea_count]=1", 1)
 	assert.Equal(t, 4, len(outputIDs.IDs))
-	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
+	assert.Equal(t, output.Data[0].ID.String(), outputIDs.IDs[0])
 }
 
 func TestSystemsIDsFilterAdvCount3(t *testing.T) {
 	outputIDs := testSystemsIDs(t, "?filter[rhsa_count]=2", 1)
 	output := testSystems(t, "?filter[rhsa_count]=2", 1)
 	assert.Equal(t, 1, len(outputIDs.IDs))
-	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
+	assert.Equal(t, output.Data[0].ID.String(), outputIDs.IDs[0])
 }
 
 func TestSystemsIDsFilterAdvCount4(t *testing.T) {
 	outputIDs := testSystemsIDs(t, "?filter[other_count]=4", 1)
 	output := testSystems(t, "?filter[other_count]=4", 1)
 	assert.Equal(t, 1, len(outputIDs.IDs))
-	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
+	assert.Equal(t, output.Data[0].ID.String(), outputIDs.IDs[0])
 }
 
 func TestSystemsIDsFilterNotExisting(t *testing.T) {
@@ -134,30 +134,30 @@ func TestSystemsIDsFilterPartialOS(t *testing.T) {
 	outputIDs := testSystemsIDs(t, "?filter[osname]=RHEL&filter[osmajor]=8&filter[osminor]=1", 1)
 	output := testSystems(t, "?filter[osname]=RHEL&filter[osmajor]=8&filter[osminor]=1", 1)
 	assert.Equal(t, 3, len(outputIDs.IDs))
-	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
-	assert.Equal(t, output.Data[1].ID, outputIDs.IDs[1])
+	assert.Equal(t, output.Data[0].ID.String(), outputIDs.IDs[0])
+	assert.Equal(t, output.Data[1].ID.String(), outputIDs.IDs[1])
 }
 
 func TestSystemsIDsFilterOS(t *testing.T) {
 	outputIDs := testSystemsIDs(t, `?filter[os]=in:RHEL 8.1,RHEL 7.3&sort=os`, 1)
 	output := testSystems(t, `?filter[os]=in:RHEL 8.1,RHEL 7.3&sort=os`, 1)
 	assert.Equal(t, 4, len(outputIDs.IDs))
-	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
-	assert.Equal(t, output.Data[1].ID, outputIDs.IDs[1])
-	assert.Equal(t, output.Data[2].ID, outputIDs.IDs[2])
+	assert.Equal(t, output.Data[0].ID.String(), outputIDs.IDs[0])
+	assert.Equal(t, output.Data[1].ID.String(), outputIDs.IDs[1])
+	assert.Equal(t, output.Data[2].ID.String(), outputIDs.IDs[2])
 }
 
 func TestSystemsIDsOrderOS(t *testing.T) {
 	output := testSystems(t, `?sort=os`, 1)
 	outputIDs := testSystemsIDs(t, `?sort=os`, 1)
-	assert.Equal(t, output.Data[0].ID, outputIDs.IDs[0])
-	assert.Equal(t, output.Data[1].ID, outputIDs.IDs[1])
-	assert.Equal(t, output.Data[2].ID, outputIDs.IDs[2])
-	assert.Equal(t, output.Data[3].ID, outputIDs.IDs[3])
-	assert.Equal(t, output.Data[4].ID, outputIDs.IDs[4])
-	assert.Equal(t, output.Data[5].ID, outputIDs.IDs[5])
-	assert.Equal(t, output.Data[6].ID, outputIDs.IDs[6])
-	assert.Equal(t, output.Data[7].ID, outputIDs.IDs[7])
+	assert.Equal(t, output.Data[0].ID.String(), outputIDs.IDs[0])
+	assert.Equal(t, output.Data[1].ID.String(), outputIDs.IDs[1])
+	assert.Equal(t, output.Data[2].ID.String(), outputIDs.IDs[2])
+	assert.Equal(t, output.Data[3].ID.String(), outputIDs.IDs[3])
+	assert.Equal(t, output.Data[4].ID.String(), outputIDs.IDs[4])
+	assert.Equal(t, output.Data[5].ID.String(), outputIDs.IDs[5])
+	assert.Equal(t, output.Data[6].ID.String(), outputIDs.IDs[6])
+	assert.Equal(t, output.Data[7].ID.String(), outputIDs.IDs[7])
 }
 
 func TestSystemsIDsFilterArch(t *testing.T) {
@@ -166,7 +166,7 @@ func TestSystemsIDsFilterArch(t *testing.T) {
 	assert.Equal(t, 9, len(outputIDs.Data))
 	assert.Equal(t, 9, len(output.Data))
 	for i, d := range outputIDs.Data {
-		assert.Equal(t, output.Data[i].ID, d.ID)
+		assert.Equal(t, output.Data[i].ID.String(), d.ID)
 	}
 }
 
@@ -176,7 +176,7 @@ func TestSystemsIDsFilterTemplateName(t *testing.T) {
 	assert.Equal(t, 2, len(outputIDs.Data))
 	assert.Equal(t, 2, len(output.Data))
 	for i, d := range outputIDs.Data {
-		assert.Equal(t, output.Data[i].ID, d.ID)
+		assert.Equal(t, output.Data[i].ID.String(), d.ID)
 	}
 }
 
@@ -186,7 +186,7 @@ func TestSystemsIDsFilterTemplateUUID(t *testing.T) {
 	assert.Equal(t, 2, len(outputIDs.Data))
 	assert.Equal(t, 2, len(output.Data))
 	for i, d := range outputIDs.Data {
-		assert.Equal(t, output.Data[i].ID, d.ID)
+		assert.Equal(t, output.Data[i].ID.String(), d.ID)
 	}
 }
 

--- a/manager/controllers/systems_test.go
+++ b/manager/controllers/systems_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +20,7 @@ func TestSystemsDefault(t *testing.T) {
 
 	// data
 	assert.Equal(t, 10, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output.Data[0].ID)
 	assert.Equal(t, "system", output.Data[0].Type)
 	assert.Equal(t, "2020-09-22 16:00:00 +0000 UTC", output.Data[0].Attributes.LastUpload.String())
 	assert.Equal(t, 1, output.Data[0].Attributes.RheaCount)
@@ -84,7 +85,7 @@ func TestSystemsWrongSort(t *testing.T) {
 func TestSystemsSearch(t *testing.T) {
 	output := testSystems(t, "?search=001", 1)
 	assert.Equal(t, 3, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output.Data[0].ID)
 	assert.Equal(t, "system", output.Data[0].Type)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].Attributes.DisplayName)
 }
@@ -92,13 +93,13 @@ func TestSystemsSearch(t *testing.T) {
 func TestSystemsTags(t *testing.T) {
 	output := testSystems(t, "?tags=ns1/k2=val2", 1)
 	assert.Equal(t, 2, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output.Data[0].ID)
 }
 
 func TestSystemsTagsMultiple(t *testing.T) {
 	output := testSystems(t, "?tags=ns1/k3=val4&tags=ns1/k1=val1", 1)
 	assert.Equal(t, 1, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000003", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000003"), output.Data[0].ID)
 }
 
 func TestSystemsTagsUnknown(t *testing.T) {
@@ -109,7 +110,7 @@ func TestSystemsTagsUnknown(t *testing.T) {
 func TestSystemsTagsNoVal(t *testing.T) {
 	output := testSystems(t, "?tags=ns1/k3=val4&tags=ns1/k1", 1)
 	assert.Equal(t, 1, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000003", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000003"), output.Data[0].ID)
 }
 
 func TestSystemsTagsInvalid(t *testing.T) {
@@ -141,13 +142,13 @@ func TestSystemsTagsEscaping4(t *testing.T) {
 func TestSystemsWorkloads1(t *testing.T) {
 	output := testSystems(t, "?filter[system_profile][sap_system]=true&filter[system_profile][sap_sids]=ABC", 1)
 	assert.Equal(t, 2, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output.Data[0].ID)
 }
 
 func TestSystemsWorkloads2(t *testing.T) {
 	output := testSystems(t, sapABCFilter, 1)
 	assert.Equal(t, 2, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output.Data[0].ID)
 }
 
 func TestSystemsWorkloads3(t *testing.T) {
@@ -167,7 +168,7 @@ func TestSystemsWorkloadEscaping2(t *testing.T) {
 func TestSystemsPackagesCount(t *testing.T) {
 	output := testSystems(t, "?sort=-packages_installed,id", 3)
 	assert.Equal(t, 5, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000015", output.Data[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000015"), output.Data[0].ID)
 	assert.Equal(t, "system", output.Data[0].Type)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000015", output.Data[0].Attributes.DisplayName)
 	assert.Equal(t, 3, output.Data[0].Attributes.PackagesInstalled)
@@ -288,7 +289,7 @@ func TestSystemsPostByIDs(t *testing.T) {
 		},
 	}, "", 1)
 	assert.Equal(t, 2, len(out.Data))
-	ids := map[string]struct{}{out.Data[0].ID: {}, out.Data[1].ID: {}}
+	ids := map[string]struct{}{out.Data[0].ID.String(): {}, out.Data[1].ID.String(): {}}
 	_, ok1 := ids["00000000-0000-0000-0000-000000000001"]
 	_, ok2 := ids["00000000-0000-0000-0000-000000000002"]
 	assert.True(t, ok1 && ok2)
@@ -415,13 +416,9 @@ func TestAAPSystemMeta2(t *testing.T) {
 }
 
 func TestAAPSystemMeta3(t *testing.T) {
-	const (
-		ID         = "00000000-0000-0000-0000-000000000007"
-		totalItems = 2
-	)
 	output := testSystems(t, `?filter[system_profile][ansible][controller_version]=1.0`, 1)
-	assert.Equal(t, ID, output.Data[0].ID)
-	assert.Equal(t, totalItems, output.Meta.TotalItems)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000007"), output.Data[0].ID)
+	assert.Equal(t, 2, output.Meta.TotalItems)
 }
 
 func TestMSSQLSystemMeta(t *testing.T) {
@@ -443,11 +440,7 @@ func TestMSSQLSystemMeta2(t *testing.T) {
 }
 
 func TestMSSQLSystemMeta3(t *testing.T) {
-	const (
-		ID         = "00000000-0000-0000-0000-000000000006"
-		totalItems = 2
-	)
 	output := testSystems(t, `?filter[system_profile][mssql][version]=15.3.0`, 1)
-	assert.Equal(t, ID, output.Data[0].ID)
-	assert.Equal(t, totalItems, output.Meta.TotalItems)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000006"), output.Data[0].ID)
+	assert.Equal(t, 2, output.Meta.TotalItems)
 }

--- a/manager/controllers/template_subscribed_systems_update.go
+++ b/manager/controllers/template_subscribed_systems_update.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -40,7 +41,7 @@ func TemplateSubscribedSystemsUpdateHandler(c *gin.Context) {
 		return
 	}
 
-	systemList := []string{systemUUID}
+	systemList := []uuid.UUID{systemUUID}
 	err = checkTemplateSystems(c, db, account, template, systemList, nil)
 	if err != nil {
 		return
@@ -64,24 +65,25 @@ func TemplateSubscribedSystemsUpdateHandler(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-func getSubscribedSystem(c *gin.Context, tx *gorm.DB) (int, string, string, error) {
+func getSubscribedSystem(c *gin.Context, tx *gorm.DB) (int, string, uuid.UUID, error) {
 	account := c.GetInt(utils.KeyAccount)
 	orgID := c.GetString(utils.KeyOrgID)
 	systemCn := c.GetString(utils.KeySystem)
 
-	var inventoryID string
+	var inventoryIDStr string
 	err := tx.Select("inventory_id").
 		Table("system_inventory").
 		Where("subscription_manager_id = ? AND rh_account_id = ?", systemCn, account).
-		Limit(1).Find(&inventoryID).Error
+		Limit(1).Find(&inventoryIDStr).Error
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		utils.LogAndRespError(c, err, "database error")
-		return 0, "", "", err
+		return 0, "", uuid.Nil, err
 	}
-	if inventoryID == "" {
+	inventoryID, _ := uuid.Parse(inventoryIDStr)
+	if inventoryID == uuid.Nil {
 		err := errors.Errorf("System %s not found", systemCn)
 		utils.LogAndRespNotFound(c, err, err.Error())
-		return 0, "", "", err
+		return 0, "", uuid.Nil, err
 	}
 	return account, orgID, inventoryID, err
 }

--- a/manager/controllers/template_subscribed_systems_update_test.go
+++ b/manager/controllers/template_subscribed_systems_update_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 var subscriptionUUID = "cccccccc-0000-0000-0001-000000000004"
-var templateSystemUUID = "00000000-0000-0000-0000-000000000004"
 var subscriptionInvalidUUID = "99999999-9999-8888-8888-888888888888"
 var orgID = "org_1"
 
@@ -29,7 +29,7 @@ func TestSubscribedSystemID(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, templateAccount, account)
 	assert.Equal(t, orgID, org)
-	assert.Equal(t, templateSystemUUID, systemID)
+	assert.Equal(t, testInventoryID4, systemID)
 }
 
 func TestUnknownSubscribedSystemID(t *testing.T) {
@@ -44,7 +44,7 @@ func TestUnknownSubscribedSystemID(t *testing.T) {
 	assert.EqualError(t, err, "System cccccccc-0000-0000-0001-000000000001 not found")
 	assert.Equal(t, 0, account)
 	assert.Equal(t, "", org)
-	assert.Equal(t, "", systemID)
+	assert.Equal(t, uuid.Nil, systemID)
 }
 
 func TestUpdateTemplateSubscribedSystems(t *testing.T) {
@@ -58,7 +58,7 @@ func TestUpdateTemplateSubscribedSystems(t *testing.T) {
 		core.ContextKV{Key: utils.KeyOrgID, Value: orgID})
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	database.CheckTemplateSystems(t, templateAccount, templateUUID, []string{templateSystemUUID})
+	database.CheckTemplateSystems(t, templateAccount, templateUUID, []uuid.UUID{testInventoryID4})
 	database.DeleteTemplate(t, templateAccount, templateUUID)
 }
 
@@ -72,6 +72,6 @@ func TestUpdateTemplateSubscribedSystemsInvalid(t *testing.T) {
 		core.ContextKV{Key: utils.KeySystem, Value: subscriptionInvalidUUID})
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
-	database.CheckTemplateSystems(t, templateAccount, templateUUID, []string{})
+	database.CheckTemplateSystems(t, templateAccount, templateUUID, []uuid.UUID{})
 	database.DeleteTemplate(t, templateAccount, templateUUID)
 }

--- a/manager/controllers/template_systems.go
+++ b/manager/controllers/template_systems.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -42,7 +43,7 @@ type TemplateSystemAttributes struct {
 type TemplateSystemItem struct {
 	Attributes TemplateSystemAttributes `json:"attributes"`
 	// Template system inventory ID (uuid format)
-	InventoryID string `json:"inventory_id"`
+	InventoryID uuid.UUID `json:"inventory_id"`
 	// Document type name
 	Type string `json:"type"`
 }

--- a/manager/controllers/template_systems_delete_test.go
+++ b/manager/controllers/template_systems_delete_test.go
@@ -33,22 +33,25 @@ func TestTemplateSystemsDeleteDefault(t *testing.T) {
 
 	database.CreateTemplate(t, templateAccount, templateUUID, templateSystems)
 	template2 := "99999999-9999-8888-8888-888888888888"
-	templateSystems2 := []string{
-		"00000000-0000-0000-0000-000000000005",
+	templateSystems2 := []uuid.UUID{
+		uuid.MustParse("00000000-0000-0000-0000-000000000005"),
 	}
 	database.CreateTemplate(t, templateAccount, template2, templateSystems2)
 
 	database.CheckTemplateSystems(t, templateAccount, templateUUID, templateSystems)
 	database.CheckTemplateSystems(t, templateAccount, template2, templateSystems2)
 
+	allSystems := make([]uuid.UUID, 0, len(templateSystems)+len(templateSystems2))
+	allSystems = append(allSystems, templateSystems...)
+	allSystems = append(allSystems, templateSystems2...)
 	req := TemplateSystemsUpdateRequest{
-		Systems: append(templateSystems, templateSystems2...),
+		Systems: allSystems,
 	}
 
 	testTemplateSystemsDelete(t, req, http.StatusOK)
 
-	database.CheckTemplateSystems(t, templateAccount, templateUUID, []string{})
-	database.CheckTemplateSystems(t, templateAccount, template2, []string{})
+	database.CheckTemplateSystems(t, templateAccount, templateUUID, []uuid.UUID{})
+	database.CheckTemplateSystems(t, templateAccount, template2, []uuid.UUID{})
 	database.DeleteTemplate(t, templateAccount, templateUUID)
 	database.DeleteTemplate(t, templateAccount, template2)
 }
@@ -58,29 +61,29 @@ func TestTemplateSystemsDeleteInvalid(t *testing.T) {
 
 	for _, req := range []TemplateSystemsUpdateRequest{
 		{},
-		{Systems: []string{}}} {
+		{Systems: []uuid.UUID{}}} {
 		testTemplateSystemsDelete(t, req, http.StatusBadRequest)
 	}
 
 	testTemplateSystemsDelete(t, TemplateSystemsUpdateRequest{
-		Systems: []string{"c0ffeec0-ffee-c0ff-eec0-ffeec0ffee00"}}, http.StatusNotFound)
+		Systems: []uuid.UUID{uuid.MustParse("c0ffeec0-ffee-c0ff-eec0-ffeec0ffee00")}}, http.StatusNotFound)
 }
 
 func TestTemplateSystemsDeleteTooManySystems(t *testing.T) {
 	core.SetupTest(t)
 
-	systems := make([]string, 0, TemplateSystemsUpdateLimit+1)
+	systems := make([]uuid.UUID, 0, TemplateSystemsUpdateLimit+1)
 	for i := 0; i < TemplateSystemsUpdateLimit; i++ {
-		systems = append(systems, uuid.NewString())
+		systems = append(systems, uuid.New())
 	}
 
 	database.CreateTemplate(t, templateAccount, templateUUID, systems)
 	defer database.DeleteTemplate(t, templateAccount, templateUUID)
 
 	// Add one more system to the template so we can try to delete more than the limit
-	additionalSystem := "00000000-0000-0000-0000-000000000004"
+	additionalSystem := uuid.MustParse("00000000-0000-0000-0000-000000000004")
 	putBody := TemplateSystemsUpdateRequest{
-		Systems: []string{additionalSystem},
+		Systems: []uuid.UUID{additionalSystem},
 	}
 
 	putBodyJSON, err := sonic.Marshal(&putBody)

--- a/manager/controllers/template_systems_export_test.go
+++ b/manager/controllers/template_systems_export_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,7 +28,7 @@ func TestTemplateSystemsExportJSON(t *testing.T) {
 	assert.Equal(t, 2, len(output))
 
 	// Export uses the same default sort as the list API (-display_name), so UUID ...002 sorts before ...001.
-	assert.Equal(t, "00000000-0000-0000-0000-000000000002", output[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000002"), output[0].ID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000002", output[0].DisplayName)
 	assert.Equal(t, "RHEL 8.1", output[0].OS)
 	assert.Equal(t, "8.1", output[0].Rhsm)
@@ -39,7 +40,7 @@ func TestTemplateSystemsExportJSON(t *testing.T) {
 	assert.Equal(t, 0, output[0].ApplicableRhbaCount)
 	assert.Equal(t, 1, output[0].ApplicableRheaCount)
 	assert.Equal(t, 0, output[0].ApplicableOtherCount)
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output[1].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output[1].ID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output[1].DisplayName)
 	assert.Equal(t, "RHEL 8.10", output[1].OS)
 	assert.Equal(t, "8.10", output[1].Rhsm)
@@ -109,7 +110,7 @@ func TestExportTemplateSystemsTags(t *testing.T) {
 	CheckResponse(t, w, http.StatusOK, &output)
 
 	assert.Equal(t, 2, len(output))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000002", output[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000002"), output[0].ID)
 }
 
 func TestExportTemplateSystemsTagsInvalid(t *testing.T) {
@@ -132,5 +133,5 @@ func TestTemplateSystemsExportWorkloads(t *testing.T) {
 	CheckResponse(t, w, http.StatusOK, &output)
 
 	assert.Equal(t, 2, len(output))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000002", output[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000002"), output[0].ID)
 }

--- a/manager/controllers/template_systems_test.go
+++ b/manager/controllers/template_systems_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,9 +26,9 @@ func TestTemplateSystemsDefault(t *testing.T) {
 
 	assert.Equal(t, 2, len(output.Data))
 	assert.Equal(t, "template_system", output.Data[0].Type)
-	assert.Equal(t, "00000000-0000-0000-0000-000000000002", output.Data[0].InventoryID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000002"), output.Data[0].InventoryID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000002", output.Data[0].Attributes.DisplayName)
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[1].InventoryID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output.Data[1].InventoryID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[1].Attributes.DisplayName)
 
 	// links
@@ -89,7 +90,7 @@ func TestTemplatesFilterDisplayName(t *testing.T) {
 	output := testTemplateSystems(t, "99900000-0000-0000-0000-000000000001",
 		"?filter[display_name]=00000000-0000-0000-0000-000000000001")
 	assert.Equal(t, 1, len(output.Data))
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].InventoryID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output.Data[0].InventoryID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].Attributes.DisplayName)
 }
 
@@ -111,7 +112,7 @@ func TestTemplateSystemsSearch(t *testing.T) {
 		"?search=00000000-0000-0000-0000-000000000001")
 	assert.Equal(t, 1, len(output.Data))
 	assert.Equal(t, "template_system", output.Data[0].Type)
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].InventoryID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), output.Data[0].InventoryID)
 	assert.Equal(t, "00000000-0000-0000-0000-000000000001", output.Data[0].Attributes.DisplayName)
 
 	// links

--- a/manager/controllers/template_systems_update.go
+++ b/manager/controllers/template_systems_update.go
@@ -9,6 +9,7 @@ import (
 	"app/manager/config"
 	"app/manager/kafka"
 	"app/manager/middlewares"
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -16,10 +17,10 @@ import (
 
 	errors2 "errors"
 
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-
-	"github.com/gin-gonic/gin"
 )
 
 var candlepinClient = candlepin.CreateCandlepinClient()
@@ -29,13 +30,13 @@ const TemplateSystemsUpdateLimit = 1000
 
 type TemplateSystemsUpdateRequest struct {
 	// List of inventory IDs to have templates removed
-	Systems []string `json:"systems" example:"system1-uuid, system2-uuid, ..."`
+	Systems []uuid.UUID `json:"systems" example:"system1-uuid, system2-uuid, ..."`
 }
 
 type SystemTemplateDBLookup struct {
-	InventoryID      string `query:"si.inventory_id"`
-	SatelliteManaged bool   `query:"si.satellite_managed"`
-	Bootc            bool   `query:"si.bootc"`
+	InventoryID      uuid.UUID `query:"si.inventory_id"`
+	SatelliteManaged bool      `query:"si.satellite_managed"`
+	Bootc            bool      `query:"si.bootc"`
 }
 
 // @Summary Add systems to a template
@@ -98,7 +99,7 @@ func TemplateSystemsUpdateHandler(c *gin.Context) {
 }
 
 func checkTemplateSystems(c *gin.Context, db *gorm.DB, accountID int, template *models.Template,
-	inventoryIDs []string, groups map[string]string) error {
+	inventoryIDs []uuid.UUID, groups map[string]string) error {
 	if len(inventoryIDs) == 0 {
 		err := errors.New(InvalidInventoryIDsErr)
 		utils.LogAndRespBadRequest(c, err, InvalidInventoryIDsErr)
@@ -130,7 +131,7 @@ func checkTemplateSystems(c *gin.Context, db *gorm.DB, accountID int, template *
 }
 
 func assignTemplateSystems(c *gin.Context, db *gorm.DB, accountID int, template *models.Template,
-	inventoryIDs []string) error {
+	inventoryIDs []uuid.UUID) error {
 	tx := db.Begin()
 	defer tx.Rollback()
 
@@ -142,7 +143,7 @@ func assignTemplateSystems(c *gin.Context, db *gorm.DB, accountID int, template 
 
 	siSub := tx.Model(&models.SystemInventory{}).
 		Select("id").
-		Where("rh_account_id = ? AND inventory_id IN (?::uuid)", accountID, inventoryIDs)
+		Where("rh_account_id = ? AND inventory_id IN (?)", accountID, inventoryIDs)
 	tx = tx.Model(&models.SystemPatch{}).
 		Where("rh_account_id = ? AND system_id IN (?)", accountID, siSub).
 		Update("template_id", templateID)
@@ -165,16 +166,16 @@ func assignTemplateSystems(c *gin.Context, db *gorm.DB, accountID int, template 
 }
 
 func templateArchVersionMatch(
-	db *gorm.DB, inventoryIDs []string, template *models.Template, acc int, groups map[string]string,
+	db *gorm.DB, inventoryIDs []uuid.UUID, template *models.Template, acc int, groups map[string]string,
 ) error {
 	if template == nil {
 		return nil
 	}
-	var sysArchVersions = []struct {
-		InventoryID string
+	var sysArchVersions []struct {
+		InventoryID uuid.UUID
 		Arch        string
 		Version     string
-	}{}
+	}
 	var err error
 	err = database.Systems(db, acc, groups).
 		Select("si.inventory_id as inventory_id, si.os_major as version, si.arch as arch").
@@ -220,12 +221,12 @@ func callCandlepin(ctx context.Context, owner string, request *candlepin.Consume
 	return candlepinRespPtr.(*candlepin.ConsumersUpdateResponse), nil
 }
 
-func assignCandlepinEnvironment(c *gin.Context, db *gorm.DB, accountID int, env *string, inventoryIDs []string,
+func assignCandlepinEnvironment(c *gin.Context, db *gorm.DB, accountID int, env *string, inventoryIDs []uuid.UUID,
 	groups map[string]string) error {
-	var hosts = []struct {
-		InventoryID string
+	var hosts []struct {
+		InventoryID uuid.UUID
 		Consumer    *string
-	}{}
+	}
 
 	err := database.Systems(db, accountID, groups).
 		Select("si.inventory_id as inventory_id, si.subscription_manager_id as consumer").
@@ -271,20 +272,20 @@ func assignCandlepinEnvironment(c *gin.Context, db *gorm.DB, accountID int, env 
 	return nil
 }
 
-func checkInventoryIDs(db *gorm.DB, accountID int, inventoryIDs []string, groups map[string]string) (err error) {
+func checkInventoryIDs(db *gorm.DB, accountID int, inventoryIDs []uuid.UUID, groups map[string]string) (err error) {
 	var containingSystems []SystemTemplateDBLookup
-	var missingIDs []string
-	var satelliteIDs []string
-	var bootcIDs []string
+	var missingIDs []uuid.UUID
+	var satelliteIDs []uuid.UUID
+	var bootcIDs []uuid.UUID
 	err = database.Systems(db, accountID, groups).
 		Select("si.inventory_id, si.satellite_managed, si.bootc").
-		Where("si.inventory_id IN (?::uuid)", inventoryIDs).
+		Where("si.inventory_id IN (?)", inventoryIDs).
 		Scan(&containingSystems).Error
 	if err != nil {
 		return errors2.Join(base.ErrDatabase, err)
 	}
 
-	containingIDsMap := make(map[string]bool, len(containingSystems))
+	containingIDsMap := make(map[uuid.UUID]bool, len(containingSystems))
 	for _, containingSystem := range containingSystems {
 		containingIDsMap[containingSystem.InventoryID] = true
 
@@ -302,9 +303,9 @@ func checkInventoryIDs(db *gorm.DB, accountID int, inventoryIDs []string, groups
 		}
 	}
 
-	sort.Strings(missingIDs)
-	sort.Strings(satelliteIDs)
-	sort.Strings(bootcIDs)
+	sort.Slice(missingIDs, func(i, j int) bool { return bytes.Compare(missingIDs[i][:], missingIDs[j][:]) < 0 })
+	sort.Slice(satelliteIDs, func(i, j int) bool { return bytes.Compare(satelliteIDs[i][:], satelliteIDs[j][:]) < 0 })
+	sort.Slice(bootcIDs, func(i, j int) bool { return bytes.Compare(bootcIDs[i][:], bootcIDs[j][:]) < 0 })
 
 	switch {
 	case config.EnableSatelliteFunctionality && len(satelliteIDs) > 0:

--- a/manager/controllers/template_systems_update_test.go
+++ b/manager/controllers/template_systems_update_test.go
@@ -18,10 +18,10 @@ import (
 var templateUUID = "11111111-2222-3333-4444-555555555555"
 var templatePath = "/:template_id/systems"
 var templateAccount = 1
-var templateSystems = []string{
-	"00000000-0000-0000-0000-000000000004",
-	"00000000-0000-0000-0000-000000000007",
-	"00000000-0000-0000-0000-000000000008",
+var templateSystems = []uuid.UUID{
+	uuid.MustParse("00000000-0000-0000-0000-000000000004"),
+	uuid.MustParse("00000000-0000-0000-0000-000000000007"),
+	uuid.MustParse("00000000-0000-0000-0000-000000000008"),
 }
 
 func TestUpdateTemplateSystems(t *testing.T) {
@@ -33,8 +33,8 @@ func TestUpdateTemplateSystems(t *testing.T) {
 		]
 	}`
 
-	database.CreateTemplate(t, templateAccount, templateUUID, []string{
-		"00000000-0000-0000-0000-000000000007",
+	database.CreateTemplate(t, templateAccount, templateUUID, []uuid.UUID{
+		uuid.MustParse("00000000-0000-0000-0000-000000000007"),
 	})
 	w := CreateRequestRouterWithParams("PUT", templatePath, templateUUID, "", bytes.NewBufferString(data), "",
 		TemplateSystemsUpdateHandler, templateAccount)
@@ -52,8 +52,8 @@ func TestUpdateTemplateInvalidVersion(t *testing.T) {
 		]
 	}`
 
-	database.CreateTemplate(t, templateAccount, templateUUID, []string{
-		"00000000-0000-0000-0000-000000000007",
+	database.CreateTemplate(t, templateAccount, templateUUID, []uuid.UUID{
+		uuid.MustParse("00000000-0000-0000-0000-000000000007"),
 	})
 	w := CreateRequestRouterWithParams("PUT", templatePath, templateUUID, "", bytes.NewBufferString(data), "",
 		TemplateSystemsUpdateHandler, templateAccount)
@@ -77,7 +77,7 @@ func TestUpdateTemplateInvalidSystem(t *testing.T) {
 			"00000000-0000-0000-0000-000000000009"
 		]
 	}`
-	database.CreateTemplate(t, templateAccount, templateUUID, []string{})
+	database.CreateTemplate(t, templateAccount, templateUUID, []uuid.UUID{})
 	w := CreateRequestRouterWithParams("PUT", templatePath, templateUUID, "", bytes.NewBufferString(data), "",
 		TemplateSystemsUpdateHandler, templateAccount)
 
@@ -100,7 +100,7 @@ func TestUpdateTemplateSystemNotInCandlepin(t *testing.T) {
 			"00000000-0000-0000-0000-000000000003"
 		]
 	}`
-	database.CreateTemplate(t, templateAccount, templateUUID, []string{})
+	database.CreateTemplate(t, templateAccount, templateUUID, []uuid.UUID{})
 	w := CreateRequestRouterWithParams("PUT", templatePath, templateUUID, "", bytes.NewBufferString(data), "",
 		TemplateSystemsUpdateHandler, templateAccount)
 
@@ -142,7 +142,7 @@ func TestReassignTemplateSystems2(t *testing.T) {
 
 	template2 := "99999999-9999-8888-8888-888888888888"
 	database.CreateTemplate(t, templateAccount, templateUUID, templateSystems)
-	database.CreateTemplate(t, templateAccount, template2, []string{})
+	database.CreateTemplate(t, templateAccount, template2, []uuid.UUID{})
 
 	// Reassigning inventory IDs of another templates is allowed
 	data := `{
@@ -156,13 +156,13 @@ func TestReassignTemplateSystems2(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	database.CheckTemplateSystems(t, templateAccount, template2, []string{
-		"00000000-0000-0000-0000-000000000004",
-		"00000000-0000-0000-0000-000000000005",
+	database.CheckTemplateSystems(t, templateAccount, template2, []uuid.UUID{
+		uuid.MustParse("00000000-0000-0000-0000-000000000004"),
+		uuid.MustParse("00000000-0000-0000-0000-000000000005"),
 	})
-	database.CheckTemplateSystems(t, templateAccount, templateUUID, []string{
-		"00000000-0000-0000-0000-000000000007",
-		"00000000-0000-0000-0000-000000000008",
+	database.CheckTemplateSystems(t, templateAccount, templateUUID, []uuid.UUID{
+		uuid.MustParse("00000000-0000-0000-0000-000000000007"),
+		uuid.MustParse("00000000-0000-0000-0000-000000000008"),
 	})
 	database.DeleteTemplate(t, templateAccount, templateUUID)
 	database.DeleteTemplate(t, templateAccount, template2)
@@ -175,7 +175,7 @@ func testUpdateTemplateBadRequest(t *testing.T, satelliteManaged, bootc bool) {
 	defer database.DeleteTemplate(t, templateAccount, templateUUID)
 
 	inv := models.SystemInventory{
-		InventoryID:      "99999999-0000-0000-0000-000000000015",
+		InventoryID:      uuid.MustParse("99999999-0000-0000-0000-000000000015"),
 		RhAccountID:      templateAccount,
 		DisplayName:      "template_bad_request_test",
 		Tags:             []byte("[]"),
@@ -234,15 +234,16 @@ func TestUpdateTemplateSystemsCandlepin404(t *testing.T) {
 		]
 	}`
 
-	database.CreateTemplate(t, templateAccount, templateUUID, []string{
-		"00000000-0000-0000-0000-000000000007",
+	database.CreateTemplate(t, templateAccount, templateUUID, []uuid.UUID{
+		uuid.MustParse("00000000-0000-0000-0000-000000000007"),
 	})
 	defer database.DeleteTemplate(t, templateAccount, templateUUID)
 	w := CreateRequestRouterWithParams("PUT", templatePath, templateUUID, "", bytes.NewBufferString(data), "",
 		TemplateSystemsUpdateHandler, templateAccount, core.ContextKV{Key: utils.KeyOrgID, Value: orgID})
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	database.CheckTemplateSystems(t, templateAccount, templateUUID, []string{"00000000-0000-0000-0000-000000000007"})
+	database.CheckTemplateSystems(t, templateAccount, templateUUID,
+		[]uuid.UUID{uuid.MustParse("00000000-0000-0000-0000-000000000007")})
 
 	// Expect HTTP 400 status code even when only 1 system causes candlepin call error
 	data = `{
@@ -256,7 +257,7 @@ func TestUpdateTemplateSystemsCandlepin404(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	database.CheckTemplateSystems(t, templateAccount, templateUUID,
-		[]string{"00000000-0000-0000-0000-000000000007"})
+		[]uuid.UUID{uuid.MustParse("00000000-0000-0000-0000-000000000007")})
 }
 
 func TestUpdateTemplateTooManySystems(t *testing.T) {

--- a/manager/controllers/test_utils.go
+++ b/manager/controllers/test_utils.go
@@ -10,10 +10,17 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 const InvalidContentTypeErr = `{"error":"Invalid content type 'test-format', use 'application/json' or 'text/csv'"}`
+
+var (
+	testInventoryID1 = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	testInventoryID2 = uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	testInventoryID4 = uuid.MustParse("00000000-0000-0000-0000-000000000004")
+)
 
 func ParseResponseBody(t *testing.T, bytes []byte, out interface{}) {
 	// don't use sonic.Unmarshal as some tests receive empty output

--- a/manager/controllers/utils.go
+++ b/manager/controllers/utils.go
@@ -520,8 +520,8 @@ func systemsIDs(c *gin.Context, systems []SystemsID, meta *ListMeta) (IDsPlainRe
 	resp.IDs = make([]string, 0, len(systems))
 	resp.Data = make([]IDPlain, 0, len(systems))
 	for _, x := range systems {
-		resp.IDs = append(resp.IDs, x.ID)
-		resp.Data = append(resp.Data, IDPlain{ID: x.ID})
+		resp.IDs = append(resp.IDs, x.ID.String())
+		resp.Data = append(resp.Data, IDPlain{ID: x.ID.String()})
 	}
 	return resp, nil
 }
@@ -544,8 +544,8 @@ func systemsSatelliteIDs(c *gin.Context, systems []SystemsSatelliteManagedID, me
 	ids := make([]string, len(systems))
 	data := make([]IDSatelliteManaged, len(systems))
 	for i, x := range systems {
-		ids[i] = x.ID
-		data[i] = IDSatelliteManaged{x.ID, x.SatelliteManaged}
+		ids[i] = x.ID.String()
+		data[i] = IDSatelliteManaged{x.ID.String(), x.SatelliteManaged}
 	}
 	resp.IDs = ids
 	resp.Data = data

--- a/manager/controllers/utils_test.go
+++ b/manager/controllers/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 )
@@ -32,8 +33,8 @@ func TestGroupNameFilter(t *testing.T) {
 	tx.Scan(&systems)
 
 	assert.Equal(t, 2, len(systems)) // 2 systems with `group2` in test_data
-	assert.Equal(t, "00000000-0000-0000-0000-000000000007", systems[0].ID)
-	assert.Equal(t, "00000000-0000-0000-0000-000000000008", systems[1].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000007"), systems[0].ID)
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000008"), systems[1].ID)
 }
 
 func TestGroupNameFilter2(t *testing.T) {

--- a/manager/kafka/kafka.go
+++ b/manager/kafka/kafka.go
@@ -4,6 +4,8 @@ import (
 	"app/base"
 	"app/base/mqueue"
 	"app/base/utils"
+
+	"github.com/google/uuid"
 )
 
 var (
@@ -29,7 +31,7 @@ func runRecalcLoop() {
 	}
 }
 
-func InventoryIDs2EvalData(accountID int, orgID string, inventoryIDs []string) []mqueue.EvalData {
+func InventoryIDs2EvalData(accountID int, orgID string, inventoryIDs []uuid.UUID) []mqueue.EvalData {
 	evalDataList := make([]mqueue.EvalData, 0, len(inventoryIDs))
 	for _, v := range inventoryIDs {
 		evalDataList = append(evalDataList, mqueue.EvalData{InventoryID: v, RhAccountID: accountID, OrgID: &orgID})

--- a/manager/kafka/kafka_test.go
+++ b/manager/kafka/kafka_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
-func testRecalcSystems(t *testing.T, accountID int, orgID string, inventoryIDs []string) mqueue.PlatformEvent {
+func testRecalcSystems(t *testing.T, accountID int, orgID string, inventoryIDs []uuid.UUID) mqueue.PlatformEvent {
 	utils.SkipWithoutDB(t)
 	core.SetupTestEnvironment()
 	config.EnableTemplateChangeEval = true
@@ -30,10 +31,13 @@ func testRecalcSystems(t *testing.T, accountID int, orgID string, inventoryIDs [
 
 // Evaluate updated systems
 func TestRecalcUpdatedSystems(t *testing.T) {
-	inventoryIDs := []string{"00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000004"}
+	inventoryIDs := []uuid.UUID{
+		uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		uuid.MustParse("00000000-0000-0000-0000-000000000004"),
+	}
 	event := testRecalcSystems(t, 1, "org_1", inventoryIDs)
 	assert.Equal(t, 2, len(event.SystemIDs))
 	assert.Equal(t, 1, event.AccountID)
-	assert.Equal(t, "00000000-0000-0000-0000-000000000001", event.SystemIDs[0])
-	assert.Equal(t, "00000000-0000-0000-0000-000000000004", event.SystemIDs[1])
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000001"), event.SystemIDs[0])
+	assert.Equal(t, uuid.MustParse("00000000-0000-0000-0000-000000000004"), event.SystemIDs[1])
 }

--- a/manager/middlewares/kessel.go
+++ b/manager/middlewares/kessel.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"google.golang.org/grpc"
@@ -42,9 +43,12 @@ func processWorkspaces(workspaces []*kesselv2.StreamedListObjectsResponse) (map[
 
 	groups := make([]string, 0, len(workspaces))
 	for _, workspace := range workspaces {
-		group, err := utils.ParseInventoryGroup(&workspace.Object.ResourceId, nil)
+		id, err := uuid.Parse(workspace.Object.ResourceId)
 		if err != nil {
-			// couldn't marshal inventory group to json
+			continue
+		}
+		group, err := utils.ParseInventoryGroup(&id, nil)
+		if err != nil {
 			continue
 		}
 		groups = append(groups, group)

--- a/manager/middlewares/kessel_test.go
+++ b/manager/middlewares/kessel_test.go
@@ -67,10 +67,14 @@ func TestSetupClient(t *testing.T) {
 }
 
 func TestProcessWorkspaces(t *testing.T) {
-	expected := fmt.Sprintf("{%s,%s}", strconv.Quote(`[{"id":"test-1"}]`), strconv.Quote(`[{"id":"test-2"}]`))
+	id1 := "aaaaaaaa-0000-0000-0000-000000000001"
+	id2 := "bbbbbbbb-0000-0000-0000-000000000002"
+	expected := fmt.Sprintf("{%s,%s}",
+		strconv.Quote(fmt.Sprintf(`[{"id":"%s"}]`, id1)),
+		strconv.Quote(fmt.Sprintf(`[{"id":"%s"}]`, id2)))
 	workspaces := []*kesselv2.StreamedListObjectsResponse{
-		{Object: &kesselv2.ResourceReference{ResourceId: "test-1"}},
-		{Object: &kesselv2.ResourceReference{ResourceId: "test-2"}},
+		{Object: &kesselv2.ResourceReference{ResourceId: id1}},
+		{Object: &kesselv2.ResourceReference{ResourceId: id2}},
 	}
 	processed, err := processWorkspaces(workspaces)
 	if assert.NoError(t, err) {

--- a/manager/middlewares/rbac.go
+++ b/manager/middlewares/rbac.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 )
@@ -134,6 +135,7 @@ func isAccessGranted(c *gin.Context) bool {
 	return granted
 }
 
+// nolint: gocognit
 func findInventoryGroups(access *rbac.AccessPagination) (map[string]string, error) {
 	res := make(map[string]string)
 
@@ -171,9 +173,12 @@ func findInventoryGroups(access *rbac.AccessPagination) (map[string]string, erro
 					res[utils.KeyUngrouped] = "[]"
 					continue
 				}
-				group, err := utils.ParseInventoryGroup(v, nil)
+				id, err := uuid.Parse(*v)
 				if err != nil {
-					// couldn't marshal inventory group to json
+					continue
+				}
+				group, err := utils.ParseInventoryGroup(&id, nil)
+				if err != nil {
 					continue
 				}
 				groups = append(groups, group)

--- a/tasks/system_culling/system_culling.go
+++ b/tasks/system_culling/system_culling.go
@@ -6,6 +6,7 @@ import (
 	"app/tasks"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -48,7 +49,7 @@ func runSystemCulling() {
 
 // systems are deleted in independent transactions to avoid locking multiple rows for long time
 func deleteCulledSystems(tx *gorm.DB, limitDeleted int) (nDeleted int64, err error) {
-	var inventoryIDs []string
+	var inventoryIDs []uuid.UUID
 	err = tx.Model(&models.SystemInventory{}).
 		Where("culled_timestamp < ?", time.Now()).
 		Order("id").
@@ -61,7 +62,7 @@ func deleteCulledSystems(tx *gorm.DB, limitDeleted int) (nDeleted int64, err err
 	for _, id := range inventoryIDs {
 		var rowsAffected int64
 		delErr := tasks.CancelableDB().Transaction(func(tx2 *gorm.DB) error {
-			res := tx2.Exec("select delete_system(?::uuid)", id)
+			res := tx2.Exec("select delete_system(?)", id)
 			if res.Error != nil {
 				return res.Error
 			}

--- a/tasks/system_culling/system_culling_test.go
+++ b/tasks/system_culling/system_culling_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 )
@@ -172,7 +173,7 @@ func TestCullSystems(t *testing.T) {
 	for i := 0; i < nToDelete; i++ {
 		invID := fmt.Sprintf("00000000-0000-0000-0000-000000000de%d", i+1)
 		inv := models.SystemInventory{
-			InventoryID:     invID,
+			InventoryID:     uuid.MustParse(invID),
 			RhAccountID:     1,
 			DisplayName:     invID,
 			Tags:            []byte("[]"),
@@ -213,12 +214,12 @@ func TestPruneDeletedSystems(t *testing.T) {
 	for i := 0; i < nToDelete; i++ {
 		invID := fmt.Sprintf("00000000-0000-0000-0000-000000000de%d", i+1)
 		assert.NoError(t, database.DB.Create(&models.DeletedSystem{
-			InventoryID: invID,
+			InventoryID: uuid.MustParse(invID),
 			WhenDeleted: staleDate,
 		}).Error)
 	}
 	assert.NoError(t, database.DB.Create(&models.DeletedSystem{
-		InventoryID: "00000000-0000-0000-0000-000000000deff",
+		InventoryID: uuid.MustParse("00000000-0000-0000-0000-0000000000de"),
 		WhenDeleted: time.Now(),
 	}).Error)
 

--- a/tasks/vmaas_sync/repo_based_test.go
+++ b/tasks/vmaas_sync/repo_based_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,9 +25,9 @@ func TestGetCurrentRepoBasedInventoryIDs(t *testing.T) {
 	inventoryAIDs, err := getCurrentRepoBasedInventoryIDs()
 	assert.Nil(t, err)
 	assert.Equal(t, []mqueue.EvalData{
-		{InventoryID: "00000000-0000-0000-0000-000000000002", RhAccountID: 1, OrgID: &orgID1},
-		{InventoryID: "00000000-0000-0000-0000-000000000003", RhAccountID: 1, OrgID: &orgID1},
-		{InventoryID: "00000000-0000-0000-0000-000000000017", RhAccountID: 1, OrgID: &orgID1}},
+		{InventoryID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), RhAccountID: 1, OrgID: &orgID1},
+		{InventoryID: uuid.MustParse("00000000-0000-0000-0000-000000000003"), RhAccountID: 1, OrgID: &orgID1},
+		{InventoryID: uuid.MustParse("00000000-0000-0000-0000-000000000017"), RhAccountID: 1, OrgID: &orgID1}},
 		inventoryAIDs)
 	resetLastEvalTimestamp(t)
 }
@@ -51,13 +52,13 @@ func TestGetAllInventoryIDs(t *testing.T) {
 		if inventoryAIDs[i].RhAccountID != inventoryAIDs[j].RhAccountID {
 			return inventoryAIDs[i].RhAccountID < inventoryAIDs[j].RhAccountID
 		}
-		return inventoryAIDs[i].InventoryID < inventoryAIDs[j].InventoryID
+		return inventoryAIDs[i].InventoryID.String() < inventoryAIDs[j].InventoryID.String()
 	})
 	sort.Slice(systems, func(i, j int) bool {
 		if systems[i].RhAccountID != systems[j].RhAccountID {
 			return systems[i].RhAccountID < systems[j].RhAccountID
 		}
-		return systems[i].InventoryID < systems[j].InventoryID
+		return systems[i].InventoryID.String() < systems[j].InventoryID.String()
 	})
 
 	for i, inv := range inventoryAIDs {
@@ -113,9 +114,9 @@ func TestGetRepoPackageBasedInventoryIDs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, []mqueue.EvalData{
 		// "kernel" in "repo2"
-		{InventoryID: "00000000-0000-0000-0000-000000000002", RhAccountID: 1, OrgID: &orgID1},
-		{InventoryID: "00000000-0000-0000-0000-000000000003", RhAccountID: 1, OrgID: &orgID1},
-		{InventoryID: "00000000-0000-0000-0000-000000000017", RhAccountID: 1, OrgID: &orgID1},
+		{InventoryID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), RhAccountID: 1, OrgID: &orgID1},
+		{InventoryID: uuid.MustParse("00000000-0000-0000-0000-000000000003"), RhAccountID: 1, OrgID: &orgID1},
+		{InventoryID: uuid.MustParse("00000000-0000-0000-0000-000000000017"), RhAccountID: 1, OrgID: &orgID1},
 	}, inventoryAIDs)
 
 	repos = []string{"not_installed_pkg"}

--- a/turnpike/controllers/admin.go
+++ b/turnpike/controllers/admin.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 // @Summary Sync data from VMaaS
@@ -212,26 +213,22 @@ func CleanAADHandler(c *gin.Context) {
 // @Failure 500 {object}	string
 // @Router /systems/{inventory_id} [delete]
 func SystemDeleteHandler(c *gin.Context) {
-	inventoryID := c.Param("inventory_id")
-	if inventoryID == "" {
-		c.JSON(http.StatusBadRequest, utils.ErrorResponse{Error: "inventory_id param not found"})
+	inventoryID, err := uuid.Parse(c.Param("inventory_id"))
+	if err != nil {
+		// catches both empty and malformed inventory_id errors
+		utils.LogAndRespBadRequest(c, err, "incorrect inventory_id format")
 		return
 	}
 
-	if !utils.IsValidUUID(inventoryID) {
-		utils.LogAndRespBadRequest(c, errors.New("bad request"), "incorrect inventory_id format")
-		return
-	}
-
-	var systemInventoryID []string
+	var systemInventoryID []uuid.UUID
 	db := middlewares.DBFromContext(c)
 	tx := db.Begin()
 
 	defer tx.Rollback()
 
-	err := tx.Set("gorm:query_option", "FOR UPDATE OF system_inventory").
+	err = tx.Set("gorm:query_option", "FOR UPDATE OF system_inventory").
 		Table("system_inventory").
-		Where("inventory_id = ?::uuid", inventoryID).
+		Where("inventory_id = ?", inventoryID).
 		Pluck("inventory_id", &systemInventoryID).Error
 
 	if err != nil {
@@ -244,7 +241,7 @@ func SystemDeleteHandler(c *gin.Context) {
 		return
 	}
 
-	query := tx.Exec("select delete_system(?::uuid)", systemInventoryID[0])
+	query := tx.Exec("select delete_system(?)", systemInventoryID[0])
 	if err := query.Error; err != nil {
 		utils.LogAndRespError(c, err, "Could not delete system")
 		return

--- a/turnpike/controllers/admin_test.go
+++ b/turnpike/controllers/admin_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +20,7 @@ func TestInitDelete(t *testing.T) {
 	core.SetupTest(t)
 
 	inv := models.SystemInventory{
-		InventoryID: del,
+		InventoryID: uuid.MustParse(del),
 		RhAccountID: 1,
 		DisplayName: del,
 		Tags:        []byte("[]"),


### PR DESCRIPTION
## Summary

Replace string inventory IDs with `uuid.UUID` across the entire backend, starting from the listener entry point (Host model) through internal models, evaluator, manager controllers, and middleware (RBAC/Kessel)

Ticket: https://redhat.atlassian.net/browse/RHINENG-26450

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Switch inventory and system identifier handling from strings to uuid.UUID across models, message payloads, controllers, and background tasks.

Enhancements:
- Update core data models and helpers to store inventory IDs as uuid.UUID instead of strings.
- Adjust HTTP handlers, middleware, and query builders to accept, validate, and query UUID-typed inventory IDs directly.
- Align Kafka/mqueue platform events, notifications, and remediations payloads to carry UUID inventory IDs consistently.
- Refactor RBAC, workspace/group parsing, and template/system advisory views to operate on UUID IDs while preserving existing response formats via string conversion.
- Update listener, evaluator, and task logic (uploads, deletes, culling, repo-based sync) to work with UUID IDs and remove ::uuid casting from SQL where possible.
- Adapt tests and test utilities throughout the codebase to the new UUID-based inventory ID types.

## Summary by Sourcery

Switch inventory/system identifiers across backend services from strings to uuid.UUID, updating models, queries, handlers, and tests while preserving external string-based representations where required.

Enhancements:
- Store inventory IDs as uuid.UUID in core data models and propagate the type change through evaluators, listeners, controllers, notification/remediation payloads, and background tasks.
- Simplify SQL by removing explicit ::uuid casts and using typed UUID parameters in queries and helper utilities.
- Tighten validation and parsing of inventory IDs and workspace/group identifiers by using uuid.Parse and uuid.UUID-aware helpers.
- Adjust test fixtures and expectations to work with UUID-typed IDs, including sorting, comparison, and serialization logic.