### PR TITLE
RHINENG-27056: update cji db-migration job with name using image_tag and suffix

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -569,7 +569,7 @@ objects:
       clowder.redhat.com/expected-image-tag: ${IMAGE_TAG}
     labels:
       app: patchman
-    generateName: db-migration-
+    name: db-migration-${IMAGE_TAG}-${CJI_UID}
   spec:
     appName: patchman
     runOnNotReady: true
@@ -772,6 +772,10 @@ parameters:
 
 # DB migration
 - {name: DB_MIGRATION_DISABLED, value: 'false'} # Disable db-migration job execution
+- name: CJI_UID
+  description: Unique db-migration CJI name suffix
+  generate: expression
+  from: '[a-z0-9]{6}'
 # VMaaS sync
 - {name: VMAAS_SYNC_SCHEDULE, value: '*/5 * * * *'} # Cronjob schedule definition
 - {name: VMAAS_SYNC_SUSPEND, value: 'false'} # Disable cronjob execution


### PR DESCRIPTION
This PR:
- updates the CJI db-migration with name using image_tag and random suffix because `qontract-reconcile` does not support `generateName` for any k8s object

## Summary by Sourcery

Update the CJI db-migration job to use an explicit name incorporating the image tag and a generated unique suffix instead of relying on Kubernetes generateName, and add a new parameter to supply that suffix.