### PR TITLE
database: drop old delete_system function

### DIFF
--- a/database_admin/migrations/158_drop_old_delete_system_function.up.sql
+++ b/database_admin/migrations/158_drop_old_delete_system_function.up.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS delete_system(inventory_id_in varchar);

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (157, false);
+VALUES (158, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions


### PR DESCRIPTION
We found out that there is an old `delete_system(inventory_id_in varchar)` function that was living in our database for a long time.