### PR TITLE
HMS-9951: store template-advisory relationships on template update

### DIFF
--- a/base/content_sources/content_sources.go
+++ b/base/content_sources/content_sources.go
@@ -1,0 +1,20 @@
+package content_sources
+
+import (
+	"app/base/api"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type TemplateAdvisoryIDsResponse struct {
+	AdvisoryIDs []string `json:"advisory_ids"`
+}
+
+func CreateContentSourcesClient() *api.Client {
+	debugRequest := log.IsLevelEnabled(log.TraceLevel)
+	return &api.Client{
+		HTTPClient: &http.Client{},
+		Debug:      debugRequest,
+	}
+}

--- a/base/database/testing.go
+++ b/base/database/testing.go
@@ -497,3 +497,30 @@ func CheckTemplateSystems(t *testing.T, account int, templateUUID string, invent
 		}
 	}
 }
+
+func CreateTemplateAdvisories(t *testing.T, rhAccountID int, templateID int64, advisoryIDs []int64) {
+	for _, advisoryID := range advisoryIDs {
+		err := DB.Create(&models.TemplateAdvisory{
+			RhAccountID: rhAccountID, TemplateID: templateID, AdvisoryID: advisoryID}).Error
+		assert.Nil(t, err)
+	}
+	CheckTemplateAdvisories(t, templateID, advisoryIDs)
+}
+
+func CheckTemplateAdvisories(t *testing.T, templateID int64, advisoryIDs []int64) {
+	var templateAdvisories []models.TemplateAdvisory
+	err := DB.Where("template_id = ? AND advisory_id IN (?)", templateID, advisoryIDs).
+		Find(&templateAdvisories).Error
+	assert.Nil(t, err)
+	assert.Equal(t, len(advisoryIDs), len(templateAdvisories))
+}
+
+func DeleteTemplateAdvisories(t *testing.T, templateID int64, advisoryIDs []int64) {
+	query := DB.Model(&models.TemplateAdvisory{}).Where("template_id = ? AND advisory_id IN (?)",
+		templateID, advisoryIDs)
+	assert.Nil(t, query.Delete(&models.TemplateAdvisory{}).Error)
+
+	var count int64
+	assert.Nil(t, query.Count(&count).Error)
+	assert.Equal(t, int64(0), count)
+}

--- a/base/utils/config.go
+++ b/base/utils/config.go
@@ -81,6 +81,7 @@ type coreConfig struct {
 	ListenerPrivateAddress        string
 	EvaluatorUploadPrivateAddress string
 	EvaluatorRecalcPrivateAddress string
+	ContentSourcesAddress         string
 
 	// cloudwatch
 	CloudWatchAccessKeyID     string
@@ -187,6 +188,7 @@ func initServicesFromEnv() {
 	CoreCfg.CandlepinCert = Getenv("CANDLEPIN_CERT", CoreCfg.CandlepinCert)
 	CoreCfg.CandlepinKey = Getenv("CANDLEPIN_KEY", CoreCfg.CandlepinKey)
 	CoreCfg.CandlepinCA = Getenv("CANDLEPIN_CA", CoreCfg.CandlepinCA)
+	CoreCfg.ContentSourcesAddress = Getenv("CONTENT_SOURCES_ADDRESS", CoreCfg.ContentSourcesAddress)
 }
 
 func initDBFromClowder() {
@@ -282,6 +284,8 @@ func initServicesFromClowder() {
 			CoreCfg.RbacAddress = (*Endpoint)(&endpoint).buildURL()
 		case "rbac-service":
 			CoreCfg.RbacURL = (*Endpoint)(&endpoint).buildURL()
+		case "content-sources-backend":
+			CoreCfg.ContentSourcesAddress = (*Endpoint)(&endpoint).buildURL()
 		}
 	}
 
@@ -419,6 +423,7 @@ func printKafkaParams() {
 func printServicesParams() {
 	fmt.Printf("VMAAS_ADDRESS=http://%s\n", CoreCfg.VmaasAddress)
 	fmt.Printf("RBAC_ADDRESS=http://%s\n", CoreCfg.RbacAddress)
+	fmt.Printf("CONTENT_SOURCES_ADDRESS=http://%s\n", CoreCfg.ContentSourcesAddress)
 }
 
 func printCloudwatchParams() {

--- a/base/utils/identity.go
+++ b/base/utils/identity.go
@@ -23,3 +23,23 @@ func ParseXRHID(identityString string) (*identity.XRHID, error) {
 	}
 	return &xrhid, nil
 }
+
+func EncodeXRHID(id identity.Identity) (string, error) {
+	js, err := sonic.Marshal(identity.XRHID{Identity: id})
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(js), nil
+}
+
+func XRHIDForOrg(orgID string) identity.XRHID {
+	return identity.XRHID{
+		Identity: identity.Identity{
+			Type:  "User",
+			OrgID: orgID,
+			Internal: identity.Internal{
+				OrgID: orgID,
+			},
+		},
+	}
+}

--- a/base/utils/identity_test.go
+++ b/base/utils/identity_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"testing"
 
+	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,4 +22,26 @@ func TestParseIdentity(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "6089719", xrhid.Identity.AccountNumber)
 	assert.Equal(t, "6089719", xrhid.Identity.ServiceAccount.UserId)
+}
+
+func TestEncodeXRHID(t *testing.T) {
+	testIdentityString := "eyJpZGVudGl0eSI6eyJvcmdfaWQiOiJvcmdfMSIsImludGVybmFsIjp7Im9yZ19pZCI6Im9yZ18xIn0sInR5cGUiOiJVc2VyIn0sImVudGl0bGVtZW50cyI6bnVsbH0=" //nolint:lll
+	orgID := "org_1"
+	var xrhid identity.Identity
+	xrhid.OrgID = orgID
+	xrhid.Internal.OrgID = orgID
+	xrhid.Type = "User"
+	identityString, err := EncodeXRHID(xrhid)
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, testIdentityString, identityString)
+}
+
+func TestXRHIDForOrg(t *testing.T) {
+	orgID := "1234"
+	xrhid := XRHIDForOrg(orgID)
+
+	assert.Equal(t, orgID, xrhid.Identity.OrgID)
+	assert.Equal(t, orgID, xrhid.Identity.Internal.OrgID)
+	assert.Equal(t, "User", xrhid.Identity.Type)
 }

--- a/conf/common.env
+++ b/conf/common.env
@@ -26,3 +26,4 @@ INVENTORY_VIEWS_TOPIC=platform.inventory.host-apps
 ENABLE_PROFILER=true
 
 CANDLEPIN_ADDRESS=http://platform:9001/candlepin
+CONTENT_SOURCES_ADDRESS=http://platform:9001

--- a/conf/local.env
+++ b/conf/local.env
@@ -15,6 +15,7 @@ DB_SSLROOTCERT=dev/database/secrets/pgca.crt
 
 VMAAS_ADDRESS=http://localhost:9001
 CANDLEPIN_ADDRESS=http://localhost:9001/candlepin
+CONTENT_SOURCES_ADDRESS=http://localhost:9001
 
 KAFKA_ADDRESS=localhost:9092
 KAFKA_GROUP=patchman

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -1,6 +1,8 @@
 package listener
 
 import (
+	"app/base/api"
+	"app/base/content_sources"
 	"app/base/core"
 	"app/base/database"
 	"app/base/models"
@@ -34,6 +36,10 @@ var (
 	eventBufferSize     = 5 * mqueue.BatchSize
 	updatedEventsBuffer eventBuffer
 	createdEventsBuffer eventBuffer
+
+	// Content sources client
+	contentSourcesClient  *api.Client
+	contentSourcesBaseURL string
 )
 
 const (
@@ -63,6 +69,10 @@ func configureListener() {
 	// Toggle template message processing
 	enableTemplates = utils.PodConfig.GetBool("templates_api", true)
 	if enableTemplates {
+		if utils.CoreCfg.ContentSourcesAddress != "" {
+			contentSourcesClient = content_sources.CreateContentSourcesClient()
+			contentSourcesBaseURL = utils.CoreCfg.ContentSourcesAddress + "/api/content-sources/v1"
+		}
 		// Name of kafka template topic
 		templatesTopic = utils.FailIfEmpty(utils.CoreCfg.TemplateTopic, "TEMPLATE_TOPIC")
 		// Number of kafka readers for template topic

--- a/listener/template_advisories.go
+++ b/listener/template_advisories.go
@@ -1,0 +1,199 @@
+package listener
+
+import (
+	"app/base/content_sources"
+	"app/base/database"
+	"app/base/models"
+	"app/base/utils"
+	"context"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
+	"gorm.io/gorm"
+)
+
+func syncTemplateAdvisories(ctx context.Context, accountID int, templateID int64, templateUUID string) error {
+	current, err := callCSTemplateAdvisories(ctx, templateUUID)
+	if err != nil {
+		return errors.Wrap(err, "fetching current template advisories from content-sources")
+	}
+
+	stored, err := lookUpTemplateAdvisories(database.DB, accountID, templateID)
+	if err != nil {
+		return errors.Wrap(err, "looking up stored template advisories")
+	}
+
+	toAdd, toRemove := diffTemplateAdvisories(current.AdvisoryIDs, stored)
+	if len(toAdd) == 0 && len(toRemove) == 0 {
+		utils.LogInfo("template_uuid", templateUUID, "template advisories unchanged")
+		return nil
+	}
+
+	nameToID, err := lookUpAdvisoryMetadataIDs(toAdd)
+	if err != nil {
+		return errors.Wrap(err, "looking up advisory metadata IDs")
+	}
+
+	toInsert := buildTemplateAdvisoryRows(accountID, templateID, toAdd, nameToID)
+
+	tx := database.DB.Begin()
+	defer tx.Rollback()
+
+	err = deleteOldTemplateAdvisories(tx, accountID, templateID, toRemove)
+	if err != nil {
+		return errors.Wrap(err, "deleting old template advisories")
+	}
+
+	if len(toInsert) > 0 {
+		err = database.BulkInsert(tx, toInsert)
+		if err != nil {
+			return errors.Wrap(err, "bulk inserting added template advisories")
+		}
+	}
+
+	utils.LogInfo(
+		"template_uuid", templateUUID,
+		"added_advisories", len(toInsert),
+		"removed_advisories", len(toRemove),
+		"template advisories synced",
+	)
+
+	return tx.Commit().Error
+}
+
+// Returns advisories currently stored for the template
+func lookUpTemplateAdvisories(tx *gorm.DB, accountID int,
+	templateID int64) (map[string]models.TemplateAdvisory, error) {
+	var data []models.TemplateAdvisory
+	err := tx.Preload("Advisory").
+		Find(&data, "template_id = ? AND rh_account_id = ?", templateID, accountID).Error
+	if err != nil {
+		return nil, err
+	}
+
+	advisories := make(map[string]models.TemplateAdvisory, len(data))
+	for _, ta := range data {
+		advisories[ta.Advisory.Name] = ta
+	}
+
+	return advisories, nil
+}
+
+// Calculates the diff between template advisories from content sources and stored template advisories
+func diffTemplateAdvisories(current []string, stored map[string]models.TemplateAdvisory) ([]string, []int64) {
+	var toAdd []string
+	var toRemove []int64
+
+	// advisories from content sources
+	currentSet := make(map[string]struct{}, len(current))
+	for _, name := range current {
+		currentSet[name] = struct{}{}
+	}
+	// prepare to remove if in DB but not in content sources
+	for name, ta := range stored {
+		if _, found := currentSet[name]; !found {
+			toRemove = append(toRemove, ta.AdvisoryID)
+		}
+	}
+	// prepare to add if in content sources but not in DB
+	for name := range currentSet {
+		if _, found := stored[name]; !found {
+			toAdd = append(toAdd, name)
+		}
+	}
+
+	return toAdd, toRemove
+}
+
+// Returns the advisory IDs from advisory_metadata that map to the given advisory names
+func lookUpAdvisoryMetadataIDs(names []string) (map[string]int64, error) {
+	metadata := make(models.AdvisoryMetadataSlice, 0, len(names))
+
+	err := database.DB.Model(&models.AdvisoryMetadata{}).
+		Where("name IN (?)", names).
+		Select("id, name").
+		Scan(&metadata).Error
+	if err != nil {
+		return nil, err
+	}
+
+	nameToID := make(map[string]int64, len(metadata))
+	for _, am := range metadata {
+		nameToID[am.Name] = am.ID
+	}
+
+	return nameToID, err
+}
+
+// Builds the rows to insert in template_advisory
+func buildTemplateAdvisoryRows(accountID int, templateID int64, names []string,
+	nameToID map[string]int64) models.TemplateAdvisorySlice {
+	rows := make(models.TemplateAdvisorySlice, 0, len(names))
+	for _, name := range names {
+		advisoryID, ok := nameToID[name]
+		if !ok {
+			// log warning and skip if advisory not yet found in advisory_metadata
+			// content sources might know about it before vmaas
+			utils.LogWarn("template", templateID, "advisory", name, "not in advisory_metadata, skipping")
+			continue
+		}
+		rows = append(rows, models.TemplateAdvisory{
+			RhAccountID: accountID,
+			TemplateID:  templateID,
+			AdvisoryID:  advisoryID,
+		})
+	}
+	return rows
+}
+
+// Deletes given template advisory relationships from template_advisory
+func deleteOldTemplateAdvisories(tx *gorm.DB, accountID int, templateID int64, advisoryIDs []int64) error {
+	if len(advisoryIDs) == 0 {
+		return nil
+	}
+
+	err := tx.Where("rh_account_id = ? ", accountID).
+		Where("template_id = ?", templateID).
+		Where("advisory_id in (?)", advisoryIDs).
+		Delete(&models.TemplateAdvisory{}).Error
+	return err
+}
+
+func httpCallCSTemplateAdvisories(ctx context.Context, templateUUID string) (
+	interface{}, *http.Response, error) {
+	id := identity.GetIdentity(ctx)
+	header, err := utils.EncodeXRHID(id.Identity)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if contentSourcesClient == nil {
+		return nil, nil, errors.New("content sources client is nil")
+	}
+	client := *contentSourcesClient
+	client.DefaultHeaders = map[string]string{"x-rh-identity": header}
+
+	url := contentSourcesBaseURL + "/templates/" + templateUUID + "/advisories/ids"
+	var resp content_sources.TemplateAdvisoryIDsResponse
+	httpResp, err := client.Request(&ctx, http.MethodGet, url, nil, &resp)
+
+	return &resp, httpResp, err
+}
+
+// Fetches advisories for a template.
+// Returns an unpaginated list of advisory IDs (e.g. RHSA-1234:0001)
+func callCSTemplateAdvisories(ctx context.Context,
+	templateUUID string) (*content_sources.TemplateAdvisoryIDsResponse, error) {
+	contentSourcesRespPtr, err := utils.HTTPCallRetry(
+		func() (interface{}, *http.Response, error) {
+			return httpCallCSTemplateAdvisories(ctx, templateUUID)
+		},
+		true,
+		5,
+		http.StatusServiceUnavailable)
+	if err != nil {
+		return nil, errors.Wrap(err, "content sources template advisories call failed")
+	}
+	return contentSourcesRespPtr.(*content_sources.TemplateAdvisoryIDsResponse), nil
+}

--- a/listener/template_advisories_test.go
+++ b/listener/template_advisories_test.go
@@ -1,0 +1,144 @@
+package listener
+
+import (
+	"app/base/content_sources"
+	"app/base/core"
+	"app/base/database"
+	"app/base/models"
+	"app/base/utils"
+	"context"
+	"testing"
+
+	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupContentSourcesClient(t *testing.T) {
+	originalAddress := utils.CoreCfg.ContentSourcesAddress
+	address := utils.Getenv("CONTENT_SOURCES_ADDRESS", "http://platform:9001")
+	utils.CoreCfg.ContentSourcesAddress = address
+	contentSourcesClient = content_sources.CreateContentSourcesClient()
+	contentSourcesBaseURL = address + "/api/content-sources/v1"
+	t.Cleanup(func() {
+		utils.CoreCfg.ContentSourcesAddress = originalAddress
+		contentSourcesClient = nil
+		contentSourcesBaseURL = ""
+	})
+}
+
+func TestCallCSTemplateAdvisories(t *testing.T) {
+	setupContentSourcesClient(t)
+
+	templateUUID := "99900000-0000-0000-0000-000000000001"
+	orgID := "org_1"
+	ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(orgID))
+	result, err := callCSTemplateAdvisories(ctx, templateUUID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"RH-1", "RH-3"}, result.AdvisoryIDs)
+}
+
+func TestDiffTemplateAdvisories(t *testing.T) {
+	stored := map[string]models.TemplateAdvisory{
+		"RH-1": {AdvisoryID: 1, Advisory: models.AdvisoryMetadata{Name: "RH-1"}},
+		"RH-2": {AdvisoryID: 2, Advisory: models.AdvisoryMetadata{Name: "RH-2"}},
+	}
+	fromContentSources := []string{"RH-1", "RH-3"}
+
+	toAdd, toRemove := diffTemplateAdvisories(fromContentSources, stored)
+	assert.Equal(t, []string{"RH-3"}, toAdd)
+	assert.Equal(t, []int64{2}, toRemove)
+}
+
+func TestLookUpAdvisoryMetadataIDs(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+
+	advisoryNames := []string{"RH-1", "RH-2"}
+	nameToID, err := lookUpAdvisoryMetadataIDs(advisoryNames)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(nameToID))
+	assert.Equal(t, int64(1), nameToID["RH-1"])
+	assert.Equal(t, int64(2), nameToID["RH-2"])
+}
+
+func TestBuildTemplateAdvisoryRows(t *testing.T) {
+	nameToID := map[string]int64{
+		"RH-1": 1,
+		"RH-2": 2,
+	}
+	rows := buildTemplateAdvisoryRows(1, 42, []string{"RH-1", "RH-2"}, nameToID)
+	assert.Equal(t, 2, len(rows))
+	assert.Equal(t, models.TemplateAdvisory{
+		RhAccountID: 1,
+		TemplateID:  42,
+		AdvisoryID:  1,
+	}, rows[0])
+	assert.Equal(t, models.TemplateAdvisory{
+		RhAccountID: 1,
+		TemplateID:  42,
+		AdvisoryID:  2,
+	}, rows[1])
+}
+
+func TestBuildTemplateAdvisoryRows_SkipMissing(t *testing.T) {
+	nameToID := map[string]int64{"RH-1": 1}
+	rows := buildTemplateAdvisoryRows(1, 42, []string{"RH-1", "missing"}, nameToID)
+	assert.Equal(t, 1, len(rows))
+	assert.Equal(t, models.TemplateAdvisory{
+		RhAccountID: 1,
+		TemplateID:  42,
+		AdvisoryID:  1,
+	}, rows[0])
+}
+
+func TestLookUpTemplateAdvisories(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+
+	templateID := int64(1)
+	advisoryIDs := []int64{1, 2}
+
+	database.CreateTemplateAdvisories(t, accountID, templateID, advisoryIDs)
+	database.CheckTemplateAdvisories(t, templateID, advisoryIDs)
+	defer database.DeleteTemplateAdvisories(t, templateID, advisoryIDs)
+
+	templateAdvisories, err := lookUpTemplateAdvisories(database.DB, accountID, templateID)
+	assert.Nil(t, err)
+	assert.NotNil(t, templateAdvisories)
+	assert.Equal(t, 2, len(templateAdvisories))
+	assert.Equal(t, "RH-1", (templateAdvisories)["RH-1"].Advisory.Name)
+	assert.Equal(t, "adv-1-des", (templateAdvisories)["RH-1"].Advisory.Description)
+	assert.Equal(t, "RH-2", (templateAdvisories)["RH-2"].Advisory.Name)
+	assert.Equal(t, "adv-2-des", (templateAdvisories)["RH-2"].Advisory.Description)
+}
+
+func TestSyncTemplateAdvisories(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+	setupContentSourcesClient(t)
+
+	templateID := int64(1)
+	templateUUID := "99900000-0000-0000-0000-000000000001"
+	orgID := "org_1"
+
+	// DB has RH-1 and RH-2 linked to the template
+	database.CreateTemplateAdvisories(t, accountID, templateID, []int64{1, 2})
+	defer database.DeleteTemplateAdvisories(t, templateID, []int64{1, 2, 3})
+
+	// content sources mock returns RH-1 and RH-3 so we need to add RH-3, remove RH-2
+	ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(orgID))
+	err := syncTemplateAdvisories(ctx, accountID, templateID, templateUUID)
+	assert.Nil(t, err)
+
+	// RH-3 and RH-1 now linked to the template
+	database.CheckTemplateAdvisories(t, templateID, []int64{1, 3})
+
+	// RH-2 was removed
+	var count int64
+	err = database.DB.Model(&models.TemplateAdvisory{}).
+		Where("template_id = ? AND advisory_id = ?", templateID, 2).
+		Count(&count).Error
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), count)
+}

--- a/listener/templates.go
+++ b/listener/templates.go
@@ -6,6 +6,7 @@ import (
 	"app/base/mqueue"
 	"app/base/utils"
 	"app/manager/middlewares"
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/pkg/errors"
+	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 )
 
 const (
@@ -42,7 +44,7 @@ func TemplatesMessageHandler(m mqueue.KafkaMessage) error {
 		case TemplateEventUpdate:
 			fallthrough
 		case TemplateEventCreate:
-			err = TemplateUpdate(template)
+			err = TemplateUpdate(template, eType)
 		default:
 			utils.LogWarn("msg", fmt.Sprintf("%v", template), WarnUnknownType)
 			err = nil
@@ -86,6 +88,12 @@ func TemplateDelete(template mqueue.TemplateResponse) error {
 	}
 
 	err = database.DB.
+		Delete(&models.TemplateAdvisory{}, "template_id = ? AND rh_account_id = ?", templateID, accountID).Error
+	if err != nil {
+		return errors.Wrap(err, "deleting template advisory relationships")
+	}
+
+	err = database.DB.
 		Delete(&models.Template{}, "id = ? AND rh_account_id = ?", templateID, accountID).Error
 	if err != nil {
 		return errors.Wrap(err, "deleting template")
@@ -94,13 +102,13 @@ func TemplateDelete(template mqueue.TemplateResponse) error {
 	return nil
 }
 
-func TemplateUpdate(template mqueue.TemplateResponse) error {
+func TemplateUpdate(template mqueue.TemplateResponse, eventType string) error {
 	tStart := time.Now()
-	defer utils.ObserveSecondsSince(tStart, templateMsgHandlingDuration.WithLabelValues(TemplateEventCreate))
+	defer utils.ObserveSecondsSince(tStart, templateMsgHandlingDuration.WithLabelValues(eventType))
 
 	if template.OrgID == "" {
 		utils.LogError("template", template.UUID, ErrorNoAccountProvided)
-		eventMsgsReceivedCnt.WithLabelValues(TemplateEventCreate, ReceivedErrorIdentity).Inc()
+		eventMsgsReceivedCnt.WithLabelValues(eventType, ReceivedErrorIdentity).Inc()
 		utils.ObserveSecondsSince(tStart, messagePartDuration.WithLabelValues("template-skip"))
 		return nil
 	}
@@ -134,7 +142,15 @@ func TemplateUpdate(template mqueue.TemplateResponse) error {
 	err = database.OnConflictUpdateMulti(database.DB, []string{"rh_account_id", "uuid"},
 		"name", "environment_id", "description", "creator", "published").Save(&row).Error
 	if err != nil {
-		return errors.Wrap(err, "creating template from message")
+		return errors.Wrap(err, "creating/updating template from message")
+	}
+
+	if contentSourcesBaseURL != "" && eventType == TemplateEventUpdate {
+		ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(template.OrgID))
+		err = syncTemplateAdvisories(ctx, accountID, row.ID, template.UUID)
+		if err != nil {
+			return errors.Wrap(err, "syncing template advisories")
+		}
 	}
 	return nil
 }

--- a/platform/content_sources.go
+++ b/platform/content_sources.go
@@ -1,0 +1,20 @@
+package platform
+
+import (
+	"app/base/content_sources"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func templateAdvisoryIDsGetHandler(c *gin.Context) {
+	response := content_sources.TemplateAdvisoryIDsResponse{
+		AdvisoryIDs: []string{"RH-1", "RH-3"},
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func initContentSources(app *gin.Engine) {
+	// Mock endpoint for content sources
+	app.GET("/api/content-sources/v1/templates/:uuid/advisories/ids", templateAdvisoryIDsGetHandler)
+}

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -185,6 +185,7 @@ func platformMock() {
 	initVMaaS(app)
 	initRbac(app)
 	initCandlepin(app)
+	initContentSources(app)
 
 	// Control endpoint handler
 	app.POST("/control/upload", mockUploadHandler)


### PR DESCRIPTION
## Summary 

On template update events:
- Calls content-sources API to fetch the current advisories for a template
- Calculates the diff between returned and stored advisories
- Stores updated relationships in the template_advisory table

On template delete events:
- Removes the template_advisory entries for the deleted template

## Testing steps

1. Build and start the app: `podman-compose up --build`
2. Send a template update event to the template topic: `curl -X PUT http://localhost:9001/control/templates`. There should be a template-updated message in the logs.
3. The templates' advisories should be added to the template_advisory table: 
```
podman exec -it db psql -d patchman -U admin

patchman=# select * from template_advisory;
 rh_account_id | template_id | advisory_id 
---------------+-------------+-------------
             1 |         112 |           1
             1 |         112 |           3
             1 |         113 |           1
             1 |         113 |           3
```
4. Send the same update event. The template_advisory table should be unchanged.
5. Send a template delete event: `curl -X DELETE http://localhost:9001/control/templates`. The templates' advisories should be removed from the template_advisory table.

## Summary by Sourcery

Integrate content-sources advisory data into template processing so that template-advisory relationships are kept in sync on update and cleaned up on delete, with supporting utilities and tests.

New Features:
- Synchronize template-to-advisory relationships with content-sources on template update events.
- Expose a content-sources client and mock HTTP endpoint to retrieve advisory IDs for templates.

Enhancements:
- Track template listener metrics per event type instead of assuming create events.
- Remove template-advisory relationships when templates are deleted to keep data consistent.
- Add utilities for encoding and generating x-rh-identity headers for outbound service calls.

Tests:
- Add unit and integration tests covering advisory sync diffing, database lookups, and content-sources interactions.
- Add database test helpers for creating, checking, and deleting template-advisory records.