### PR TITLE
RHINENG-27056: add cji for the db-migration job

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -562,6 +562,21 @@ objects:
     testing:
       iqePlugin: patchman
 
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    annotations:
+      clowder.redhat.com/expected-image-tag: ${IMAGE_TAG}
+    labels:
+      app: patchman
+    generateName: db-migration-
+  spec:
+    appName: patchman
+    runOnNotReady: true
+    disabled: ${{DB_MIGRATION_DISABLED}}
+    jobs:
+      - db-migration
+
 - apiVersion: metrics.console.redhat.com/v1alpha1
   kind: FloorPlan
   metadata:
@@ -755,6 +770,8 @@ parameters:
 - {name: DB_READ_REPLICA_ENABLED_JOBS, value: 'TRUE'}
 - {name: JOBS_CONFIG, value: ''}
 
+# DB migration
+- {name: DB_MIGRATION_DISABLED, value: 'false'} # Disable db-migration job execution
 # VMaaS sync
 - {name: VMAAS_SYNC_SCHEDULE, value: '*/5 * * * *'} # Cronjob schedule definition
 - {name: VMAAS_SYNC_SUSPEND, value: 'false'} # Disable cronjob execution


### PR DESCRIPTION
This PR:
- adds CJI for the db-migration job

## Summary by Sourcery

Add configuration to invoke the db-migration job as a ClowdJobInvocation in the patchman application.

New Features:
- Introduce a ClowdJobInvocation resource for the db-migration job in the patchman app.

Build:
- Add a DB_MIGRATION_DISABLED parameter to control db-migration job execution via deployment configuration.