### PR TITLE
build: skip sast coverity check

### DIFF
--- a/.tekton/patchman-engine-pull-request.yaml
+++ b/.tekton/patchman-engine-pull-request.yaml
@@ -32,7 +32,7 @@ spec:
   - name: path-context
     value: .
   - name: skip-sast-coverity-check
-    value: "false"
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:

--- a/.tekton/patchman-engine-push.yaml
+++ b/.tekton/patchman-engine-push.yaml
@@ -29,7 +29,7 @@ spec:
   - name: path-context
     value: .
   - name: skip-sast-coverity-check
-    value: "false"
+    value: "true"
   pipelineRef:
     name: docker-build-oci-ta
   taskRunTemplate:


### PR DESCRIPTION
This PR disables sast coverity check as it takes about 45m to run.
We will need to investigate how to configure it later to run faster and not block the pipeline.

## Summary by Sourcery

Build:
- Configure Tekton pull-request and push pipelines to set skip-sast-coverity-check to true, disabling the Coverity SAST step.