### PR TITLE
test: add end-to-end advisory update Kafka test

### DIFF
--- a/base/mqueue/mqueue.go
+++ b/base/mqueue/mqueue.go
@@ -19,7 +19,7 @@ const errContextCanceled = "context canceled"
 
 // By wrapping raw value we can add new methods & ensure methods of wrapped type are callable
 type Reader interface {
-	HandleMessages(handler MessageHandler)
+	HandleMessages(ctx context.Context, handler MessageHandler)
 	io.Closer
 }
 
@@ -75,15 +75,17 @@ func MakeRetryingHandler(handler MessageHandler) MessageHandler {
 type CreateReader func(topic string) Reader
 type CreateWriter func(topic string) Writer
 
-func runReader(wg *sync.WaitGroup, topic string, createReader CreateReader, msgHandler MessageHandler) {
+func runReader(ctx context.Context, wg *sync.WaitGroup, topic string, createReader CreateReader,
+	msgHandler MessageHandler) {
 	defer wg.Done()
 	defer utils.LogPanics(true)
 	reader := createReader(topic)
 	defer reader.Close()
-	reader.HandleMessages(msgHandler)
+	reader.HandleMessages(ctx, msgHandler)
 }
 
-func SpawnReader(wg *sync.WaitGroup, topic string, createReader CreateReader, msgHandler MessageHandler) {
+func SpawnReader(ctx context.Context, wg *sync.WaitGroup, topic string, createReader CreateReader,
+	msgHandler MessageHandler) {
 	wg.Add(1)
-	go runReader(wg, topic, createReader, msgHandler)
+	go runReader(ctx, wg, topic, createReader, msgHandler)
 }

--- a/base/mqueue/mqueue_impl_gokafka.go
+++ b/base/mqueue/mqueue_impl_gokafka.go
@@ -1,7 +1,6 @@
 package mqueue
 
 import (
-	"app/base"
 	"app/base/utils"
 	"context"
 	"crypto/tls"
@@ -22,9 +21,9 @@ type kafkaGoReaderImpl struct {
 	kafka.Reader
 }
 
-func (t *kafkaGoReaderImpl) HandleMessages(handler MessageHandler) {
+func (t *kafkaGoReaderImpl) HandleMessages(ctx context.Context, handler MessageHandler) {
 	for {
-		m, err := t.FetchMessage(base.Context)
+		m, err := t.FetchMessage(ctx)
 		if err != nil {
 			if err.Error() == errContextCanceled {
 				break
@@ -43,7 +42,7 @@ func (t *kafkaGoReaderImpl) HandleMessages(handler MessageHandler) {
 		if err = handler(kafkaMessage); err != nil {
 			utils.LogPanic("err", err.Error(), "Handler failed")
 		}
-		err = t.CommitMessages(base.Context, m)
+		err = t.CommitMessages(ctx, m)
 		if err != nil {
 			if err.Error() == errContextCanceled {
 				break

--- a/base/mqueue/mqueue_impl_gokafka.go
+++ b/base/mqueue/mqueue_impl_gokafka.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -25,7 +26,8 @@ func (t *kafkaGoReaderImpl) HandleMessages(ctx context.Context, handler MessageH
 	for {
 		m, err := t.FetchMessage(ctx)
 		if err != nil {
-			if err.Error() == errContextCanceled {
+			// Both context cancellation or reader.Close() racing are expected during shutdown
+			if err.Error() == errContextCanceled || err == io.EOF {
 				break
 			}
 			utils.LogError("err", err.Error(), "unable to read message from Kafka reader")

--- a/base/mqueue/mqueue_test.go
+++ b/base/mqueue/mqueue_test.go
@@ -35,7 +35,7 @@ func TestRoundTripKafkaGo(t *testing.T) {
 	reader := NewKafkaReaderFromEnv("test")
 
 	var eventOut PlatformEvent
-	go reader.HandleMessages(MakeMessageHandler(func(event PlatformEvent) error {
+	go reader.HandleMessages(context.Background(), MakeMessageHandler(func(event PlatformEvent) error {
 		eventOut = event
 		return nil
 	}))
@@ -51,7 +51,7 @@ func TestRoundTripKafkaGo(t *testing.T) {
 func TestSpawnReader(t *testing.T) {
 	var nReaders int32
 	wg := sync.WaitGroup{}
-	SpawnReader(&wg, "", CreateCountedMockReader(&nReaders),
+	SpawnReader(context.Background(), &wg, "", CreateCountedMockReader(&nReaders),
 		MakeMessageHandler(func(_ PlatformEvent) error { return nil }))
 	wg.Wait()
 	assert.Equal(t, 1, int(nReaders))

--- a/base/mqueue/mqueue_test.go
+++ b/base/mqueue/mqueue_test.go
@@ -33,9 +33,10 @@ func TestParseEvents(t *testing.T) {
 func TestRoundTripKafkaGo(t *testing.T) {
 	utils.SkipWithoutPlatform(t)
 	reader := NewKafkaReaderFromEnv("test")
+	defer reader.Close()
 
 	var eventOut PlatformEvent
-	go reader.HandleMessages(context.Background(), MakeMessageHandler(func(event PlatformEvent) error {
+	go reader.HandleMessages(t.Context(), MakeMessageHandler(func(event PlatformEvent) error {
 		eventOut = event
 		return nil
 	}))

--- a/base/mqueue/testing.go
+++ b/base/mqueue/testing.go
@@ -7,8 +7,8 @@ import (
 
 type mockReader struct{}
 
-func (t *mockReader) HandleMessages(_ MessageHandler) {}
-func (t *mockReader) Close() error                    { return nil }
+func (t *mockReader) HandleMessages(_ context.Context, _ MessageHandler) {}
+func (t *mockReader) Close() error                                       { return nil }
 
 // Count how many times reader is created.
 func CreateCountedMockReader(cnt *int32) CreateReader {

--- a/conf/test.env
+++ b/conf/test.env
@@ -10,7 +10,7 @@ DB_PASSWD=passwd
 LIMIT_PAGE_SIZE=false
 
 # don't put "" or '' around the text otherwise they'll be included into content
-POD_CONFIG=label=upload;vmaas_call_max_retries=100;template_change_eval=false;update_users;update_db_config;use_testing_db
+POD_CONFIG=label=upload;vmaas_call_max_retries=100;template_change_eval=false;update_users;update_db_config;use_testing_db;advisory_updates=true
 
 KESSEL_URL=platform:9005
 KESSEL_INSECURE=true

--- a/evaluator/advisory_update_test.go
+++ b/evaluator/advisory_update_test.go
@@ -50,51 +50,38 @@ func TestCreateAdvisoryUpdateEvent(t *testing.T) {
 }
 
 func TestPublishAdvisoryUpdates(t *testing.T) {
-	utils.SkipWithoutDB(t)
-	utils.SkipWithoutPlatform(t)
-	core.SetupTestEnvironment()
-
-	configure()
-	loadCache()
 	mockWriter := mqueue.MockKafkaWriter{}
 	advisoryUpdatePublisher = &mockWriter
 
-	enableAdvisoryUpdates = true
-	defer func() { enableAdvisoryUpdates = false }()
+	wsID := uuid.MustParse("d964b282-17f6-47ab-b596-a4a34d711f04")
+	wsName := "test-workspace"
+	system := &models.SystemPlatformV2{
+		Inventory: models.SystemInventory{
+			ID:            1,
+			RhAccountID:   rhAccountID,
+			InventoryID:   uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+			WorkspaceID:   &wsID,
+			WorkspaceName: &wsName,
+		},
+		Patch: models.SystemPatch{},
+	}
 
-	// Remove stale rows that may remain from previous test runs
-	database.DeleteSystemAdvisories(t, testDBID, []int64{1, 2})
-	database.DeleteAdvisoryAccountData(t, rhAccountID, []int64{1, 2})
+	advisories := extendedAdvisoryMap{
+		"RH-1": {change: Add, SystemAdvisories: models.SystemAdvisories{AdvisoryID: 1}},
+		"RH-2": {change: Keep, SystemAdvisories: models.SystemAdvisories{AdvisoryID: 2}},
+		"RH-3": {change: Remove, SystemAdvisories: models.SystemAdvisories{AdvisoryID: 3}},
+	}
 
-	// Pair system with advisories before evaluation
-	oldAdvisoryIDs := []int64{1, 3, 4}
-	database.CreateSystemAdvisories(t, rhAccountID, testDBID, oldAdvisoryIDs)
-	database.CreateAdvisoryAccountData(t, rhAccountID, oldAdvisoryIDs, 1)
-	database.CheckCachesValid(t)
-
-	// Run evaluation
-	err := evaluateHandler(mqueue.PlatformEvent{
-		SystemIDs:  []uuid.UUID{testInventoryID},
-		RequestIDs: []string{"request-1"},
-		OrgID:      &orgID,
-		AccountID:  rhAccountID})
+	err := publishAdvisoryUpdates(system, advisories)
 	assert.NoError(t, err)
+	assert.Len(t, mockWriter.Messages, 1)
 
-	// Verify evaluated advisories exist in DB and get their IDs for cleanup
-	evaluatedAdvisoryNames := []string{"RH-1", "RH-2", "RH-100"}
-	evaluatedAdvisoryIDs := database.CheckAdvisoriesInDB(t, evaluatedAdvisoryNames)
-
-	// Verify published Kafka message contains correct payload
-	assert.GreaterOrEqual(t, len(mockWriter.Messages), 1)
 	var event mqueue.AdvisoryUpdateEvent
 	assert.NoError(t, sonic.Unmarshal(mockWriter.Messages[0].Value, &event))
 	assert.Equal(t, rhAccountID, event.RhAccountID)
-	assert.NotEmpty(t, event.AdvisoryIDs) // RH-100 gets a dynamic ID via lazy-save, so we only check delta is non-empty
+	assert.Equal(t, wsID, event.WorkspaceID)
+	assert.ElementsMatch(t, []int64{1, 3}, event.AdvisoryIDs)
 	assert.False(t, event.ProducedAt.Time().IsZero())
-
-	database.DeleteSystemAdvisories(t, testDBID, evaluatedAdvisoryIDs)
-	database.DeleteAdvisoryAccountData(t, rhAccountID, evaluatedAdvisoryIDs)
-	database.DeleteAdvisoryAccountData(t, rhAccountID, oldAdvisoryIDs)
 }
 
 func TestPublishAdvisoryUpdatesNoDelta(t *testing.T) {
@@ -118,4 +105,70 @@ func TestPublishAdvisoryUpdatesNoDelta(t *testing.T) {
 	err := publishAdvisoryUpdates(system, advisories)
 	assert.NoError(t, err)
 	assert.Empty(t, mockWriter.Messages)
+}
+
+func TestAdvisoryUpdateKafkaRoundTrip(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	utils.SkipWithoutPlatform(t)
+	core.SetupTestEnvironment()
+
+	configure()
+	loadCache()
+
+	topic := utils.CoreCfg.AdvisoryUpdateTopic
+	if topic == "" {
+		t.Skip("ADVISORY_UPDATE_TOPIC not configured")
+	}
+
+	advisoryUpdatePublisher = mqueue.NewKafkaWriterFromEnv(topic)
+	reader := mqueue.NewKafkaReaderFromEnv(topic)
+	defer func() {
+		assert.NoError(t, reader.Close(), "failed to close Kafka reader")
+	}()
+
+	// recover() absorbs the EOF panic from HandleMessages after reader.Close()
+	// We can't use t.Context() because HandleMessages hardcodes base.Context internally
+	var received mqueue.KafkaMessage
+	go func() {
+		defer func() { _ = recover() }()
+		reader.HandleMessages(func(m mqueue.KafkaMessage) error {
+			received = m
+			return nil
+		})
+	}()
+
+	// Remove stale rows from previous test runs
+	database.DeleteSystemAdvisories(t, testDBID, []int64{1, 2})
+	database.DeleteAdvisoryAccountData(t, rhAccountID, []int64{1, 2})
+
+	// Pair system with advisories before evaluation
+	oldAdvisoryIDs := []int64{1, 3, 4}
+	database.CreateSystemAdvisories(t, rhAccountID, testDBID, oldAdvisoryIDs)
+	database.CreateAdvisoryAccountData(t, rhAccountID, oldAdvisoryIDs, 1)
+	database.CheckCachesValid(t)
+
+	// Run evaluation
+	err := evaluateHandler(mqueue.PlatformEvent{
+		SystemIDs:  []uuid.UUID{testInventoryID},
+		RequestIDs: []string{"request-1"},
+		OrgID:      &orgID,
+		AccountID:  rhAccountID})
+	assert.NoError(t, err)
+
+	utils.AssertEqualWait(t, 10, func() (exp, act interface{}) {
+		return true, len(received.Value) > 0
+	})
+	var event mqueue.AdvisoryUpdateEvent
+	assert.NoError(t, sonic.Unmarshal(received.Value, &event), "message should be valid AdvisoryUpdateEvent JSON")
+	assert.Equal(t, rhAccountID, event.RhAccountID)
+	assert.NotEqual(t, uuid.Nil, event.WorkspaceID)
+	assert.NotEmpty(t, event.AdvisoryIDs)
+	assert.False(t, event.ProducedAt.Time().IsZero())
+
+	// Cleanup
+	evaluatedAdvisoryNames := []string{"RH-1", "RH-2", "RH-100"}
+	evaluatedAdvisoryIDs := database.CheckAdvisoriesInDB(t, evaluatedAdvisoryNames)
+	database.DeleteSystemAdvisories(t, testDBID, evaluatedAdvisoryIDs)
+	database.DeleteAdvisoryAccountData(t, rhAccountID, evaluatedAdvisoryIDs)
+	database.DeleteAdvisoryAccountData(t, rhAccountID, oldAdvisoryIDs)
 }

--- a/evaluator/advisory_update_test.go
+++ b/evaluator/advisory_update_test.go
@@ -1,6 +1,7 @@
 package evaluator
 
 import (
+	"app/base"
 	"app/base/core"
 	"app/base/database"
 	"app/base/models"
@@ -107,6 +108,16 @@ func TestPublishAdvisoryUpdatesNoDelta(t *testing.T) {
 	assert.Empty(t, mockWriter.Messages)
 }
 
+func waitForConsumerGroup(t *testing.T, writer mqueue.Writer, received *mqueue.KafkaMessage) {
+	t.Helper()
+	err := writer.WriteMessages(base.Context, mqueue.KafkaMessage{Value: []byte("probe")})
+	assert.NoError(t, err, "failed to send probe message")
+	utils.AssertEqualWait(t, 10, func() (exp, act interface{}) {
+		return true, len(received.Value) > 0
+	})
+	*received = mqueue.KafkaMessage{}
+}
+
 func TestAdvisoryUpdateKafkaRoundTrip(t *testing.T) {
 	utils.SkipWithoutDB(t)
 	utils.SkipWithoutPlatform(t)
@@ -136,6 +147,8 @@ func TestAdvisoryUpdateKafkaRoundTrip(t *testing.T) {
 			return nil
 		})
 	}()
+
+	waitForConsumerGroup(t, advisoryUpdatePublisher, &received)
 
 	// Remove stale rows from previous test runs
 	database.DeleteSystemAdvisories(t, testDBID, []int64{1, 2})

--- a/evaluator/advisory_update_test.go
+++ b/evaluator/advisory_update_test.go
@@ -1,7 +1,6 @@
 package evaluator
 
 import (
-	"app/base"
 	"app/base/core"
 	"app/base/database"
 	"app/base/models"
@@ -110,7 +109,7 @@ func TestPublishAdvisoryUpdatesNoDelta(t *testing.T) {
 
 func waitForConsumerGroup(t *testing.T, writer mqueue.Writer, received *mqueue.KafkaMessage) {
 	t.Helper()
-	err := writer.WriteMessages(base.Context, mqueue.KafkaMessage{Value: []byte("probe")})
+	err := writer.WriteMessages(t.Context(), mqueue.KafkaMessage{Value: []byte("probe")})
 	assert.NoError(t, err, "failed to send probe message")
 	utils.AssertEqualWait(t, 10, func() (exp, act interface{}) {
 		return true, len(received.Value) > 0
@@ -137,16 +136,11 @@ func TestAdvisoryUpdateKafkaRoundTrip(t *testing.T) {
 		assert.NoError(t, reader.Close(), "failed to close Kafka reader")
 	}()
 
-	// recover() absorbs the EOF panic from HandleMessages after reader.Close()
-	// We can't use t.Context() because HandleMessages hardcodes base.Context internally
 	var received mqueue.KafkaMessage
-	go func() {
-		defer func() { _ = recover() }()
-		reader.HandleMessages(func(m mqueue.KafkaMessage) error {
-			received = m
-			return nil
-		})
-	}()
+	go reader.HandleMessages(t.Context(), func(m mqueue.KafkaMessage) error {
+		received = m
+		return nil
+	})
 
 	waitForConsumerGroup(t, advisoryUpdatePublisher, &received)
 

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -796,7 +796,7 @@ func run(wg *sync.WaitGroup, readerBuilder mqueue.CreateReader) {
 	// We create multiple consumers, and hope that the partition rebalancing
 	// algorithm assigns each consumer a single partition
 	for i := 0; i < consumerCount; i++ {
-		mqueue.SpawnReader(wg, evalTopic, readerBuilder, handler)
+		mqueue.SpawnReader(base.Context, wg, evalTopic, readerBuilder, handler)
 	}
 }
 

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"app/base"
 	"app/base/api"
 	"app/base/content_sources"
 	"app/base/core"
@@ -115,12 +116,12 @@ func runReaders(wg *sync.WaitGroup, readerBuilder mqueue.CreateReader) {
 	// We create multiple consumers, and hope that the partition rebalancing
 	// algorithm assigns each consumer a single partition
 	for i := 0; i < eventsConsumers; i++ {
-		mqueue.SpawnReader(wg, eventsTopic, readerBuilder, mqueue.MakeRetryingHandler(EventsMessageHandler))
+		mqueue.SpawnReader(base.Context, wg, eventsTopic, readerBuilder, mqueue.MakeRetryingHandler(EventsMessageHandler))
 		utils.LogDebug("spawned eventsTopic reader", i)
 	}
 	if enableTemplates {
 		for i := 0; i < templatesConsumers; i++ {
-			mqueue.SpawnReader(wg, templatesTopic, readerBuilder, mqueue.MakeRetryingHandler(TemplatesMessageHandler))
+			mqueue.SpawnReader(base.Context, wg, templatesTopic, readerBuilder, mqueue.MakeRetryingHandler(TemplatesMessageHandler)) //nolint:lll
 			utils.LogDebug("spawned templatesTopic reader", i)
 		}
 	}


### PR DESCRIPTION
## Summary

- Added `TestPublishAdvisoryUpdates`: Unit test for the publishAdvisoryUpdates happy path. Verifies that only changed advisories (Add/Remove) are published, while Keep entries are excluded. Complements TestPublishAdvisoryUpdatesNoDelta which covers the no-changes-published case

- Added `TestAdvisoryUpdateKafkaRoundTrip`: End-to-end test covering the full path from evaluation through Kafka publish consume. Validates the produced AdvisoryUpdateEvent fields after deserialization

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Add and refine tests around advisory update Kafka event publishing and round-trip behaviour.

Tests:
- Refactor advisory update publishing test to validate emitted events from publishAdvisoryUpdates with workspace context and specific advisory deltas.
- Introduce an end-to-end Kafka round-trip test that exercises advisory evaluation, publishing, and consumption of advisory update events against a real topic.

## Summary by Sourcery

Add tests and Kafka integration improvements around advisory update events and message consumption.

Enhancements:
- Extend the Kafka Reader interface and implementations to accept an explicit context and improve graceful shutdown handling, including EOF from reader closure.
- Update Kafka reader spawning to pass application context into message consumers in the listener and evaluator components.

Tests:
- Update advisory update publishing unit test to assert workspace ID propagation and that only added/removed advisories are emitted.
- Introduce an end-to-end Kafka round-trip test that exercises advisory evaluation, publishing, and consumption of advisory update events.
- Add helper to wait for Kafka consumer group readiness in tests and adapt existing Kafka round-trip tests to the new reader interface.