### PR TITLE
feat: AdvisoryUpdateEvent supports multiple workspace IDs

### DIFF
--- a/base/mqueue/advisory_update_event.go
+++ b/base/mqueue/advisory_update_event.go
@@ -5,15 +5,14 @@ import (
 	"context"
 
 	"github.com/bytedance/sonic"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
 type AdvisoryUpdateEvent struct {
-	RhAccountID int                    `json:"rh_account_id"`
-	WorkspaceID uuid.UUID              `json:"workspace_id"`
-	AdvisoryIDs []int64                `json:"advisory_ids"`
-	ProducedAt  types.Rfc3339Timestamp `json:"produced_at"`
+	RhAccountID  int                    `json:"rh_account_id"`
+	WorkspaceIDs []string               `json:"workspace_ids"`
+	AdvisoryIDs  []int64                `json:"advisory_ids"`
+	ProducedAt   types.Rfc3339Timestamp `json:"produced_at"`
 }
 
 type AdvisoryUpdateEvents []AdvisoryUpdateEvent

--- a/base/mqueue/advisory_update_event_test.go
+++ b/base/mqueue/advisory_update_event_test.go
@@ -7,21 +7,20 @@ import (
 	"time"
 
 	"github.com/bytedance/sonic"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	testWorkspaceID = uuid.New()
-	testNow         = types.Rfc3339Timestamp(time.Now())
+	testWorkspaceIDs = []string{"00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002"}
+	testNow          = types.Rfc3339Timestamp(time.Now())
 )
 
 func TestAdvisoryUpdateEventMarshal(t *testing.T) {
 	event := AdvisoryUpdateEvent{
-		RhAccountID: 1,
-		WorkspaceID: testWorkspaceID,
-		AdvisoryIDs: []int64{101, 202, 303},
-		ProducedAt:  testNow,
+		RhAccountID:  1,
+		WorkspaceIDs: testWorkspaceIDs,
+		AdvisoryIDs:  []int64{101, 202, 303},
+		ProducedAt:   testNow,
 	}
 
 	data, err := sonic.Marshal(&event)
@@ -31,7 +30,7 @@ func TestAdvisoryUpdateEventMarshal(t *testing.T) {
 	err = sonic.Unmarshal(data, &parsed)
 	assert.NoError(t, err)
 	assert.Equal(t, event.RhAccountID, parsed.RhAccountID)
-	assert.Equal(t, event.WorkspaceID, parsed.WorkspaceID)
+	assert.Equal(t, event.WorkspaceIDs, parsed.WorkspaceIDs)
 	assert.Equal(t, event.AdvisoryIDs, parsed.AdvisoryIDs)
 	assert.NotNil(t, parsed.ProducedAt)
 }
@@ -41,16 +40,16 @@ func TestAdvisoryUpdateEventsWriteEvents(t *testing.T) {
 
 	events := AdvisoryUpdateEvents{
 		{
-			RhAccountID: 1,
-			WorkspaceID: testWorkspaceID,
-			AdvisoryIDs: []int64{100, 200},
-			ProducedAt:  testNow,
+			RhAccountID:  1,
+			WorkspaceIDs: testWorkspaceIDs,
+			AdvisoryIDs:  []int64{100, 200},
+			ProducedAt:   testNow,
 		},
 		{
-			RhAccountID: 2,
-			WorkspaceID: testWorkspaceID,
-			AdvisoryIDs: []int64{300},
-			ProducedAt:  testNow,
+			RhAccountID:  2,
+			WorkspaceIDs: testWorkspaceIDs,
+			AdvisoryIDs:  []int64{300},
+			ProducedAt:   testNow,
 		},
 	}
 
@@ -64,7 +63,7 @@ func TestAdvisoryUpdateEventsWriteEvents(t *testing.T) {
 	err = sonic.Unmarshal(mockWriter.Messages[0].Value, &firstEvent)
 	assert.NoError(t, err)
 	assert.Equal(t, events[0].RhAccountID, firstEvent.RhAccountID)
-	assert.Equal(t, events[0].WorkspaceID, firstEvent.WorkspaceID)
+	assert.Equal(t, events[0].WorkspaceIDs, firstEvent.WorkspaceIDs)
 	assert.Equal(t, events[0].AdvisoryIDs, firstEvent.AdvisoryIDs)
 	assert.NotNil(t, firstEvent.ProducedAt)
 
@@ -72,7 +71,7 @@ func TestAdvisoryUpdateEventsWriteEvents(t *testing.T) {
 	err = sonic.Unmarshal(mockWriter.Messages[1].Value, &secondEvent)
 	assert.NoError(t, err)
 	assert.Equal(t, events[1].RhAccountID, secondEvent.RhAccountID)
-	assert.Equal(t, events[1].WorkspaceID, secondEvent.WorkspaceID)
+	assert.Equal(t, events[1].WorkspaceIDs, secondEvent.WorkspaceIDs)
 	assert.Equal(t, events[1].AdvisoryIDs, secondEvent.AdvisoryIDs)
 	assert.NotNil(t, secondEvent.ProducedAt)
 }


### PR DESCRIPTION
Updated `AdvisoryUpdateEvent` structure to support multiple workspace IDs

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Support advisory update events targeting multiple workspaces instead of a single workspace ID.

New Features:
- Allow AdvisoryUpdateEvent to carry multiple workspace identifiers per event.

Enhancements:
- Change AdvisoryUpdateEvent schema to use a list of workspace IDs rather than a single workspace ID.
- Update advisory update event tests to cover the new multi-workspace payload shape.