### PR TITLE
RHINENG-26549: log kessel errors to external service metric

### DIFF
--- a/manager/middlewares/kessel.go
+++ b/manager/middlewares/kessel.go
@@ -4,6 +4,7 @@ import (
 	"app/base/utils"
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -96,6 +97,7 @@ func hasPermissionKessel(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, utils.ErrorResponse{
 			Error: "Unexpected server error", // missing cert or failed to make a new gRPC client
 		})
+		serviceErrorCnt.WithLabelValues("kessel", strconv.Itoa(http.StatusInternalServerError)).Inc()
 		return
 	}
 	defer func() {
@@ -117,6 +119,7 @@ func hasPermissionKessel(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, utils.ErrorResponse{
 			Error: "Communication with RBAC failed",
 		})
+		serviceErrorCnt.WithLabelValues("kessel", strconv.Itoa(http.StatusInternalServerError)).Inc()
 		return
 	}
 


### PR DESCRIPTION
## Summary
There is a PatchmanAlertExternalService alert that check if the count of these external service errors is increasing. It used to be tracked for RBAC calls, but not for Kessel. This adds the prometheus counter increments back.

Associated ticket: [[RHINENG-26549](https://redhat.atlassian.net/browse/RHINENG-26549)]

[RHINENG-26549]: https://redhat.atlassian.net/browse/RHINENG-26549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ