### PR TITLE
RHINENG-26549: add glitchtip integration, fix logging calls

### DIFF
--- a/base/base.go
+++ b/base/base.go
@@ -56,7 +56,7 @@ func TryExposeOnMetricsPort(app *gin.Engine) {
 	}
 	err := utils.RunServer(Context, app, metricsPort)
 	if err != nil {
-		utils.LogError("err", err.Error())
+		utils.LogError("err", err)
 		panic(err)
 	}
 }

--- a/base/database/utils.go
+++ b/base/database/utils.go
@@ -125,7 +125,7 @@ func UpdateTimestampKVValue(key string, value time.Time) {
 	ts := value.Format(time.RFC3339Nano)
 	err := UpdateTimestampKVValueStr(key, ts)
 	if err != nil {
-		utils.LogError("err", err.Error(), "key", key, "Unable to updated timestamp KV value")
+		utils.LogError("err", err, "key", key, "Unable to updated timestamp KV value")
 	}
 }
 

--- a/base/mqueue/event.go
+++ b/base/mqueue/event.go
@@ -29,7 +29,7 @@ func MakeMessageHandler(eventHandler EventHandler) MessageHandler {
 		err := sonic.Unmarshal(m.Value, &event)
 		// Not a fatal error, invalid data format, log and skip
 		if err != nil {
-			utils.LogError("err", err.Error(), "Could not deserialize platform event")
+			utils.LogError("err", err, "Could not deserialize platform event")
 			return nil
 		}
 		return eventHandler(event)

--- a/base/mqueue/mqueue.go
+++ b/base/mqueue/mqueue.go
@@ -62,7 +62,7 @@ func MakeRetryingHandler(handler MessageHandler) MessageHandler {
 			if err = handler(message); err == nil || !errors.Is(err, base.ErrFatal) {
 				return nil
 			}
-			utils.LogError("err", err.Error(), "attempt", attempt, "Try failed")
+			utils.LogError("err", err, "attempt", attempt, "Try failed")
 			attempt++
 		}
 		if err != nil && errors.Is(err, base.ErrFatal) {

--- a/base/mqueue/mqueue_impl_gokafka.go
+++ b/base/mqueue/mqueue_impl_gokafka.go
@@ -29,7 +29,7 @@ func (t *kafkaGoReaderImpl) HandleMessages(handler MessageHandler) {
 			if err.Error() == errContextCanceled {
 				break
 			}
-			utils.LogError("err", err.Error(), "unable to read message from Kafka reader")
+			utils.LogError("err", err, "unable to read message from Kafka reader")
 			panic(err)
 		}
 		if log.IsLevelEnabled(log.TraceLevel) {
@@ -41,14 +41,14 @@ func (t *kafkaGoReaderImpl) HandleMessages(handler MessageHandler) {
 		// At this level, all errors are fatal
 		kafkaMessage := KafkaMessage{Key: m.Key, Value: m.Value, Headers: m.Headers}
 		if err = handler(kafkaMessage); err != nil {
-			utils.LogPanic("err", err.Error(), "Handler failed")
+			utils.LogPanic("err", err, "Handler failed")
 		}
 		err = t.CommitMessages(base.Context, m)
 		if err != nil {
 			if err.Error() == errContextCanceled {
 				break
 			}
-			utils.LogError("err", err.Error(), "unable to commit kafka message")
+			utils.LogError("err", err, "unable to commit kafka message")
 			panic(err)
 		}
 	}

--- a/base/utils/awscloudwatch.go
+++ b/base/utils/awscloudwatch.go
@@ -16,7 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var hook *lc.Hook
+var cloudwatchHook *lc.Hook
 
 // Try to init CloudWatch logging
 func trySetupCloudWatchLogging() {
@@ -47,17 +47,11 @@ func trySetupCloudWatchLogging() {
 
 	cred := credentials.NewStaticCredentials(key, secret, "")
 	awsconf := aws.NewConfig().WithRegion(region).WithCredentials(cred)
-	hook, err = lc.NewBatchingHook(group, hostname, awsconf, 10*time.Second)
+	cloudwatchHook, err = lc.NewBatchingHook(group, hostname, awsconf, 10*time.Second)
 	if err != nil {
 		LogError("err", err.Error(), "unable to setup CloudWatch logging")
 		return
 	}
-	log.AddHook(hook)
+	log.AddHook(cloudwatchHook)
 	log.Info("CloudWatch logging configured")
-}
-
-func FlushLogs() {
-	if hook != nil {
-		_ = hook.Flush()
-	}
 }

--- a/base/utils/awscloudwatch.go
+++ b/base/utils/awscloudwatch.go
@@ -32,7 +32,7 @@ func trySetupCloudWatchLogging() {
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		LogError("err", err.Error(), "unable to get hostname to set CloudWatch log_stream")
+		LogError("err", err, "unable to get hostname to set CloudWatch log_stream")
 		return
 	}
 
@@ -49,7 +49,7 @@ func trySetupCloudWatchLogging() {
 	awsconf := aws.NewConfig().WithRegion(region).WithCredentials(cred)
 	cloudwatchHook, err = lc.NewBatchingHook(group, hostname, awsconf, 10*time.Second)
 	if err != nil {
-		LogError("err", err.Error(), "unable to setup CloudWatch logging")
+		LogError("err", err, "unable to setup CloudWatch logging")
 		return
 	}
 	log.AddHook(cloudwatchHook)

--- a/base/utils/config.go
+++ b/base/utils/config.go
@@ -108,6 +108,9 @@ type coreConfig struct {
 	LogLevel string
 	LogStyle string
 
+	// glitchtip logging
+	SentryDSN string
+
 	ConsoledotHostname string
 }
 
@@ -350,6 +353,7 @@ func initConsoledotFromEnv() {
 func initLoggerFromEnv() {
 	CoreCfg.LogLevel = Getenv("LOG_LEVEL", "INFO")
 	CoreCfg.LogStyle = Getenv("LOG_STYLE", "plain")
+	CoreCfg.SentryDSN = Getenv("SENTRY_DSN", "")
 }
 
 func initKesselFromEnv() {

--- a/base/utils/controller.go
+++ b/base/utils/controller.go
@@ -7,7 +7,7 @@ import (
 )
 
 func LogAndRespError(c *gin.Context, err error, respMsg string) {
-	LogError("err", err.Error(), respMsg)
+	LogError("err", err, respMsg)
 	c.AbortWithStatusJSON(http.StatusInternalServerError, ErrorResponse{Error: respMsg})
 }
 
@@ -17,16 +17,16 @@ func LogWarnAndResp(c *gin.Context, code int, respMsg string) {
 }
 
 func LogAndRespStatusError(c *gin.Context, code int, err error, msg string) {
-	LogError("err", err.Error(), msg)
+	LogError("err", err, msg)
 	c.AbortWithStatusJSON(code, ErrorResponse{Error: msg})
 }
 
 func LogAndRespBadRequest(c *gin.Context, err error, respMsg string) {
-	LogWarn("err", err.Error(), respMsg)
+	LogWarn("err", err, respMsg)
 	c.AbortWithStatusJSON(http.StatusBadRequest, ErrorResponse{Error: respMsg})
 }
 
 func LogAndRespNotFound(c *gin.Context, err error, respMsg string) {
-	LogWarn("err", err.Error(), respMsg)
+	LogWarn("err", err, respMsg)
 	c.AbortWithStatusJSON(http.StatusNotFound, ErrorResponse{Error: respMsg})
 }

--- a/base/utils/core.go
+++ b/base/utils/core.go
@@ -189,7 +189,7 @@ func ParseInventoryGroup(id *uuid.UUID, name *string) (string, error) {
 	group := rbac.InventoryGroup{{ID: id, Name: name}}
 	groupJSON, err := sonic.Marshal(&group)
 	if err != nil {
-		LogError("group", group, "err", err.Error(), "Cannot Marshal Inventory group")
+		LogError("group", group, "err", err, "Cannot Marshal Inventory group")
 		return "", err
 	}
 	return strconv.Quote(string(groupJSON)), nil

--- a/base/utils/gin.go
+++ b/base/utils/gin.go
@@ -109,7 +109,7 @@ func RunServer(ctx context.Context, handler http.Handler, port int) error {
 		LogDebug("gracefully shutting down server...")
 		err := srv.Shutdown(context.Background())
 		if err != nil {
-			LogError("err", err.Error(), "server shutting down failed")
+			LogError("err", err, "server shutting down failed")
 			return
 		}
 		LogInfo("server closed successfully")

--- a/base/utils/gin_test.go
+++ b/base/utils/gin_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestRunServer(t *testing.T) {
+	prev := CoreCfg.LogLevel
+	CoreCfg.LogLevel = "debug"
+	defer func() { CoreCfg.LogLevel = prev }()
+
 	ConfigureLogging()
 
 	var hook = NewTestLogHook()

--- a/base/utils/http.go
+++ b/base/utils/http.go
@@ -34,7 +34,7 @@ func HTTPCallRetry(httpCallFun func() (outputDataPtr interface{}, resp *http.Res
 		}
 
 		if len(codesToRetry) == 0 { // no "retry" codes specified, continue always
-			LogWarn("attempt", attempt, "err", callErr.Error(), "HTTP call failed, trying again")
+			LogWarn("attempt", attempt, "err", callErr, "HTTP call failed, trying again")
 			continue
 		}
 
@@ -123,7 +123,7 @@ func RunProfiler() {
 			server := &http.Server{Addr: fmt.Sprintf(":%d", CoreCfg.PrivatePort), ReadHeaderTimeout: 120 * time.Second}
 			err := server.ListenAndServe()
 			if err != nil {
-				LogWarn("err", err.Error(), "couldn't start profiler")
+				LogWarn("err", err, "couldn't start profiler")
 			}
 		}()
 	}

--- a/base/utils/log.go
+++ b/base/utils/log.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	sentry "github.com/getsentry/sentry-go"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -17,6 +18,8 @@ func ConfigureLogging() {
 		initJSONLogStyle()
 	}
 	trySetupCloudWatchLogging()
+	trySetupSentryLogging()
+	log.RegisterExitHandler(FlushLogs)
 }
 
 func processArgs(args []interface{}) (log.Fields, interface{}) {
@@ -41,6 +44,8 @@ func logLevel(level log.Level, args ...interface{}) {
 		return
 	}
 	fields, msg := processArgs(args)
+
+	tryCaptureSentryException(level, fields, msg)
 
 	// using standard Log at Fatal or Panic level will not properly exit or panic
 	entry := log.WithFields(fields)
@@ -122,4 +127,13 @@ func LogProgress(msg string, duration time.Duration, total int64) (*time.Ticker,
 		}
 	}()
 	return timer, &count
+}
+
+func FlushLogs() {
+	if cloudwatchHook != nil {
+		cloudwatchHook.Flush()
+	}
+	if sentryEnabled {
+		sentry.Flush(5 * time.Second)
+	}
 }

--- a/base/utils/sentry.go
+++ b/base/utils/sentry.go
@@ -1,0 +1,105 @@
+package utils
+
+import (
+	"fmt"
+	"maps"
+
+	sentry "github.com/getsentry/sentry-go"
+	log "github.com/sirupsen/logrus"
+)
+
+var sentryEnabled bool
+
+func trySetupSentryLogging() {
+	sentryEnabled = false
+
+	dsn := CoreCfg.SentryDSN
+	if dsn == "" {
+		LogInfo("config for Sentry not loaded")
+		return
+	}
+
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn:              dsn,
+		AttachStacktrace: true,
+	})
+	if err != nil {
+		LogWarn("err", err, "unable to setup Sentry logging")
+		return
+	}
+
+	sentryEnabled = true
+	log.Info("Sentry error monitoring configured")
+}
+
+func tryCaptureSentryException(level log.Level, fields log.Fields, msg any) {
+	if !sentryEnabled {
+		return
+	}
+
+	var sentryLevel sentry.Level
+
+	switch level {
+	case log.ErrorLevel:
+		sentryLevel = sentry.LevelError
+	case log.FatalLevel, log.PanicLevel:
+		sentryLevel = sentry.LevelFatal
+	default:
+		return
+	}
+
+	err := findErrorInFieldsOrMsg(fields, msg)
+
+	sentry.WithScope(func(scope *sentry.Scope) {
+		scope.SetLevel(sentryLevel)
+		scope.SetContext("log", buildSentryLogContext(level, fields, msg))
+		if err != nil {
+			sentry.CaptureException(err)
+		} else {
+			sentry.CaptureMessage(sentryLogMessage(msg))
+		}
+	})
+}
+
+func findErrorInFieldsOrMsg(fields log.Fields, msg any) error {
+	for _, key := range []string{"err", "error"} {
+		if v, ok := fields[key]; ok {
+			if err, ok := v.(error); ok {
+				return err
+			}
+		}
+	}
+
+	if err, ok := msg.(error); ok {
+		return err
+	}
+
+	return nil
+}
+
+func buildSentryLogContext(level log.Level, fields log.Fields, msg any) sentry.Context {
+	context := sentry.Context{"level": level.String()}
+
+	maps.Copy(context, fields)
+
+	if message := sentryLogMessage(msg); message != "" {
+		context["message"] = message
+	}
+
+	return context
+}
+
+func sentryLogMessage(msg any) string {
+	if msg == nil {
+		return ""
+	}
+
+	switch value := msg.(type) {
+	case error:
+		return value.Error()
+	case string:
+		return value
+	default:
+		return fmt.Sprint(value)
+	}
+}

--- a/base/utils/sentry_test.go
+++ b/base/utils/sentry_test.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindSentryExceptionUsesErrField(t *testing.T) {
+	err := errors.New("boom")
+
+	got := findErrorInFieldsOrMsg(log.Fields{"err": err}, "processing failed")
+
+	assert.Same(t, err, got)
+}
+
+func TestFindSentryExceptionFallsBackToMessage(t *testing.T) {
+	err := errors.New("boom")
+
+	got := findErrorInFieldsOrMsg(log.Fields{}, err)
+
+	assert.Same(t, err, got)
+}
+
+func TestFindSentryExceptionIgnoresStringifiedError(t *testing.T) {
+	got := findErrorInFieldsOrMsg(log.Fields{"err": "boom"}, "processing failed")
+
+	assert.Nil(t, got)
+}

--- a/base/utils/vmaas.go
+++ b/base/utils/vmaas.go
@@ -93,7 +93,7 @@ func RemoveNonLatestPackages(updates *vmaas.UpdatesV3Response) {
 	for k := range updateList {
 		nevra, err := ParseNevra(k)
 		if err != nil {
-			LogWarn("err", err.Error(), "Removing package because nevra is malformed")
+			LogWarn("err", err, "Removing package because nevra is malformed")
 			toDel = append(toDel, k)
 			continue
 		}
@@ -130,7 +130,7 @@ func ParseVmaasJSON(inv *models.SystemInventory) (vmaas.UpdatesV3Request, error)
 	}
 	err := sonic.Unmarshal([]byte(*inv.VmaasJSON), &updatesReq)
 	if err != nil {
-		LogWarn("inventoryID", inv.GetInventoryID(), "err", err.Error(), "failed to parse vmaas json")
+		LogWarn("inventoryID", inv.GetInventoryID(), "err", err, "failed to parse vmaas json")
 	}
 	return updatesReq, err
 }

--- a/database_admin/migrate.go
+++ b/database_admin/migrate.go
@@ -67,7 +67,7 @@ func MigrateUp(conn database.Driver, sourceURL string) {
 	}
 
 	if err != nil {
-		utils.LogError("err", err.Error(), "error upgrading the database")
+		utils.LogError("err", err, "error upgrading the database")
 		panic(err)
 	}
 }
@@ -127,12 +127,12 @@ func migrateAction(conn database.Driver, sourceURL string) int {
 		if errors.As(err, &migrate.ErrDirty{}) && forceMigrationVersion > 0 {
 			return MIGRATE
 		}
-		utils.LogError("err", err.Error(), "error getting current DB version")
+		utils.LogError("err", err, "error getting current DB version")
 		return BLOCK
 	}
 	migrationSchema, err := latestSchemaMigrationFileVersion(sourceURL)
 	if err != nil {
-		utils.LogError("err", err.Error(), "failed to load latestSchemaMigrationFileVersion")
+		utils.LogError("err", err, "failed to load latestSchemaMigrationFileVersion")
 		return BLOCK
 	}
 

--- a/database_admin/update.go
+++ b/database_admin/update.go
@@ -118,7 +118,7 @@ func waitForSessionClosed(db *sql.DB) {
 		sessions, err := listActiveAppSessions(db)
 		if err != nil {
 			errRetries++
-			utils.LogError("err", err.Error(), "attempt", errRetries, "failed to check app database sessions")
+			utils.LogError("err", err, "attempt", errRetries, "failed to check app database sessions")
 			if errRetries >= sessionCheckMaxRetries {
 				panic(fmt.Errorf("failed to check app database sessions after %d attempts: %w",
 					sessionCheckMaxRetries, err))

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -34,6 +34,7 @@ objects:
           - admin
         env:
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: KAFKA_GROUP, value: patchman}
         - {name: KAFKA_WRITER_MAX_ATTEMPTS, value: '${KAFKA_WRITER_MAX_ATTEMPTS}'}
         - {name: EVAL_TOPIC, value: patchman.evaluator.recalc}
@@ -67,6 +68,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_MANAGER}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: SHOW_CLOWDER_VARS, value: ''}
         - {name: DB_DEBUG, value: '${DB_DEBUG_MANAGER}'}
         - {name: DB_USER, value: manager}
@@ -131,6 +133,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_LISTENER}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: SHOW_CLOWDER_VARS, value: ''}
         - {name: DB_DEBUG, value: '${DB_DEBUG_LISTENER}'}
         - {name: DB_USER, value: listener}
@@ -180,6 +183,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_EVALUATOR_UPLOAD}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: SHOW_CLOWDER_VARS, value: ''}
         - {name: DB_DEBUG, value: '${DB_DEBUG_EVALUATOR_UPLOAD}'}
         - {name: DB_USER, value: evaluator}
@@ -228,6 +232,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_EVALUATOR_RECALC}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: SHOW_CLOWDER_VARS, value: ''}
         - {name: DB_DEBUG, value: '${DB_DEBUG_EVALUATOR_RECALC}'}
         - {name: DB_USER, value: evaluator}
@@ -276,6 +281,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_EVALUATOR_USER_EVALUATION}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: SHOW_CLOWDER_VARS, value: ''}
         - {name: DB_DEBUG, value: '${DB_DEBUG_EVALUATOR_USER_EVALUATION}'}
         - {name: DB_USER, value: evaluator}
@@ -314,6 +320,7 @@ objects:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_DATABASE_ADMIN}'}
         - {name: DB_DEBUG, value: '${DB_DEBUG_DATABASE_ADMIN}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: SHOW_CLOWDER_VARS, value: ''}
         - {name: MANAGER_PASSWORD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
                                                                   key: manager-database-password}}}
@@ -349,6 +356,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_JOBS}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: SHOW_CLOWDER_VARS, value: ''}
         - {name: DB_DEBUG, value: '${DB_DEBUG_JOBS}'}
         - {name: DB_USER, value: vmaas_sync}
@@ -388,6 +396,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_JOBS}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: DB_DEBUG, value: '${DB_DEBUG_JOBS}'}
         - {name: DB_USER, value: vmaas_sync}
         - {name: DB_PASSWD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
@@ -416,6 +425,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_JOBS}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: DB_DEBUG, value: '${DB_DEBUG_JOBS}'}
         - {name: DB_USER, value: vmaas_sync}
         - {name: DB_PASSWD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
@@ -450,6 +460,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_JOBS}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: DB_DEBUG, value: '${DB_DEBUG_JOBS}'}
         - {name: DB_USER, value: vmaas_sync}
         - {name: DB_PASSWD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
@@ -477,6 +488,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_JOBS}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: DB_DEBUG, value: '${DB_DEBUG_JOBS}'}
         - {name: DB_USER, value: vmaas_sync}
         - {name: DB_PASSWD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
@@ -504,6 +516,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_JOBS}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: DB_DEBUG, value: '${DB_DEBUG_JOBS}'}
         - {name: POD_CONFIG, value: '${JOBS_CONFIG}'}
 
@@ -528,6 +541,7 @@ objects:
         env:
         - {name: LOG_LEVEL, value: '${LOG_LEVEL_JOBS}'}
         - {name: GIN_MODE, value: '${GIN_MODE}'}
+        - {name: SENTRY_DSN, valueFrom: {secretKeyRef: {name: patchman-sentry, key: sentry-dsn}}}
         - {name: DB_DEBUG, value: '${DB_DEBUG_JOBS}'}
         - {name: DB_USER, value: vmaas_sync}
         - {name: DB_PASSWD, valueFrom: {secretKeyRef: {name: patchman-engine-database-passwords,
@@ -686,6 +700,15 @@ objects:
   kind: Secret
   metadata:
     name: kessel-service-client
+    namespace: test  # namespace is overwritten by bonfire
+  type: Opaque
+
+- apiVersion: v1
+  data:
+    sentry-dsn: ""
+  kind: Secret
+  metadata:
+    name: patchman-sentry
     namespace: test  # namespace is overwritten by bonfire
   type: Opaque
 

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -194,7 +194,7 @@ func runEvaluate(
 			event := <-ptEventC
 			event.Status = "error"
 			ptEventC <- event
-			utils.LogError("err", err.Error(), "inventoryID", inventoryID, "evalLabel", evalLabel,
+			utils.LogError("err", err, "inventoryID", inventoryID, "evalLabel", evalLabel,
 				"Eval message handling")
 		}
 		errc <- err
@@ -304,7 +304,7 @@ func getUpdatesData(ctx context.Context, system *models.SystemPlatformV2) (*vmaa
 		yumUpdates, yumErr = tryGetYumUpdates(system)
 		if yumErr != nil {
 			// ignore broken yum updates
-			utils.LogWarn("Can't parse yum_updates", yumErr.Error())
+			utils.LogWarn("err", yumErr, "Can't parse yum_updates")
 		}
 	}
 
@@ -314,14 +314,14 @@ func getUpdatesData(ctx context.Context, system *models.SystemPlatformV2) (*vmaa
 			// vmaas bad request means we either created wrong vmaas request
 			// or more likely we received package_list without epochs
 			// either way, we should skip this system and not fail hard which will cause pod to restart
-			utils.LogWarn("Vmaas response error - bad request, skipping system", vmaasErr.Error())
+			utils.LogWarn("err", vmaasErr, "Vmaas response error - bad request, skipping system")
 			return nil, nil
 		}
 		// if there's no yum update fail hard otherwise only log warning and use yum data
 		if yumUpdates == nil {
 			return nil, errors.Wrap(vmaasErr, vmaasErr.Error())
 		}
-		utils.LogWarn("Vmaas response error, continuing with yum updates only", vmaasErr.Error())
+		utils.LogWarn("err", vmaasErr, "Vmaas response error, continuing with yum updates only")
 	}
 
 	if system.Inventory.SatelliteManaged || system.Patch.TemplateID != nil {
@@ -500,7 +500,7 @@ func evaluateAndStore(system *models.SystemPlatformV2,
 		err = publishInventoryViewsEvent(tx, []models.SystemPlatformV2{*system}, event)
 		if err != nil {
 			evaluationCnt.WithLabelValues("error-inventory-views-publish").Inc()
-			utils.LogError("orgID", event.GetOrgID(), "inventoryID", system.GetInventoryID(), "err", err.Error(),
+			utils.LogError("orgID", event.GetOrgID(), "inventoryID", system.GetInventoryID(), "err", err,
 				"publishing inventory views event failed")
 		}
 	}
@@ -510,7 +510,7 @@ func evaluateAndStore(system *models.SystemPlatformV2,
 		err = publishNewAdvisoriesNotification(tx, system, event.GetOrgID(), systemAdvisoriesNew)
 		if err != nil {
 			evaluationCnt.WithLabelValues("error-advisory-notification").Inc()
-			utils.LogError("orgID", event.GetOrgID(), "inventoryID", system.GetInventoryID(), "err", err.Error(),
+			utils.LogError("orgID", event.GetOrgID(), "inventoryID", system.GetInventoryID(), "err", err,
 				"publishing new advisories notification failed")
 		}
 	}
@@ -519,7 +519,7 @@ func evaluateAndStore(system *models.SystemPlatformV2,
 		err = publishAdvisoryUpdates(system, advisoriesByName)
 		if err != nil {
 			evaluationCnt.WithLabelValues("error-advisory-update-publish").Inc()
-			utils.LogError("orgID", event.GetOrgID(), "inventoryID", system.GetInventoryID(), "err", err.Error(),
+			utils.LogError("orgID", event.GetOrgID(), "inventoryID", system.GetInventoryID(), "err", err,
 				"publishing advisory update event failed")
 		}
 	}
@@ -551,7 +551,7 @@ func analyzeRepos(system *models.SystemPlatformV2) (thirdParty bool, err error) 
 		Where("r.third_party = true").
 		Count(&thirdPartyCount).Error
 	if err != nil {
-		utils.LogWarn("err", err.Error(), "accountID", system.Inventory.RhAccountID, "systemID", system.Inventory.ID,
+		utils.LogWarn("err", err, "accountID", system.Inventory.RhAccountID, "systemID", system.Inventory.ID,
 			"counting third party repos")
 		return false, err
 	}
@@ -759,7 +759,7 @@ func evaluateHandler(event mqueue.PlatformEvent) error {
 	wg.Wait()
 
 	if cacheErr := invalidateCaches(event.GetOrgID()); cacheErr != nil {
-		utils.LogError("err", err.Error(), "org_id", event.GetOrgID(), "Couldn't invalidate caches")
+		utils.LogError("err", cacheErr, "org_id", event.GetOrgID(), "Couldn't invalidate caches")
 	}
 
 	// send kafka message to payload tracker
@@ -767,7 +767,7 @@ func evaluateHandler(event mqueue.PlatformEvent) error {
 		ptErr := mqueue.SendMessages(base.Context, ptWriter, &ptEvents)
 		if ptErr != nil {
 			// don't fail with err, just log that we couldn't send msg to payload tracker
-			utils.LogWarn("err", ptErr.Error(), WarnPayloadTracker)
+			utils.LogWarn("err", ptErr, WarnPayloadTracker)
 		}
 	}
 	return err

--- a/evaluator/evaluate_packages.go
+++ b/evaluator/evaluate_packages.go
@@ -69,7 +69,7 @@ func getMissingPackage(nevra string, parsed *utils.Nevra) *models.Package {
 		pkgName := models.PackageName{Name: parsed.Name}
 		err := updatePackageNameDB(&pkgName)
 		if err != nil {
-			utils.LogError("err", err.Error(), "nevra", nevra, "unknown package name insert failed")
+			utils.LogError("err", err, "nevra", nevra, "unknown package name insert failed")
 		}
 		pkg.NameID = pkgName.ID
 		if pkg.NameID == 0 {

--- a/evaluator/metrics.go
+++ b/evaluator/metrics.go
@@ -99,7 +99,7 @@ func RunMetrics() {
 	publicPort := utils.CoreCfg.PublicPort
 	err := utils.RunServer(base.Context, app, publicPort)
 	if err != nil {
-		utils.LogError("err", err.Error())
+		utils.LogError("err", err)
 		panic(err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.55.8
 	github.com/bytedance/sonic v1.15.2
 	github.com/getkin/kin-openapi v0.140.0
+	github.com/getsentry/sentry-go v0.47.0
 	github.com/gin-contrib/timeout v1.2.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/gocarina/gocsv v0.0.0-20260607070740-0735908c6461

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/getkin/kin-openapi v0.140.0 h1:JFn675aXRFjyiZKa/BFWploGldQlI0gobp4J5k0EZ2g=
 github.com/getkin/kin-openapi v0.140.0/go.mod h1:lISrB64F0CPcuDJ3LdtPTMJBY8VENjR9wJBdrcT6J3g=
+github.com/getsentry/sentry-go v0.47.0 h1:AnSMSyrYA5qZCIN/2xpgAAwv63sVULV+vBq37ajouc8=
+github.com/getsentry/sentry-go v0.47.0/go.mod h1:h+b4VHpKnK7aUXB5wc+KDnPgp9ZtfliRD4eV85FbiSA=
 github.com/gin-contrib/gzip v1.2.5 h1:fIZs0S+l17pIu1P5XRJOo/YNqfIuPCrZZ3TWB7pjckI=
 github.com/gin-contrib/gzip v1.2.5/go.mod h1:aomRgR7ftdZV3uWY0gW/m8rChfxau0n8YVvwlOHONzw=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=

--- a/listener/event_buffers.go
+++ b/listener/event_buffers.go
@@ -65,12 +65,12 @@ func (b *eventBuffer) flushEvalEvents() {
 	defer b.lock.Unlock()
 	err := mqueue.SendMessages(base.Context, *b.evalWriter, b.evalBuffer)
 	if err != nil {
-		utils.LogError("err", err.Error(), ErrorKafkaSend)
+		utils.LogError("err", err, ErrorKafkaSend)
 	}
 	utils.ObserveSecondsSince(tStart, messagePartDuration.WithLabelValues("buffer-sent-evaluator"))
 	err = mqueue.SendMessages(base.Context, *b.ptWriter, b.ptBuffer)
 	if err != nil {
-		utils.LogWarn("err", err.Error(), WarnPayloadTracker)
+		utils.LogWarn("err", err, WarnPayloadTracker)
 	}
 	utils.ObserveSecondsSince(tStart, messagePartDuration.WithLabelValues("buffer-sent-payload-tracker"))
 	utils.LogDebug("evaluator_messages", len(b.evalBuffer),

--- a/listener/events.go
+++ b/listener/events.go
@@ -73,7 +73,7 @@ func HandleDelete(event mqueue.PlatformEvent) error {
 		}).Error
 
 	if err != nil {
-		utils.LogError("inventoryID", event.ID, "err", err.Error(), "Could not delete system")
+		utils.LogError("inventoryID", event.ID, "err", err, "Could not delete system")
 		eventMsgsReceivedCnt.WithLabelValues(EventDelete, ReceivedErrorProcessing).Inc()
 		return errors.Wrap(err, "Could not delete system")
 	}
@@ -86,7 +86,7 @@ func HandleDelete(event mqueue.PlatformEvent) error {
 	err = query.Error
 	if err != nil {
 		wrappedErr := errors.Wrap(err, "Could not mark system as deleted")
-		utils.LogError("inventoryID", event.ID, "err", wrappedErr.Error())
+		utils.LogError("inventoryID", event.ID, "err", wrappedErr)
 		eventMsgsReceivedCnt.WithLabelValues(EventDelete, ReceivedErrorProcessing).Inc()
 		return wrappedErr
 	}

--- a/listener/metrics.go
+++ b/listener/metrics.go
@@ -91,7 +91,7 @@ func RunMetrics() {
 	publicPort := utils.CoreCfg.PublicPort
 	err := utils.RunServer(base.Context, app, publicPort)
 	if err != nil {
-		utils.LogError("err", err.Error())
+		utils.LogError("err", err)
 		panic(err)
 	}
 }

--- a/listener/templates.go
+++ b/listener/templates.go
@@ -24,7 +24,7 @@ const (
 func TemplatesMessageHandler(m mqueue.KafkaMessage) error {
 	eType, event, err := processTemplateEvent(m.Value)
 	if err != nil {
-		utils.LogError("msg", err.Error(), "skipping template event")
+		utils.LogError("err", err, "skipping template event")
 		// Skip invalid messages
 		return nil
 	}

--- a/listener/upload.go
+++ b/listener/upload.go
@@ -197,10 +197,10 @@ func handleListenerErrors(err error, event *HostEvent, ptEvent *mqueue.PayloadTr
 	if err != nil {
 		if errors.Is(err, base.ErrFatal) {
 			// fatal error which should restart the pod
-			utils.LogError("inventoryID", event.Host.ID, "err", err.Error())
+			utils.LogError("inventoryID", event.Host.ID, "err", err)
 		} else {
 			utils.LogWarn("inventoryID", event.Host.ID, "reporter", event.Host.Reporter,
-				"hostType", event.Host.SystemProfile.HostType, "err", err.Error())
+				"hostType", event.Host.SystemProfile.HostType, "err", err)
 		}
 	}
 	metric, ok := metricByErr[err]
@@ -264,7 +264,7 @@ func sendPayloadStatus(w mqueue.Writer, event mqueue.PayloadTrackerEvent, status
 		event.StatusMsg = statusMsg
 	}
 	if err := mqueue.SendMessages(base.Context, w, &event); err != nil {
-		utils.LogWarn("err", err.Error(), WarnPayloadTracker)
+		utils.LogWarn("err", err, WarnPayloadTracker)
 	}
 }
 

--- a/manager/controllers/advisory_detail.go
+++ b/manager/controllers/advisory_detail.go
@@ -141,7 +141,7 @@ func PreloadAdvisoryCacheItems() {
 	for _, advisoryName := range advisoryNames {
 		_, err = getAdvisory(database.DB, advisoryName, true)
 		if err != nil {
-			utils.LogError("advisoryName", advisoryName, "err", err.Error(), "can not re-load item to cache")
+			utils.LogError("advisoryName", advisoryName, "err", err, "can not re-load item to cache")
 		}
 		*count++
 	}

--- a/manager/controllers/systems.go
+++ b/manager/controllers/systems.go
@@ -147,7 +147,7 @@ func (v *SystemGroupsList) Scan(value interface{}) error {
 func SystemJSONBItemString[T SystemJSONBItemType](v T) string {
 	b, err := sonic.Marshal(v)
 	if err != nil {
-		utils.LogError("err", err.Error(), "Unable to convert tags struct to json")
+		utils.LogError("err", err, "Unable to convert tags struct to json")
 	}
 	replacedQuotes := strings.ReplaceAll(string(b), `"`, `'`) // use the same way as "vulnerability app"
 	return replacedQuotes

--- a/manager/kafka/kafka.go
+++ b/manager/kafka/kafka.go
@@ -46,7 +46,7 @@ func sendInventoryIDs(inventoryIDs mqueue.EvalDataSlice) {
 
 	err := mqueue.SendMessages(base.Context, evalWriter, &inventoryIDs)
 	if err != nil {
-		utils.LogError("nInventoryIDs", len(inventoryIDs), "err", err.Error(),
+		utils.LogError("nInventoryIDs", len(inventoryIDs), "err", err,
 			"Inventory IDs sending failed")
 	}
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -72,7 +72,7 @@ func RunManager() {
 
 	err := utils.RunServer(base.Context, app, port)
 	if err != nil {
-		utils.LogFatal("err", err.Error(), "server listening failed")
+		utils.LogFatal("err", err, "server listening failed")
 		panic(err)
 	}
 	utils.LogInfo("manager completed")

--- a/manager/middlewares/kessel.go
+++ b/manager/middlewares/kessel.go
@@ -74,7 +74,7 @@ func useStreamedListObjects(
 	) {
 		if err != nil {
 			utils.LogError(
-				"err", err.Error(), "durationMs", time.Since(start).Milliseconds(), "permission", permission,
+				"err", err, "durationMs", time.Since(start).Milliseconds(), "permission", permission,
 				"received_count", len(workspaces), "failed to useStreamedListObjects",
 			)
 			return nil, err
@@ -92,7 +92,7 @@ func useStreamedListObjects(
 func hasPermissionKessel(c *gin.Context) {
 	client, conn, err := setupClient()
 	if err != nil {
-		utils.LogError("err", err.Error(), "failed to setup Kessel service client")
+		utils.LogError("err", err, "failed to setup Kessel service client")
 		c.AbortWithStatusJSON(http.StatusInternalServerError, utils.ErrorResponse{
 			Error: "Unexpected server error", // missing cert or failed to make a new gRPC client
 		})
@@ -100,13 +100,13 @@ func hasPermissionKessel(c *gin.Context) {
 	}
 	defer func() {
 		if closeErr := conn.Close(); closeErr != nil {
-			utils.LogError("err", closeErr.Error(), "failed to close gRPC client")
+			utils.LogError("err", closeErr, "failed to close gRPC client")
 		}
 	}()
 
 	xrhid, err := utils.ParseXRHID(c.GetHeader("x-rh-identity"))
 	if err != nil {
-		utils.LogError("err", err.Error(), "failed to ParseXRHID")
+		utils.LogError("err", err, "failed to ParseXRHID")
 		c.AbortWithStatusJSON(http.StatusUnauthorized, utils.ErrorResponse{Error: "Invalid x-rh-identity header"})
 		return
 	}

--- a/manager/middlewares/rbac.go
+++ b/manager/middlewares/rbac.go
@@ -113,7 +113,7 @@ func isAccessGranted(c *gin.Context) bool {
 	}
 
 	if err != nil {
-		utils.LogError("err", err.Error(), "Call to RBAC svc failed")
+		utils.LogError("err", err, "Call to RBAC svc failed")
 		status := http.StatusInternalServerError
 		if res != nil {
 			status = res.StatusCode
@@ -128,7 +128,7 @@ func isAccessGranted(c *gin.Context) bool {
 	if granted {
 		workspaces, err := findInventoryWorkspaces(&access)
 		if err != nil {
-			utils.LogError("err", err.Error(), "RBAC")
+			utils.LogError("err", err, "RBAC")
 			granted = false
 		}
 		c.Set(utils.KeyInventoryWorkspaces, workspaces)

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -282,7 +282,7 @@ func mockUploadManyHandler(c *gin.Context) {
 	countParam := c.Param("count")
 	count, err := strconv.Atoi(countParam)
 	if err != nil {
-		utils.LogError("err", err.Error())
+		utils.LogError("err", err)
 		c.AbortWithStatus(http.StatusBadRequest)
 		return
 	}

--- a/tasks/caches/caches.go
+++ b/tasks/caches/caches.go
@@ -30,7 +30,7 @@ func RunPackageRefresh() {
 		utils.LogInfo("err", err, "Could not push to pushgateway")
 	}
 	if errRefresh != nil {
-		utils.LogError("err", errRefresh.Error(), "Refresh account packages caches")
+		utils.LogError("err", errRefresh, "Refresh account packages caches")
 		return
 	}
 	utils.LogInfo("Refreshed account packages caches")

--- a/tasks/caches/refresh_advisory_caches.go
+++ b/tasks/caches/refresh_advisory_caches.go
@@ -29,7 +29,7 @@ func refreshAdvisoryCachesPerAccounts(wg *sync.WaitGroup) {
 	}
 	utils.LogInfo("accounts", len(rhAccountIDs), "Starting advisory cache refresh for accounts")
 	if err != nil {
-		utils.LogError("err", err.Error(), "Unable to load rh_account table ids to refresh caches")
+		utils.LogError("err", err, "Unable to load rh_account table ids to refresh caches")
 		return
 	}
 
@@ -50,12 +50,12 @@ func refreshAdvisoryCachesPerAccounts(wg *sync.WaitGroup) {
 				return tx.Exec("select refresh_advisory_caches(NULL, ?)", rhAccountID).Error
 			})
 			if err != nil {
-				utils.LogError("err", err.Error(), "rh_account_id", rhAccountID,
+				utils.LogError("err", err, "rh_account_id", rhAccountID,
 					"Refreshed account advisory caches")
 				return
 			}
 			if err := updateAdvisoryCacheValidity(rhAccountID); err != nil {
-				utils.LogError("err", err.Error(), "rh_account_id", rhAccountID, "Refresh failed")
+				utils.LogError("err", err, "rh_account_id", rhAccountID, "Refresh failed")
 				return
 			}
 			utils.LogInfo("i", i, "rh_account_id", rhAccountID, "Refreshed account advisory cache")

--- a/tasks/caches/refresh_packages_caches.go
+++ b/tasks/caches/refresh_packages_caches.go
@@ -30,22 +30,22 @@ func RefreshPackagesCaches(accID *int) error {
 	for i, acc := range accs {
 		utils.LogInfo("account", acc, "#", i, "Refreshing account")
 		if err = getCounts(&pkgSysCounts, &acc); err != nil {
-			utils.LogError("err", err.Error(), "Refresh failed")
+			utils.LogError("err", err, "Refresh failed")
 			continue
 		}
 
 		if err = updatePackageAccountData(pkgSysCounts); err != nil {
-			utils.LogError("err", err.Error(), "Refresh failed")
+			utils.LogError("err", err, "Refresh failed")
 			continue
 		}
 
 		if err = deleteOldCache(pkgSysCounts, &acc); err != nil {
-			utils.LogError("err", err.Error(), "Refresh failed")
+			utils.LogError("err", err, "Refresh failed")
 			continue
 		}
 
 		if err = updatePkgCacheValidity(&acc); err != nil {
-			utils.LogError("err", err.Error(), "Refresh failed")
+			utils.LogError("err", err, "Refresh failed")
 			continue
 		}
 		utils.LogDebug("account", acc, "#", i, "Cache refreshed")

--- a/tasks/cleaning/clean_advisory_account_data.go
+++ b/tasks/cleaning/clean_advisory_account_data.go
@@ -14,7 +14,7 @@ func RunCleanAdvisoryAccountData() {
 	utils.LogInfo("Deleting advisory rows with 0 applicable systems from advisory_account_data")
 
 	if err := CleanAdvisoryAccountData(); err != nil {
-		utils.LogError("err", err.Error(), "Cleaning advisory account data")
+		utils.LogError("err", err, "Cleaning advisory account data")
 		return
 	}
 	utils.LogInfo("CleanAdvisoryAccountData task performed successfully")

--- a/tasks/cleaning/clean_unused_data.go
+++ b/tasks/cleaning/clean_unused_data.go
@@ -30,7 +30,7 @@ func deleteUnusedPackages() {
 	err := tx.Delete(&models.Package{}, "id IN (?)", subq).Error
 
 	if err != nil {
-		utils.LogError("err", err.Error(), "DeleteUnusedPackages")
+		utils.LogError("err", err, "DeleteUnusedPackages")
 		return
 	}
 
@@ -56,7 +56,7 @@ func deleteUnusedAdvisories() {
 	err := tx.Delete(&models.AdvisoryMetadata{}, "id IN (?)", subq).Error
 
 	if err != nil {
-		utils.LogError("err", err.Error(), "DeleteUnusedAdvisories")
+		utils.LogError("err", err, "DeleteUnusedAdvisories")
 		return
 	}
 

--- a/tasks/repack/repack.go
+++ b/tasks/repack/repack.go
@@ -75,7 +75,7 @@ func RunRepack() {
 	for table, columns := range TABLES {
 		err := Repack(table, columns)
 		if err != nil {
-			utils.LogError("err", err.Error(), fmt.Sprintf("Failed to repack table %s", table))
+			utils.LogError("err", err, fmt.Sprintf("Failed to repack table %s", table))
 			continue
 		}
 		utils.LogInfo(fmt.Sprintf("Successfully repacked table %s", table))

--- a/tasks/system_culling/system_culling.go
+++ b/tasks/system_culling/system_culling.go
@@ -41,7 +41,7 @@ func runSystemCulling() {
 	})
 
 	if err != nil {
-		utils.LogError("err", err.Error(), "System culling")
+		utils.LogError("err", err, "System culling")
 	} else {
 		utils.LogInfo("System culling tasks performed successfully")
 	}
@@ -70,7 +70,7 @@ func deleteCulledSystems(tx *gorm.DB, limitDeleted int) (nDeleted int64, err err
 			return nil
 		})
 		if delErr != nil {
-			utils.LogWarn("inventoryID", id, "err", delErr.Error(), "Delete culled system")
+			utils.LogWarn("inventoryID", id, "err", delErr, "Delete culled system")
 			continue
 		}
 		nDeleted += rowsAffected
@@ -110,7 +110,7 @@ func markSystemsStale(tx *gorm.DB, markedLimit int) (nMarked int64, err error) {
 			return nil
 		})
 		if markErr != nil {
-			utils.LogWarn("rhAccountID", c.RhAccountID, "systemID", c.ID, "err", markErr.Error(), "Mark stale system")
+			utils.LogWarn("rhAccountID", c.RhAccountID, "systemID", c.ID, "err", markErr, "Mark stale system")
 			continue
 		}
 		nMarked += rowsAffected

--- a/tasks/vmaas_sync/advisory_sync.go
+++ b/tasks/vmaas_sync/advisory_sync.go
@@ -137,7 +137,7 @@ func checkUpdatedSummaryDescription(errataName string, vmaasData vmaas.ErrataRes
 	if err != nil {
 		modified, err = time.Parse(time.RFC3339, vmaasData.Updated)
 		if err != nil {
-			utils.LogError("err", err.Error(), "erratum", errataName, "Invalid errata modified date")
+			utils.LogError("err", err, "erratum", errataName, "Invalid errata modified date")
 			return time.Time{}, false
 		}
 	}

--- a/tasks/vmaas_sync/metrics.go
+++ b/tasks/vmaas_sync/metrics.go
@@ -126,7 +126,7 @@ func update() {
 func updateSystemMetrics() {
 	counts, err := getSystemCounts()
 	if err != nil {
-		utils.LogError("err", err.Error(), "unable to update system metrics")
+		utils.LogError("err", err, "unable to update system metrics")
 		return
 	}
 
@@ -180,7 +180,7 @@ func getSystemCounts() (map[systemsCntLabels]int, error) {
 func updateAdvisoryMetrics() {
 	other, enh, bug, sec, err := getAdvisoryCounts()
 	if err != nil {
-		utils.LogError("err", err.Error(), "unable to update advisory metrics")
+		utils.LogError("err", err, "unable to update advisory metrics")
 	}
 	advisoriesCnt.WithLabelValues("other").Set(float64(other))
 	advisoriesCnt.WithLabelValues("enhancement").Set(float64(enh))
@@ -191,13 +191,13 @@ func updateAdvisoryMetrics() {
 func updatePackageMetrics() {
 	nPackages, err := getPackageCounts()
 	if err != nil {
-		utils.LogError("err", err.Error(), "unable to update package metrics")
+		utils.LogError("err", err, "unable to update package metrics")
 	}
 	packageCnt.Set(float64(nPackages))
 
 	nPackageNames, err := getPackageNameCounts()
 	if err != nil {
-		utils.LogError("err", err.Error(), "unable to update package_name metrics")
+		utils.LogError("err", err, "unable to update package_name metrics")
 	}
 	packageNameCnt.Set(float64(nPackageNames))
 }

--- a/tasks/vmaas_sync/metrics_db.go
+++ b/tasks/vmaas_sync/metrics_db.go
@@ -56,7 +56,7 @@ func getTableSizes() []keyValue {
         from (select * from pg_catalog.pg_tables where schemaname in ('public', 'inventory', 'repack')) t;`).
 		Find(&tableSizes).Error
 	if err != nil {
-		utils.LogError("err", err.Error(), "unable to get database table sizes")
+		utils.LogError("err", err, "unable to get database table sizes")
 	}
 	return tableSizes
 }
@@ -68,7 +68,7 @@ func getDatabaseSize() []keyValue {
 		fmt.Sprintf(`SELECT 'database' as key, pg_database_size('%s') as value;`, dbName)).
 		Find(&dbSize).Error
 	if err != nil {
-		utils.LogError("err", err.Error(), "unable to get database total size")
+		utils.LogError("err", err, "unable to get database total size")
 	}
 
 	return dbSize
@@ -80,7 +80,7 @@ func getDatabaseProcesses() []keyValue {
 		Select("COALESCE(usename, '-') as key, COUNT(*) as value, COALESCE(state, '-') state").
 		Group("key, state").Find(&usenameCounts).Error
 	if err != nil {
-		utils.LogError("err", err.Error(), "unable to get processes counts")
+		utils.LogError("err", err, "unable to get processes counts")
 	}
 
 	return usenameCounts

--- a/tasks/vmaas_sync/metrics_systems.go
+++ b/tasks/vmaas_sync/metrics_systems.go
@@ -45,7 +45,7 @@ var querySystemInventoryMetricColumns = database.MustGetSelect(&systemInventoryM
 func updateSystemInventoryData() {
 	tagStats, systemStats, err := getSystemInventoryData()
 	if err != nil {
-		utils.LogError("err", err.Error(), "unable to update system inventory metrics")
+		utils.LogError("err", err, "unable to update system inventory metrics")
 	}
 
 	for label, count := range tagStats {

--- a/tasks/vmaas_sync/send_messages.go
+++ b/tasks/vmaas_sync/send_messages.go
@@ -29,7 +29,7 @@ func SendReevaluationMessages() error {
 	defer utils.ObserveSecondsSince(time.Now(), messageSendDuration)
 	err = mqueue.SendMessages(base.Context, evalWriter, &inventoryAIDs)
 	if err != nil {
-		utils.LogError("err", err.Error(), "sending to re-evaluate failed")
+		utils.LogError("err", err, "sending to re-evaluate failed")
 	}
 	utils.LogInfo("count", len(inventoryAIDs), "systems sent to re-calc")
 	return nil

--- a/tasks/vmaas_sync/vmaas_sync.go
+++ b/tasks/vmaas_sync/vmaas_sync.go
@@ -53,12 +53,12 @@ func runSync() {
 		err := SyncData(lastModified, vmaasExportedTS)
 		if err != nil {
 			// This probably means programming error, better to exit with nonzero error code, so the error is noticed
-			utils.LogFatal("err", err.Error(), "vmaas data sync failed")
+			utils.LogFatal("err", err, "vmaas data sync failed")
 		}
 
 		err = SendReevaluationMessages()
 		if err != nil {
-			utils.LogError("err", err.Error(), "re-evaluation sending routine failed")
+			utils.LogError("err", err, "re-evaluation sending routine failed")
 		}
 	}
 }

--- a/turnpike/admin_api.go
+++ b/turnpike/admin_api.go
@@ -39,7 +39,7 @@ func RunAdminAPI() {
 
 	err := utils.RunServer(base.Context, app, utils.CoreCfg.PublicPort)
 	if err != nil {
-		utils.LogError("err", err.Error())
+		utils.LogError("err", err)
 		panic(err)
 	}
 }

--- a/turnpike/controllers/admin.go
+++ b/turnpike/controllers/admin.go
@@ -32,7 +32,7 @@ func Syncapi(c *gin.Context) {
 	vmaasExportedTS := sync.VmaasDBExported()
 	err := sync.SyncData(nil, vmaasExportedTS)
 	if err != nil {
-		utils.LogError("err", err.Error(), "manual called syncing failed")
+		utils.LogError("err", err, "manual called syncing failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
 		return
 	}
@@ -53,7 +53,7 @@ func Recalc(c *gin.Context) {
 	utils.LogInfo("manual re-calc messages sending called...")
 	err := sync.SendReevaluationMessages()
 	if err != nil {
-		utils.LogError("err", err.Error(), "manual re-calc msgs sending failed")
+		utils.LogError("err", err, "manual re-calc msgs sending failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
 		return
 	}
@@ -133,7 +133,7 @@ func RefreshPackagesAccountHandler(c *gin.Context) {
 	}
 	err = caches.RefreshPackagesCaches(&accID)
 	if err != nil {
-		utils.LogError("error", err.Error(), "Could not refresh package caches")
+		utils.LogError("error", err, "Could not refresh package caches")
 		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
 		return
 	}
@@ -170,7 +170,7 @@ func RepackHandler(c *gin.Context) {
 
 	err := repack.Repack(tableName, columns)
 	if err != nil {
-		utils.LogError("err", err.Error(), "manual repack call failed")
+		utils.LogError("err", err, "manual repack call failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"err": err.Error()})
 		return
 	}


### PR DESCRIPTION
This adds integration with GlitchTip through the sentry Go SDK. It will
try to set up the client if the sentry DSN is present in the config and
then capture exceptions and messages with error, fatal or panic level.
When captured some context is added, and then it's sent as an event.

_Related to GlitchTip logging, logging util functions calls were 
changed to **not** pass stringified errors as arguments._
> _[fix: stop stringifying errors when logging]_
> Errors don't need to be stringified when being passed into log functions
> as they will be turned into strings there. Having them as proper errors
> will enable better error logging with sentry/glitchtip, stack traces
> will be present.

Associated Ticket: [[RHINENG-26549](https://redhat.atlassian.net/browse/RHINENG-26549)]

[RHINENG-26549]: https://redhat.atlassian.net/browse/RHINENG-26549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ