### PR TITLE
HMS-9955: use template advisory information to determine installability of advisories

### DIFF
--- a/conf/evaluator_recalc.env
+++ b/conf/evaluator_recalc.env
@@ -1,3 +1,4 @@
 EVAL_TOPIC=patchman.evaluator.recalc
 
+# template_advisory_eval=false — template installability (enable on listener and evaluator pods)
 POD_CONFIG=label=recalc

--- a/conf/evaluator_upload.env
+++ b/conf/evaluator_upload.env
@@ -1,3 +1,4 @@
 EVAL_TOPIC=patchman.evaluator.upload
 
+# template_advisory_eval=false — template installability (enable on listener and evaluator pods)
 POD_CONFIG=label=upload

--- a/conf/evaluator_user_evaluation.env
+++ b/conf/evaluator_user_evaluation.env
@@ -1,3 +1,4 @@
 EVAL_TOPIC=patchman.evaluator.user-evaluation
 
+# template_advisory_eval=false — template installability + listener recalc (enable on listener and evaluator pods)
 POD_CONFIG=label=user-evaluation

--- a/conf/listener.env
+++ b/conf/listener.env
@@ -2,4 +2,5 @@ DB_USER=listener
 DB_PASSWD=listener
 CREATED_SYSTEMS_TOPIC=patchman.evaluator.user-evaluation
 
+# template_advisory_eval=false — recalc template systems on advisory change/delete (enable with evaluator pods)
 POD_CONFIG=

--- a/docs/md/architecture.md
+++ b/docs/md/architecture.md
@@ -19,6 +19,10 @@ on [this service](https://github.com/RedHatInsights/insights-rbac), however it c
 archive is uploaded, it upserts **`system_inventory`** (including `vmaas_json` with installed packages, repos, and modules) and the matching **`system_patch`** row. Upload locks and checksum logic apply to **`system_inventory`**. It registers repositories for the system by pairing `repo` with the internal system id (**`system_inventory.id`**) through **`system_repo`**. After that it sends a
 Kafka message (`patchman.evaluator.upload` topic) to evaluate the system with the `evaluator-upload` component. This
 component also handles system deleting events (`platform.inventory.events` Kafka topic).
+It consumes template events from Content Sources (`platform.content-sources.template`), upserts **`template`** metadata,
+and on `template-updated` syncs **`template_advisory`** rows from the Content Sources API. When template advisories
+change and `template_advisory_eval` is enabled, it sends a bulk re-evaluation message to
+`patchman.evaluator.user-evaluation`.
 See [component environment variables](../../conf/listener.env)
 
 - **evaluator-upload** - connects to the Kafka service (`patchman.evaluator.upload` topic) and listens for evaluation
@@ -32,8 +36,10 @@ See [component environment variables](../../conf/evaluator_upload.env)
 table). After this event all registered systems have to be re-evaluated because the input data for the system evaluation
 has changed. See [component environment variables](../../conf/evaluator_recalc.env)
 
-- **evaluator-user-evaluation** - same as the `-upload` instance, but listens for re-evaluation requests from the `manager` 
-component when user adds system to the template (`patchman.evaluator.user-evaluation` topic). The requests are separated 
+- **evaluator-user-evaluation** - same as the `-upload` instance, but listens for re-evaluation requests from the `manager`
+component when user adds or removes systems from a template, and from the `listener` when template advisory content
+changes (`patchman.evaluator.user-evaluation` topic). Recalc messages carry explicit `system_ids`; the listener
+resolves template-assigned systems before sending. The requests are separated
 as when there is a heavy load from inventory at the time it may take very long for systems to be recalculated/updated.
 See [component environment variables](../../conf/evaluator_user_evaluation.env)
 
@@ -61,3 +67,29 @@ and the [major migration runbook](major-migration-runbook.md). Using container C
 
 ### Components cooperation schema
 ![](graphics/schema.png)
+
+### Template content update flow
+
+When Content Sources publishes a `template-updated` event:
+
+1. **listener** upserts **`template`** metadata and calls Content Sources `GET /templates/{uuid}/advisories/ids`.
+2. **listener** diffs the response against **`template_advisory`** and inserts or deletes rows.
+3. If advisories changed and `template_advisory_eval=true`, **listener** looks up systems assigned to the
+   template and sends `PlatformEvent{system_ids}` to `patchman.evaluator.user-evaluation`.
+4. **evaluator-user-evaluation** re-evaluates each system in the message.
+5. For template-assigned systems, **evaluator** skips yum updates, calls VMaaS, and marks advisories in
+   **`template_advisory`** as installable; other applicable advisories remain applicable.
+
+### `template_advisory_eval` rollout
+
+One flag controls the full template-advisory feature. Set `template_advisory_eval=true` in `POD_CONFIG` on:
+
+- **listener** — triggers re-evaluation when template advisory content changes or a template is deleted
+- **evaluator-upload**, **evaluator-user-evaluation**, and **evaluator-recalc** — applies installability from
+  **`template_advisory`** for template-assigned systems
+
+Default is `false` everywhere. Enable listener and evaluator pods together; listener-only leaves advisories synced but
+installability unchanged, evaluator-only leaves content changes without automatic recalc.
+
+This is separate from **manager** `template_change_eval`, which still controls recalc when users assign or remove systems
+via the REST API.

--- a/docs/md/database.md
+++ b/docs/md/database.md
@@ -11,6 +11,12 @@ Main database tables description:
 - **package_name** - names of the packages installed on systems
 - **package** - list of all packages versions, precisely all EVRAs (epoch-version-release-arch)
 - **system_package2** - list of packages installed on a system
+- **template** - Content Sources template metadata per account (`rh_account_id`, `id`, `uuid`, `name`, `environment_id`,
+  `arch`, `version`, etc.). Upserted by **listener** from `platform.content-sources.template` events.
+- **template_advisory** - junction table linking a **template** to **advisory_metadata** rows
+  (`rh_account_id`, `template_id`, `advisory_id`). Populated by **listener** on `template-updated` from Content Sources.
+  Read by **evaluator** (when `template_advisory_eval=true`) to determine which advisories are installable for systems
+  assigned via **`system_patch.template_id`**. The same flag on **listener** triggers re-evaluation when rows change.
 
 ## Schema
 The ERD image below may lag `database_admin/schema/create_schema.sql`; for systems it may not reflect the split between **system_inventory** (host profile / upload payload) and **system_patch** (evaluation caches and aggregates).

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -63,6 +63,7 @@ var (
 	enableInventoryViews          bool
 	enableAdvisoryUpdates         bool
 	enableSatelliteFunctionality  bool
+	enableTemplateAdvisoryEval    bool
 	errVmaasBadRequest            = errors.New("vmaas bad request")
 )
 
@@ -137,6 +138,8 @@ func configureEvaluator() {
 	enableAdvisoryUpdates = utils.PodConfig.GetBool("advisory_updates", false)
 	// Ignore templates for satellite managed systems
 	enableSatelliteFunctionality = utils.PodConfig.GetBool("satellite_functionality", true)
+	// template_advisory_eval — template installability from template_advisory
+	enableTemplateAdvisoryEval = utils.PodConfig.GetBool("template_advisory_eval", false)
 }
 
 func Evaluate(ctx context.Context, event *mqueue.PlatformEvent, inventoryID uuid.UUID, evaluationType string) error {
@@ -298,9 +301,13 @@ func evaluateWithVmaas(updatesData *vmaas.UpdatesV3Response,
 func getUpdatesData(ctx context.Context, system *models.SystemPlatformV2) (*vmaas.UpdatesV3Response, error) {
 	defer utils.ObserveSecondsSince(time.Now(), evaluationPartDuration.WithLabelValues("get-updates-data"))
 
+	if useTemplateAdvisoryEval(system) {
+		return getTemplateAdvisoryUpdatesData(ctx, system)
+	}
+
 	var yumUpdates *vmaas.UpdatesV3Response
-	var yumErr error
 	if enableYumUpdatesEval {
+		var yumErr error
 		yumUpdates, yumErr = tryGetYumUpdates(system)
 		if yumErr != nil {
 			// ignore broken yum updates
@@ -325,7 +332,8 @@ func getUpdatesData(ctx context.Context, system *models.SystemPlatformV2) (*vmaa
 	}
 
 	if system.Inventory.SatelliteManaged || system.Patch.TemplateID != nil {
-		// satellite managed systems and systems using template has vmaas updates APPLICABLE instead of INSTALLABLE
+		// satellite managed systems and template-assigned systems (when template_advisory_eval is off)
+		// have vmaas updates APPLICABLE instead of INSTALLABLE; yum updates may still be INSTALLABLE
 		mergedUpdateList := vmaasData.GetUpdateList()
 		for nevra := range mergedUpdateList {
 			(*mergedUpdateList[nevra]).SetUpdatesInstallability(APPLICABLE)

--- a/evaluator/template_advisory.go
+++ b/evaluator/template_advisory.go
@@ -1,0 +1,81 @@
+package evaluator
+
+import (
+	"app/base/database"
+	"app/base/models"
+	"app/base/utils"
+	"app/base/vmaas"
+	"context"
+
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+)
+
+func useTemplateAdvisoryEval(system *models.SystemPlatformV2) bool {
+	return enableTemplateAdvisoryEval && system.Patch.TemplateID != nil &&
+		!system.Inventory.SatelliteManaged
+}
+
+// getTemplateAdvisoryUpdatesData evaluates template-assigned systems using VMaaS only.
+// Yum updates are intentionally not merged; installability comes from template_advisory.
+func getTemplateAdvisoryUpdatesData(ctx context.Context, system *models.SystemPlatformV2) (
+	*vmaas.UpdatesV3Response, error) {
+	vmaasData, vmaasErr := getVmaasUpdates(ctx, system)
+	if vmaasErr != nil {
+		if errors.Is(vmaasErr, errVmaasBadRequest) {
+			utils.LogWarn("Vmaas response error - bad request, skipping system", vmaasErr.Error())
+			return nil, nil
+		}
+		return nil, errors.Wrap(vmaasErr, vmaasErr.Error())
+	}
+	if vmaasData == nil {
+		return nil, nil
+	}
+
+	templateErrata, err := loadTemplateAdvisoryErrata(database.DB, system.Inventory.RhAccountID,
+		*system.Patch.TemplateID)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading template advisories")
+	}
+	applyTemplateAdvisoryInstallability(vmaasData, templateErrata)
+	return vmaasData, nil
+}
+
+func loadTemplateAdvisoryErrata(tx *gorm.DB, accountID int, templateID int64) (map[string]struct{}, error) {
+	var data []models.TemplateAdvisory
+	err := tx.Preload("Advisory").
+		Find(&data, "template_id = ? AND rh_account_id = ?", templateID, accountID).Error
+	if err != nil {
+		return nil, err
+	}
+
+	errata := make(map[string]struct{}, len(data))
+	for _, ta := range data {
+		errata[ta.Advisory.Name] = struct{}{}
+	}
+	return errata, nil
+}
+
+func applyTemplateAdvisoryInstallability(vmaasData *vmaas.UpdatesV3Response, templateErrata map[string]struct{}) {
+	if vmaasData == nil {
+		return
+	}
+	updateList := vmaasData.GetUpdateList()
+	for _, updates := range updateList {
+		if updates == nil || updates.AvailableUpdates == nil {
+			continue
+		}
+		for i := range *updates.AvailableUpdates {
+			u := &(*updates.AvailableUpdates)[i]
+			erratum := u.GetErratum()
+			if len(erratum) == 0 {
+				continue
+			}
+			if _, inTemplate := templateErrata[erratum]; inTemplate {
+				u.SetInstallability(INSTALLABLE)
+			} else {
+				u.SetInstallability(APPLICABLE)
+			}
+		}
+	}
+}

--- a/evaluator/template_advisory.go
+++ b/evaluator/template_advisory.go
@@ -26,7 +26,7 @@ func getTemplateAdvisoryUpdatesData(ctx context.Context, system *models.SystemPl
 			utils.LogWarn("Vmaas response error - bad request, skipping system", vmaasErr.Error())
 			return nil, nil
 		}
-		return nil, errors.Wrap(vmaasErr, vmaasErr.Error())
+		return nil, errors.Wrap(vmaasErr, "getting vmaas updates for template-advisory evaluation")
 	}
 	if vmaasData == nil {
 		return nil, nil

--- a/evaluator/template_advisory_e2e_test.go
+++ b/evaluator/template_advisory_e2e_test.go
@@ -1,0 +1,161 @@
+package evaluator
+
+import (
+	"app/base/core"
+	"app/base/database"
+	"app/base/models"
+	"app/base/mqueue"
+	"app/base/utils"
+	"app/listener"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func prepareTemplateAdvisoryIntegrationTest() {
+	configure()
+	enableTemplateAdvisoryEval = true
+	enableVmaasCache = false
+	loadCache()
+	remediationsPublisher = &mqueue.MockKafkaWriter{}
+}
+
+func evaluateHandlerForTest(event mqueue.PlatformEvent) error {
+	return evaluateHandler(event)
+}
+
+// nolint: funlen
+func TestTemplateAdvisoryEvalE2E(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	utils.SkipWithoutPlatform(t)
+	core.SetupTestEnvironment()
+
+	mockWriter, cleanupListener := listener.InitForTemplateAdvisoryIntegrationTest(t)
+	defer cleanupListener()
+
+	const accountID = 1
+	const orgID = "org_1"
+	templateUUID := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	inventoryID := uuid.MustParse("00000000-0000-0000-0000-0000000000e1")
+	vmaasJSON := `{ "package_list": [ "firefox-0:76.0.1-1.fc31.x86_64", "kernel-0:5.6.13-200.fc31.x86_64" ], "repository_list": [ "repo1" ] }` //nolint:lll
+
+	systemInv := createE2ETestSystem(t, inventoryID, accountID, vmaasJSON)
+	database.CreateSystemRepos(t, accountID, systemInv.ID, []int64{1})
+	t.Cleanup(func() {
+		database.DeleteSystemRepos(t, accountID, systemInv.ID, []int64{1})
+		database.DeleteTemplate(t, accountID, templateUUID)
+		deleteE2ETestSystem(t, inventoryID)
+	})
+
+	database.CreateTemplate(t, accountID, templateUUID, []uuid.UUID{inventoryID})
+
+	var template models.Template
+	err := database.DB.Where("rh_account_id = ? AND uuid = ?::uuid", accountID, templateUUID).First(&template).Error
+	require.NoError(t, err)
+
+	database.CreateTemplateAdvisories(t, accountID, template.ID, []int64{1, 2})
+	defer database.DeleteTemplateAdvisories(t, template.ID, []int64{1, 2, 3})
+
+	database.DeleteSystemAdvisories(t, systemInv.ID, []int64{1, 2, 3, 100})
+	database.DeleteAdvisoryAccountData(t, accountID, []int64{1, 2, 3, 100})
+
+	description := "e2e template"
+	updateEvent := mqueue.TemplateEvent{
+		Type:  "com.redhat.console.repositories." + listener.TemplateEventUpdate,
+		OrgID: orgID,
+		Data: []mqueue.TemplateResponse{{
+			UUID:          templateUUID,
+			EnvironmentID: strings.ReplaceAll(templateUUID, "-", ""),
+			Name:          "e2e-template",
+			OrgID:         orgID,
+			Description:   &description,
+			Date:          time.Now(),
+			Arch:          "x86_64",
+			Version:       "8",
+		}},
+	}
+	msg, err := sonic.Marshal(updateEvent)
+	require.NoError(t, err)
+
+	err = listener.TemplatesMessageHandler(mqueue.KafkaMessage{Value: msg})
+	require.NoError(t, err)
+
+	database.CheckTemplateAdvisories(t, template.ID, []int64{1, 3})
+	require.Equal(t, 1, len(mockWriter.Messages))
+
+	var recalcEvent mqueue.PlatformEvent
+	require.NoError(t, sonic.Unmarshal(mockWriter.Messages[0].Value, &recalcEvent))
+	require.Equal(t, accountID, recalcEvent.AccountID)
+	require.Equal(t, orgID, recalcEvent.GetOrgID())
+	require.Equal(t, []uuid.UUID{inventoryID}, recalcEvent.SystemIDs)
+
+	prepareTemplateAdvisoryIntegrationTest()
+	err = evaluateHandlerForTest(recalcEvent)
+	require.NoError(t, err)
+
+	assertSystemAdvisoryStatus(t, systemInv.ID, "RH-1", INSTALLABLE)
+	assertSystemAdvisoryStatus(t, systemInv.ID, "RH-2", APPLICABLE)
+	assertSystemAdvisoryStatus(t, systemInv.ID, "RH-100", APPLICABLE)
+}
+
+func createE2ETestSystem(t *testing.T, inventoryID uuid.UUID, accountID int, vmaasJSON string) models.SystemInventory {
+	t.Helper()
+	inv := models.SystemInventory{
+		InventoryID:  inventoryID,
+		RhAccountID:  accountID,
+		DisplayName:  "template-advisory-e2e",
+		Tags:         []byte("[]"),
+		VmaasJSON:    &vmaasJSON,
+		JSONChecksum: strPtr("e2e-template-advisory"),
+	}
+	require.NoError(t, database.DB.Create(&inv).Error)
+	require.NoError(t, database.DB.Create(&models.SystemPatch{
+		SystemID:    inv.ID,
+		RhAccountID: accountID,
+	}).Error)
+	return inv
+}
+
+func deleteE2ETestSystem(t *testing.T, inventoryID uuid.UUID) {
+	t.Helper()
+	var inv models.SystemInventory
+	err := database.DB.Where("inventory_id = ?", inventoryID).First(&inv).Error
+	if err != nil {
+		return
+	}
+	require.NoError(t, database.DB.Unscoped().
+		Where("rh_account_id = ? AND system_id = ?", inv.RhAccountID, inv.ID).
+		Delete(&models.SystemAdvisories{}).Error)
+	require.NoError(t, database.DB.Unscoped().
+		Where("rh_account_id = ? AND system_id = ?", inv.RhAccountID, inv.ID).
+		Delete(&models.SystemPackage{}).Error)
+	require.NoError(t, database.DB.Unscoped().
+		Where("rh_account_id = ? AND system_id = ?", inv.RhAccountID, inv.ID).
+		Delete(&models.SystemRepo{}).Error)
+	require.NoError(t, database.DB.Unscoped().Exec(
+		"DELETE FROM system_patch WHERE rh_account_id = ? AND system_id = ?",
+		inv.RhAccountID, inv.ID).Error)
+	require.NoError(t, database.DB.Unscoped().Where("inventory_id = ?", inventoryID).
+		Delete(&models.SystemInventory{}).Error)
+}
+
+func assertSystemAdvisoryStatus(t *testing.T, systemID int64, advisoryName string, expectedStatus int) {
+	t.Helper()
+	var systemAdvisory models.SystemAdvisories
+	err := database.DB.Table("system_advisories sa").
+		Select("sa.*").
+		Joins("JOIN advisory_metadata am ON am.id = sa.advisory_id").
+		Where("sa.system_id = ? AND am.name = ?", systemID, advisoryName).
+		First(&systemAdvisory).Error
+	require.NoError(t, err)
+	assert.Equal(t, expectedStatus, systemAdvisory.StatusID)
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/evaluator/template_advisory_test.go
+++ b/evaluator/template_advisory_test.go
@@ -1,0 +1,183 @@
+package evaluator
+
+import (
+	"app/base/core"
+	"app/base/database"
+	"app/base/models"
+	"app/base/utils"
+	"app/base/vmaas"
+	"context"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyTemplateAdvisoryInstallability(t *testing.T) {
+	erratumInstallable := "RHSA-2023:3246"
+	erratumApplicable := "RHSA-2023:3240"
+	vmaasDataResp := `
+	{
+		"update_list": {
+			"git-2.30.1-1.el8_8.x86_64": {
+				"available_updates": [
+					{
+						"erratum": "RHSA-2023:3246",
+						"package": "git-2.39.3-1.el8_8.x86_64"
+					},
+					{
+						"erratum": "RHSA-2023:3240",
+						"package": "git-2.39.4-1.el8_8.x86_64"
+					}
+				]
+			}
+		}
+	}
+	`
+	var vmaasData vmaas.UpdatesV3Response
+	err := sonic.Unmarshal([]byte(vmaasDataResp), &vmaasData)
+	assert.Nil(t, err)
+
+	templateErrata := map[string]struct{}{
+		erratumInstallable: {},
+	}
+	applyTemplateAdvisoryInstallability(&vmaasData, templateErrata)
+
+	updateList := vmaasData.GetUpdateList()["git-2.30.1-1.el8_8.x86_64"].GetAvailableUpdates()
+	assert.Equal(t, 2, len(updateList))
+	assert.Equal(t, INSTALLABLE, updateList[0].StatusID)
+	assert.Equal(t, erratumInstallable, updateList[0].GetErratum())
+	assert.Equal(t, APPLICABLE, updateList[1].StatusID)
+	assert.Equal(t, erratumApplicable, updateList[1].GetErratum())
+}
+
+func TestLoadTemplateAdvisoryErrata(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+
+	templateID := int64(1)
+	database.CreateTemplateAdvisories(t, 1, templateID, []int64{1, 2})
+	defer database.DeleteTemplateAdvisories(t, templateID, []int64{1, 2})
+
+	errata, err := loadTemplateAdvisoryErrata(database.DB, 1, templateID)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(errata))
+	_, ok := errata["RH-1"]
+	assert.True(t, ok)
+	_, ok = errata["RH-2"]
+	assert.True(t, ok)
+}
+
+//nolint:funlen
+func TestGetUpdatesDataTemplateAdvisoryEval(t *testing.T) {
+	vmaasJSON := `
+	{
+		"package_list": ["git-2.30.1-1.el8_8.x86_64"],
+		"repository_list": ["rhel-8-for-x86_64-appstream-rpms"],
+		"releasever": "8",
+		"basearch": "x86_64",
+		"latest_only": true
+	}
+	`
+	vmaasDataResp := `
+	{
+		"update_list": {
+			"git-2.30.1-1.el8_8.x86_64": {
+				"available_updates": [
+					{
+						"erratum": "RH-1",
+						"package": "git-2.39.3-1.el8_8.x86_64"
+					},
+					{
+						"erratum": "RH-2",
+						"package": "git-2.39.4-1.el8_8.x86_64"
+					}
+				]
+			}
+		}
+	}
+	`
+	yumUpdatesRaw := []byte(`
+	{
+		"update_list": {
+			"git-2.30.1-1.el8_8.x86_64": {
+				"available_updates": [
+					{
+						"erratum": "RH-100",
+						"package": "git-9.9.9-1.el8_8.x86_64"
+					}
+				]
+			}
+		}
+	}
+	`)
+
+	var vmaasData vmaas.UpdatesV3Response
+	assert.Nil(t, sonic.Unmarshal([]byte(vmaasDataResp), &vmaasData))
+	vmaasJSONChecksum := "template-advisory-eval-test"
+
+	templateID := int64(1)
+	system := &models.SystemPlatformV2{
+		Inventory: models.SystemInventory{
+			RhAccountID:  1,
+			JSONChecksum: &vmaasJSONChecksum,
+			VmaasJSON:    &vmaasJSON,
+			YumUpdates:   yumUpdatesRaw,
+		},
+		Patch: models.SystemPatch{
+			TemplateID: &templateID,
+		},
+	}
+
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+	configure()
+	loadCache()
+
+	ogYum := enableYumUpdatesEval
+	ogTemplateEval := enableTemplateAdvisoryEval
+	enableYumUpdatesEval = true
+	enableTemplateAdvisoryEval = true
+	defer func() {
+		enableYumUpdatesEval = ogYum
+		enableTemplateAdvisoryEval = ogTemplateEval
+	}()
+
+	memoryVmaasCache.Add(&vmaasJSONChecksum, &vmaasData)
+	database.CreateTemplateAdvisories(t, 1, templateID, []int64{1})
+	defer database.DeleteTemplateAdvisories(t, templateID, []int64{1})
+
+	result, err := getUpdatesData(context.Background(), system)
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+
+	var installableCnt, applicableCnt int
+	for _, updates := range result.GetUpdateList() {
+		for _, update := range updates.GetAvailableUpdates() {
+			switch update.StatusID {
+			case INSTALLABLE:
+				installableCnt++
+			case APPLICABLE:
+				applicableCnt++
+			}
+		}
+	}
+	assert.Equal(t, 1, installableCnt)
+	assert.Equal(t, 1, applicableCnt)
+}
+
+func TestUseTemplateAdvisoryEval(t *testing.T) {
+	templateID := int64(1)
+	system := &models.SystemPlatformV2{
+		Patch: models.SystemPatch{TemplateID: &templateID},
+	}
+
+	ogTemplateEval := enableTemplateAdvisoryEval
+	enableTemplateAdvisoryEval = true
+	defer func() { enableTemplateAdvisoryEval = ogTemplateEval }()
+
+	assert.True(t, useTemplateAdvisoryEval(system))
+
+	system.Inventory.SatelliteManaged = true
+	assert.False(t, useTemplateAdvisoryEval(system))
+}

--- a/listener/common_test.go
+++ b/listener/common_test.go
@@ -49,6 +49,7 @@ func deleteData(t *testing.T) {
 	assert.Nil(t, database.DB.Unscoped().Where("inventory_id = ?", testInventoryID).Delete(&models.DeletedSystem{}).Error)
 }
 
+// nolint: unparam
 func createTestSystemInDB(t *testing.T, inventoryID uuid.UUID, rhAccountID int, displayName string) {
 	t.Helper()
 	inv := models.SystemInventory{
@@ -62,6 +63,26 @@ func createTestSystemInDB(t *testing.T, inventoryID uuid.UUID, rhAccountID int, 
 		SystemID:    inv.ID,
 		RhAccountID: rhAccountID,
 	}).Error)
+}
+
+func deleteTestSystemInDB(t *testing.T, inventoryID uuid.UUID) {
+	t.Helper()
+	var inv models.SystemInventory
+	err := database.DB.Where("inventory_id = ?", inventoryID).First(&inv).Error
+	if err != nil {
+		return
+	}
+	assert.NoError(t, database.DB.Unscoped().
+		Where("rh_account_id = ? AND system_id = ?", inv.RhAccountID, inv.ID).
+		Delete(&models.SystemAdvisories{}).Error)
+	assert.NoError(t, database.DB.Unscoped().
+		Where("rh_account_id = ? AND system_id = ?", inv.RhAccountID, inv.ID).
+		Delete(&models.SystemPackage{}).Error)
+	assert.NoError(t, database.DB.Unscoped().Exec(
+		"DELETE FROM system_patch WHERE rh_account_id = ? AND system_id = ?",
+		inv.RhAccountID, inv.ID).Error)
+	assert.NoError(t, database.DB.Unscoped().Where("inventory_id = ?", inventoryID).
+		Delete(&models.SystemInventory{}).Error)
 }
 
 // nolint: unparam

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -16,21 +16,22 @@ import (
 )
 
 var (
-	eventsTopic          string
-	eventsConsumers      int
-	enableTemplates      bool
-	templatesTopic       string
-	templatesConsumers   int
-	evalWriter           mqueue.Writer
-	createdSystemsWriter mqueue.Writer
-	ptWriter             mqueue.Writer
-	validReporters       map[string]int
-	allowedReporters     map[string]bool
-	excludedHostTypes    map[string]bool
-	enableBypass         bool
-	uploadEvalTimeout    time.Duration
-	deletionThreshold    time.Duration
-	useTraceLevel        bool
+	eventsTopic                string
+	eventsConsumers            int
+	enableTemplates            bool
+	templatesTopic             string
+	templatesConsumers         int
+	evalWriter                 mqueue.Writer
+	createdSystemsWriter       mqueue.Writer
+	ptWriter                   mqueue.Writer
+	validReporters             map[string]int
+	allowedReporters           map[string]bool
+	excludedHostTypes          map[string]bool
+	enableBypass               bool
+	enableTemplateAdvisoryEval bool
+	uploadEvalTimeout          time.Duration
+	deletionThreshold          time.Duration
+	useTraceLevel              bool
 
 	// Event buffers
 	eventBufferSize     = 5 * mqueue.BatchSize
@@ -85,6 +86,8 @@ func configureListener() {
 	excludedHostTypes = utils.PodConfig.GetStringSet("excluded_host_types", "edge")
 	// Toggle bypass (fake) messages processing
 	enableBypass = utils.PodConfig.GetBool("bypass", false)
+	// Template advisory evaluation: recalc on advisory content change and template delete
+	enableTemplateAdvisoryEval = utils.PodConfig.GetBool("template_advisory_eval", false)
 	// How long to collect upload messages before grouping them and sending to evaluator
 	uploadEvalTimeout = time.Duration(utils.PodConfig.GetInt("upload_eval_timeout_ms", 500)) * time.Millisecond
 	// Ignore a system if there was a delete message in the last X hours

--- a/listener/template_advisories.go
+++ b/listener/template_advisories.go
@@ -13,7 +13,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func syncTemplateAdvisories(ctx context.Context, accountID int, templateID int64, templateUUID string) error {
+func syncTemplateAdvisories(ctx context.Context, accountID int, templateID int64, templateUUID, orgID string) error {
 	current, err := callCSTemplateAdvisories(ctx, templateUUID)
 	if err != nil {
 		return errors.Wrap(err, "fetching current template advisories from content-sources")
@@ -59,7 +59,16 @@ func syncTemplateAdvisories(ctx context.Context, accountID int, templateID int64
 		"template advisories synced",
 	)
 
-	return tx.Commit().Error
+	err = tx.Commit().Error
+	if err != nil {
+		return err
+	}
+
+	if err := SendTemplateRecalc(accountID, orgID, templateID); err != nil {
+		utils.LogError("err", err.Error(), "template_id", templateID, "account_id", accountID,
+			"Template recalc lookup failed")
+	}
+	return nil
 }
 
 // Returns advisories currently stored for the template

--- a/listener/template_advisories_test.go
+++ b/listener/template_advisories_test.go
@@ -128,7 +128,7 @@ func TestSyncTemplateAdvisories(t *testing.T) {
 
 	// content sources mock returns RH-1 and RH-3 so we need to add RH-3, remove RH-2
 	ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(orgID))
-	err := syncTemplateAdvisories(ctx, accountID, templateID, templateUUID)
+	err := syncTemplateAdvisories(ctx, accountID, templateID, templateUUID, orgID)
 	assert.Nil(t, err)
 
 	// RH-3 and RH-1 now linked to the template

--- a/listener/template_recalc.go
+++ b/listener/template_recalc.go
@@ -1,0 +1,75 @@
+package listener
+
+import (
+	"app/base"
+	"app/base/database"
+	"app/base/mqueue"
+	"app/base/utils"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"gorm.io/gorm"
+)
+
+func lookupTemplateSystemInventoryIDs(tx *gorm.DB, accountID int, templateID int64) ([]uuid.UUID, error) {
+	var inventoryIDs []uuid.UUID
+	err := tx.Table("system_patch sp").
+		Select("si.inventory_id").
+		Joins("JOIN system_inventory si ON si.id = sp.system_id AND si.rh_account_id = sp.rh_account_id").
+		Where("sp.rh_account_id = ? AND sp.template_id = ?", accountID, templateID).
+		Scan(&inventoryIDs).Error
+	if err != nil {
+		return nil, errors.Wrap(err, "looking up template systems")
+	}
+	return inventoryIDs, nil
+}
+
+func inventoryIDsToEvalData(accountID int, orgID string, inventoryIDs []uuid.UUID) mqueue.EvalDataSlice {
+	evalDataList := make(mqueue.EvalDataSlice, 0, len(inventoryIDs))
+	for _, id := range inventoryIDs {
+		evalDataList = append(evalDataList, mqueue.EvalData{
+			InventoryID: id,
+			RhAccountID: accountID,
+			OrgID:       &orgID,
+		})
+	}
+	return evalDataList
+}
+
+// SendTemplateRecalc looks up systems assigned to the template and requests their re-evaluation.
+// Call before unassigning systems from a deleted template so inventory IDs are still known.
+func SendTemplateRecalc(accountID int, orgID string, templateID int64) error {
+	if !enableTemplateAdvisoryEval {
+		return nil
+	}
+	if orgID == "" {
+		utils.LogWarn("template_id", templateID, "account_id", accountID, "skipping template recalc: missing org_id")
+		return nil
+	}
+	inventoryIDs, err := lookupTemplateSystemInventoryIDs(database.DB, accountID, templateID)
+	if err != nil {
+		return err
+	}
+	SendTemplateSystemsRecalc(accountID, orgID, inventoryIDs)
+	return nil
+}
+
+// SendTemplateSystemsRecalc requests re-evaluation of explicit systems.
+func SendTemplateSystemsRecalc(accountID int, orgID string, inventoryIDs []uuid.UUID) {
+	if !enableTemplateAdvisoryEval {
+		return
+	}
+	if orgID == "" {
+		utils.LogWarn("account_id", accountID, "nSystems", len(inventoryIDs),
+			"skipping template systems recalc: missing org_id")
+		return
+	}
+	if len(inventoryIDs) == 0 {
+		return
+	}
+	err := mqueue.SendMessages(base.Context, createdSystemsWriter, inventoryIDsToEvalData(accountID, orgID, inventoryIDs))
+	if err != nil {
+		utils.LogError("err", err.Error(), "account_id", accountID, "nSystems", len(inventoryIDs),
+			"Template systems recalc message sending failed")
+	}
+}

--- a/listener/template_recalc_test.go
+++ b/listener/template_recalc_test.go
@@ -1,0 +1,132 @@
+package listener
+
+import (
+	"app/base/core"
+	"app/base/database"
+	"app/base/models"
+	"app/base/mqueue"
+	"app/base/utils"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendTemplateRecalcDisabled(t *testing.T) {
+	originalFlag := enableTemplateAdvisoryEval
+	originalWriter := createdSystemsWriter
+	defer func() {
+		enableTemplateAdvisoryEval = originalFlag
+		createdSystemsWriter = originalWriter
+	}()
+
+	mockWriter := &mqueue.MockKafkaWriter{}
+	createdSystemsWriter = mockWriter
+	enableTemplateAdvisoryEval = false
+
+	err := SendTemplateRecalc(1, "org_1", 42)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(mockWriter.Messages))
+}
+
+func TestSendTemplateRecalcSkipsEmptyOrgID(t *testing.T) {
+	originalFlag := enableTemplateAdvisoryEval
+	originalWriter := createdSystemsWriter
+	defer func() {
+		enableTemplateAdvisoryEval = originalFlag
+		createdSystemsWriter = originalWriter
+	}()
+
+	mockWriter := &mqueue.MockKafkaWriter{}
+	createdSystemsWriter = mockWriter
+	enableTemplateAdvisoryEval = true
+
+	err := SendTemplateRecalc(1, "", 42)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(mockWriter.Messages))
+}
+
+func TestSendTemplateRecalcWithAssignedSystems(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+
+	originalFlag := enableTemplateAdvisoryEval
+	originalWriter := createdSystemsWriter
+	defer func() {
+		enableTemplateAdvisoryEval = originalFlag
+		createdSystemsWriter = originalWriter
+	}()
+
+	mockWriter := &mqueue.MockKafkaWriter{}
+	createdSystemsWriter = mockWriter
+	enableTemplateAdvisoryEval = true
+
+	const accountID = 1
+	const orgID = "org_1"
+	templateUUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	inv1 := uuid.MustParse("00000000-0000-0000-0000-0000000000a1")
+	inv2 := uuid.MustParse("00000000-0000-0000-0000-0000000000a2")
+
+	createTestSystemInDB(t, inv1, accountID, "template-recalc-test-1")
+	createTestSystemInDB(t, inv2, accountID, "template-recalc-test-2")
+	t.Cleanup(func() {
+		database.DeleteTemplate(t, accountID, templateUUID)
+		deleteTestSystemInDB(t, inv1)
+		deleteTestSystemInDB(t, inv2)
+	})
+
+	database.CreateTemplate(t, accountID, templateUUID, []uuid.UUID{inv1, inv2})
+
+	var template models.Template
+	err := database.DB.Where("rh_account_id = ? AND uuid = ?::uuid", accountID, templateUUID).First(&template).Error
+	require.Nil(t, err)
+
+	err = SendTemplateRecalc(accountID, orgID, template.ID)
+	assert.Nil(t, err)
+	require.Equal(t, 1, len(mockWriter.Messages))
+
+	var event mqueue.PlatformEvent
+	assert.Nil(t, sonic.Unmarshal(mockWriter.Messages[0].Value, &event))
+	assert.Equal(t, orgID, event.GetOrgID())
+	assert.Equal(t, accountID, event.AccountID)
+	assert.ElementsMatch(t, []uuid.UUID{inv1, inv2}, event.SystemIDs)
+}
+
+func TestSendTemplateSystemsRecalc(t *testing.T) {
+	originalFlag := enableTemplateAdvisoryEval
+	originalWriter := createdSystemsWriter
+	defer func() {
+		enableTemplateAdvisoryEval = originalFlag
+		createdSystemsWriter = originalWriter
+	}()
+
+	mockWriter := &mqueue.MockKafkaWriter{}
+	createdSystemsWriter = mockWriter
+	enableTemplateAdvisoryEval = true
+
+	inv1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	inv2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	SendTemplateSystemsRecalc(1, "org_1", []uuid.UUID{inv1, inv2})
+	assert.Equal(t, 1, len(mockWriter.Messages))
+
+	var event mqueue.PlatformEvent
+	assert.Nil(t, sonic.Unmarshal(mockWriter.Messages[0].Value, &event))
+	assert.Equal(t, "org_1", event.GetOrgID())
+	assert.Equal(t, 1, event.AccountID)
+	assert.Equal(t, []uuid.UUID{inv1, inv2}, event.SystemIDs)
+
+	mockWriter.Messages = nil
+	SendTemplateSystemsRecalc(1, "org_1", nil)
+	assert.Equal(t, 0, len(mockWriter.Messages))
+}
+
+func TestInventoryIDsToEvalData(t *testing.T) {
+	inv := uuid.MustParse("00000000-0000-0000-0000-00000000000a")
+	evalData := inventoryIDsToEvalData(1, "org_1", []uuid.UUID{inv})
+	assert.Equal(t, 1, len(evalData))
+	assert.Equal(t, inv, evalData[0].InventoryID)
+	assert.Equal(t, 1, evalData[0].RhAccountID)
+	assert.Equal(t, "org_1", *evalData[0].OrgID)
+}

--- a/listener/templates.go
+++ b/listener/templates.go
@@ -79,6 +79,11 @@ func TemplateDelete(template mqueue.TemplateResponse) error {
 		return nil
 	}
 
+	err = SendTemplateRecalc(accountID, template.OrgID, templateID)
+	if err != nil {
+		return errors.Wrap(err, "sending template recalc")
+	}
+
 	// unassign systems from the template (template_id lives on system_patch)
 	err = database.DB.Model(&models.SystemPatch{}).
 		Where("rh_account_id = ? AND template_id = ?", accountID, templateID).
@@ -147,7 +152,7 @@ func TemplateUpdate(template mqueue.TemplateResponse, eventType string) error {
 
 	if contentSourcesBaseURL != "" && eventType == TemplateEventUpdate {
 		ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(template.OrgID))
-		err = syncTemplateAdvisories(ctx, accountID, row.ID, template.UUID)
+		err = syncTemplateAdvisories(ctx, accountID, row.ID, template.UUID, template.OrgID)
 		if err != nil {
 			return errors.Wrap(err, "syncing template advisories")
 		}

--- a/listener/testutil.go
+++ b/listener/testutil.go
@@ -1,0 +1,33 @@
+package listener
+
+import (
+	"app/base/content_sources"
+	"app/base/mqueue"
+	"app/base/utils"
+	"testing"
+)
+
+// InitForTemplateAdvisoryIntegrationTest configures listener for cross-package integration tests.
+func InitForTemplateAdvisoryIntegrationTest(t *testing.T) (*mqueue.MockKafkaWriter, func()) {
+	t.Helper()
+	configure()
+	address := utils.Getenv("CONTENT_SOURCES_ADDRESS", "http://platform:9001")
+	utils.CoreCfg.ContentSourcesAddress = address
+	contentSourcesClient = content_sources.CreateContentSourcesClient()
+	contentSourcesBaseURL = address + "/api/content-sources/v1"
+	t.Cleanup(func() {
+		contentSourcesClient = nil
+		contentSourcesBaseURL = ""
+	})
+
+	origFlag := enableTemplateAdvisoryEval
+	origWriter := createdSystemsWriter
+	enableTemplateAdvisoryEval = true
+	mockWriter := &mqueue.MockKafkaWriter{}
+	createdSystemsWriter = mockWriter
+	cleanup := func() {
+		enableTemplateAdvisoryEval = origFlag
+		createdSystemsWriter = origWriter
+	}
+	return mockWriter, cleanup
+}


### PR DESCRIPTION
This PR:

- Adds `template_advisory_eval` to use `template_advisory` for installability on template-assigned systems (skips yum merge)
- Sends bulk recalc via `system_ids` when template advisories change or a template is deleted (listener → user-evaluation)
- Keeps manager `template_change_eval` for assign/remove; upload and recalc paths use the new evaluator logic when the flag is on
- Adds unit and E2E tests plus architecture/database docs for rollout (enable flag on listener and all evaluator pods)

## Summary by Sourcery

Integrate a feature-flagged template-advisory evaluation path that uses template advisory data to determine installability for template-assigned systems and wires listener-driven template content changes to bulk system re-evaluation via user-evaluation, with supporting documentation and tests.

New Features:
- Add template-advisory-based evaluation path that derives installability from template-advisory data instead of yum for template-assigned systems.
- Trigger bulk user-evaluation re-calculation for all systems assigned to a template when its advisory content changes or the template is deleted.

Enhancements:
- Introduce configuration flag `template_advisory_eval` on listener and evaluator pods to control rollout of template-advisory-driven installability.
- Document template content update flow, template_advisory-based evaluation, and rollout strategy in architecture and database docs.

Tests:
- Add unit tests for template advisory installability, advisory loading, template recalc messaging, and helper utilities.
- Add end-to-end test covering listener → evaluator integration for template advisory updates and system re-evaluation.