### PR TITLE
fix: add user for patch to call content sources API

### DIFF
--- a/base/utils/config.go
+++ b/base/utils/config.go
@@ -82,6 +82,7 @@ type coreConfig struct {
 	EvaluatorUploadPrivateAddress string
 	EvaluatorRecalcPrivateAddress string
 	ContentSourcesAddress         string
+	ContentSourcesUser            string
 
 	// cloudwatch
 	CloudWatchAccessKeyID     string
@@ -192,6 +193,7 @@ func initServicesFromEnv() {
 	CoreCfg.CandlepinKey = Getenv("CANDLEPIN_KEY", CoreCfg.CandlepinKey)
 	CoreCfg.CandlepinCA = Getenv("CANDLEPIN_CA", CoreCfg.CandlepinCA)
 	CoreCfg.ContentSourcesAddress = Getenv("CONTENT_SOURCES_ADDRESS", CoreCfg.ContentSourcesAddress)
+	CoreCfg.ContentSourcesUser = Getenv("CONTENT_SOURCES_USER", CoreCfg.ContentSourcesUser)
 }
 
 func initDBFromClowder() {

--- a/base/utils/identity.go
+++ b/base/utils/identity.go
@@ -32,10 +32,13 @@ func EncodeXRHID(id identity.Identity) (string, error) {
 	return base64.StdEncoding.EncodeToString(js), nil
 }
 
-func XRHIDForOrg(orgID string) identity.XRHID {
+func XRHIDForOrg(orgID string, username string) identity.XRHID {
 	return identity.XRHID{
 		Identity: identity.Identity{
-			Type:  "User",
+			Type: "User",
+			User: &identity.User{
+				Username: username,
+			},
 			OrgID: orgID,
 			Internal: identity.Internal{
 				OrgID: orgID,

--- a/base/utils/identity_test.go
+++ b/base/utils/identity_test.go
@@ -37,11 +37,13 @@ func TestEncodeXRHID(t *testing.T) {
 	assert.Equal(t, testIdentityString, identityString)
 }
 
-func TestXRHIDForOrg(t *testing.T) {
+func TestContentSourcesXRHIDForOrg(t *testing.T) {
+	const testUser = "test-user"
 	orgID := "1234"
-	xrhid := XRHIDForOrg(orgID)
+	xrhid := XRHIDForOrg(orgID, testUser)
 
 	assert.Equal(t, orgID, xrhid.Identity.OrgID)
 	assert.Equal(t, orgID, xrhid.Identity.Internal.OrgID)
 	assert.Equal(t, "User", xrhid.Identity.Type)
+	assert.Equal(t, testUser, xrhid.Identity.User.Username)
 }

--- a/conf/common.env
+++ b/conf/common.env
@@ -27,3 +27,4 @@ ENABLE_PROFILER=true
 
 CANDLEPIN_ADDRESS=http://platform:9001/candlepin
 CONTENT_SOURCES_ADDRESS=http://platform:9001
+CONTENT_SOURCES_USER=test-user

--- a/conf/local.env
+++ b/conf/local.env
@@ -16,6 +16,7 @@ DB_SSLROOTCERT=dev/database/secrets/pgca.crt
 VMAAS_ADDRESS=http://localhost:9001
 CANDLEPIN_ADDRESS=http://localhost:9001/candlepin
 CONTENT_SOURCES_ADDRESS=http://localhost:9001
+CONTENT_SOURCES_USER=test-user
 
 KAFKA_ADDRESS=localhost:9092
 KAFKA_GROUP=patchman

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -154,6 +154,7 @@ objects:
         - {name: ENABLE_PROFILER, value: '${ENABLE_PROFILER_LISTENER}'}
         - {name: GOMEMLIMIT, value: '${GOMEMLIMIT_LISTENER}'}
         - {name: POD_CONFIG, value: '${LISTENER_CONFIG}'}
+        - {name: CONTENT_SOURCES_USER, value: '${CONTENT_SOURCES_USER}'}
 
         resources:
           limits: {cpu: '${CPU_LIMIT_LISTENER}', memory: '${MEM_LIMIT_LISTENER}'}
@@ -790,6 +791,7 @@ parameters:
 - {name: ENABLE_PROFILER_LISTENER, value: 'false'}
 - {name: GOMEMLIMIT_LISTENER, value: '691MiB'} # set to 90% of the default memory limit (don't forget `B`)
 - {name: LISTENER_CONFIG, value: ''}
+- {name: CONTENT_SOURCES_USER, value: ''}
 
 # Evaluator
 - {name: GOGC, value: '100'}

--- a/listener/template_advisories_test.go
+++ b/listener/template_advisories_test.go
@@ -17,12 +17,16 @@ func setupContentSourcesClient(t *testing.T) {
 	originalAddress := utils.CoreCfg.ContentSourcesAddress
 	address := utils.Getenv("CONTENT_SOURCES_ADDRESS", "http://platform:9001")
 	utils.CoreCfg.ContentSourcesAddress = address
+	originalUser := utils.CoreCfg.ContentSourcesUser
+	user := utils.Getenv("CONTENT_SOURCES_USER", "test-user")
+	utils.CoreCfg.ContentSourcesUser = user
 	contentSourcesClient = content_sources.CreateContentSourcesClient()
 	contentSourcesBaseURL = address + "/api/content-sources/v1"
 	t.Cleanup(func() {
 		utils.CoreCfg.ContentSourcesAddress = originalAddress
 		contentSourcesClient = nil
 		contentSourcesBaseURL = ""
+		utils.CoreCfg.ContentSourcesUser = originalUser
 	})
 }
 
@@ -31,7 +35,7 @@ func TestCallCSTemplateAdvisories(t *testing.T) {
 
 	templateUUID := "99900000-0000-0000-0000-000000000001"
 	orgID := "org_1"
-	ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(orgID))
+	ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(orgID, utils.CoreCfg.ContentSourcesUser))
 	result, err := callCSTemplateAdvisories(ctx, templateUUID)
 
 	assert.NoError(t, err)
@@ -127,7 +131,7 @@ func TestSyncTemplateAdvisories(t *testing.T) {
 	defer database.DeleteTemplateAdvisories(t, templateID, []int64{1, 2, 3})
 
 	// content sources mock returns RH-1 and RH-3 so we need to add RH-3, remove RH-2
-	ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(orgID))
+	ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(orgID, utils.CoreCfg.ContentSourcesUser))
 	err := syncTemplateAdvisories(ctx, accountID, templateID, templateUUID, orgID)
 	assert.Nil(t, err)
 

--- a/listener/templates.go
+++ b/listener/templates.go
@@ -150,8 +150,9 @@ func TemplateUpdate(template mqueue.TemplateResponse, eventType string) error {
 		return errors.Wrap(err, "creating/updating template from message")
 	}
 
-	if contentSourcesBaseURL != "" && eventType == TemplateEventUpdate {
-		ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(template.OrgID))
+	if contentSourcesBaseURL != "" && utils.CoreCfg.ContentSourcesUser != "" && eventType == TemplateEventUpdate {
+		ctx := identity.WithIdentity(context.Background(),
+			utils.XRHIDForOrg(template.OrgID, utils.CoreCfg.ContentSourcesUser))
 		err = syncTemplateAdvisories(ctx, accountID, row.ID, template.UUID, template.OrgID)
 		if err != nil {
 			return errors.Wrap(err, "syncing template advisories")


### PR DESCRIPTION
To fix the rejected requests from patch to content sources:

- Adds a user environment variable to the deployment
- Adds this user to the identity of the request to content sources endpoint that lists template advisory IDs for a specific template
- If this user is empty, no request is sent to content sources

Related to https://github.com/content-services/content-sources-backend/pull/1556

## Summary by Sourcery

Add support for configuring a content sources user and include it in identity used for content sources requests.

Enhancements:
- Extend core configuration and deployment to provide a CONTENT_SOURCES_USER environment parameter.
- Include the configured content sources user in the XRHID identity used for content sources calls.
- Guard template advisory synchronization so it only runs when a content sources user is configured.

Tests:
- Update identity tests to validate the content sources user is included in the generated XRHID.