### PR TITLE
HMS-10821: create template advisories table

### DIFF
--- a/base/models/models.go
+++ b/base/models/models.go
@@ -52,6 +52,19 @@ func (TemplateBase) TableName() string {
 	return "template"
 }
 
+type TemplateAdvisory struct {
+	RhAccountID int   `gorm:"primaryKey"`
+	TemplateID  int64 `gorm:"primaryKey"`
+	AdvisoryID  int64 `gorm:"primaryKey"`
+	Advisory    AdvisoryMetadata
+}
+
+func (TemplateAdvisory) TableName() string {
+	return "template_advisory"
+}
+
+type TemplateAdvisorySlice []TemplateAdvisory
+
 type SystemInventory struct {
 	ID                               int64     `gorm:"primaryKey"`
 	InventoryID                      uuid.UUID `gorm:"unique"`

--- a/database_admin/migrations/161_template_advisory.down.sql
+++ b/database_admin/migrations/161_template_advisory.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS template_advisory;

--- a/database_admin/migrations/161_template_advisory.up.sql
+++ b/database_admin/migrations/161_template_advisory.up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS template_advisory
+(
+    rh_account_id INT    NOT NULL,
+    template_id   BIGINT NOT NULL,
+    advisory_id   BIGINT NOT NULL,
+    PRIMARY KEY (rh_account_id, template_id, advisory_id),
+    CONSTRAINT template_advisory_template_id
+        FOREIGN KEY (rh_account_id, template_id)
+            REFERENCES template (rh_account_id, id) ON DELETE CASCADE,
+    CONSTRAINT template_advisory_advisory_id
+        FOREIGN KEY (advisory_id)
+            REFERENCES advisory_metadata (id) ON DELETE CASCADE
+) PARTITION BY HASH (rh_account_id);
+
+SELECT create_table_partitions('template_advisory', 16,
+                               $$WITH (fillfactor = '70', autovacuum_vacuum_scale_factor = '0.05')$$);
+
+CREATE INDEX ON template_advisory (rh_account_id, advisory_id);
+
+SELECT grant_table_partitions('SELECT', 'template_advisory', 'manager');
+SELECT grant_table_partitions('SELECT', 'template_advisory', 'evaluator');
+SELECT grant_table_partitions('SELECT, INSERT, UPDATE, DELETE', 'template_advisory', 'listener');
+SELECT grant_table_partitions('SELECT', 'template_advisory', 'vmaas_sync');

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (160, false);
+VALUES (161, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -786,6 +786,31 @@ VALUES (0, 'Installable'),
        (1, 'Applicable')
 ON CONFLICT DO NOTHING;
 
+
+-- template_advisory
+CREATE TABLE IF NOT EXISTS template_advisory
+(
+    rh_account_id INT    NOT NULL,
+    template_id   BIGINT NOT NULL,
+    advisory_id   BIGINT NOT NULL,
+    PRIMARY KEY (rh_account_id, template_id, advisory_id),
+    CONSTRAINT template_advisory_template_id
+        FOREIGN KEY (rh_account_id, template_id)
+            REFERENCES template (rh_account_id, id) ON DELETE CASCADE,
+    CONSTRAINT template_advisory_advisory_id
+        FOREIGN KEY (advisory_id)
+            REFERENCES advisory_metadata (id) ON DELETE CASCADE
+) PARTITION BY HASH (rh_account_id);
+
+SELECT create_table_partitions('template_advisory', 16,
+                               $$WITH (fillfactor = '70', autovacuum_vacuum_scale_factor = '0.05')$$);
+
+CREATE INDEX ON template_advisory (rh_account_id, advisory_id);
+
+SELECT grant_table_partitions('SELECT', 'template_advisory', 'manager');
+SELECT grant_table_partitions('SELECT', 'template_advisory', 'evaluator');
+SELECT grant_table_partitions('SELECT, INSERT, UPDATE, DELETE', 'template_advisory', 'listener');
+SELECT grant_table_partitions('SELECT', 'template_advisory', 'vmaas_sync');
 
 -- system_advisories
 CREATE TABLE IF NOT EXISTS system_advisories

--- a/tasks/cleaning/clean_unused_data.go
+++ b/tasks/cleaning/clean_unused_data.go
@@ -48,6 +48,7 @@ func deleteUnusedAdvisories() {
 	subq := tx.Select("id").Table("advisory_metadata am").
 		Where("am.synced = ?", false).
 		Where("NOT EXISTS (SELECT 1 FROM system_advisories sa WHERE am.id = sa.advisory_id)").
+		Where("NOT EXISTS (SELECT 1 FROM template_advisory ta WHERE am.id = ta.advisory_id)").
 		Where("NOT EXISTS (SELECT 1 FROM package p WHERE am.id = p.advisory_id)").
 		Where("NOT EXISTS (SELECT 1 FROM advisory_account_data aad WHERE am.id = aad.advisory_id)").
 		Limit(tasks.DeleteUnusedDataLimit)

--- a/tasks/vmaas_sync/metrics_db_test.go
+++ b/tasks/vmaas_sync/metrics_db_test.go
@@ -17,13 +17,14 @@ func TestTableSizes(t *testing.T) {
 	for _, item := range tableSizes {
 		uniqueTables[item.Key] = true
 	}
-	assert.Equal(t, 263, len(tableSizes))
-	assert.Equal(t, 263, len(uniqueTables))
+	assert.Equal(t, 280, len(tableSizes))
+	assert.Equal(t, 280, len(uniqueTables))
 	assert.True(t, uniqueTables["public.system_inventory"]) // check whether table names were loaded
 	assert.True(t, uniqueTables["public.system_patch"])     // check whether table names were loaded
 	assert.True(t, uniqueTables["public.package"])
 	assert.True(t, uniqueTables["public.repo"])
 	assert.True(t, uniqueTables["public.account_advisory"])
+	assert.True(t, uniqueTables["public.template_advisory"])
 }
 
 func TestDatabaseSize(t *testing.T) {


### PR DESCRIPTION
This PR:

 - creates new `template_advisory` table to store template↔advisory associations (one row per pair, keyed by `rh_account_id`, `template_id`, `advisory_id`)
- adds index on `(rh_account_id, advisory_id)` for reverse lookups by advisory
- partitions the table by `rh_account_id` (16 partitions, matching `template`) with FKs to `template` (CASCADE on delete) and advisory_metadata
- updates schema 
- introduces the `TemplateAdvisory` model
- updates `TestTableSizes` expected table count for the new partitioned table

## Summary by Sourcery

Introduce a partitioned template_advisory table to store associations between templates and advisories and expose it via a new GORM model.

New Features:
- Add template_advisory table partitioned by rh_account_id to model template-to-advisory relationships with appropriate foreign keys and indexing.
- Introduce a TemplateAdvisory GORM model and slice type for application-level access to template_advisory records.

Build:
- Add schema migration 161 to create and grant access to the template_advisory table and update the base schema version.

Tests:
- Update TestTableSizes expectations and assertions to account for the new partitioned template_advisory table.