### PR TITLE
fix semantic release workflow failure

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -13,7 +13,7 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ secrets.SEMANTIC_RELEASE_APP_ID }}
+        client-id: ${{ secrets.SEMANTIC_RELEASE_APP_ID }}
         private-key: ${{ secrets.SEMANTIC_RELEASE_PK }}
     - uses: actions/checkout@v7
       with:
@@ -43,5 +43,5 @@ jobs:
         echo $VERSION_NEXT >VERSION
         git commit -am "${VERSION_NEXT}"
         git push
-        git tag ${VERSION_NEXT}
-        git push origin ${VERSION_NEXT}
+        git tag "${VERSION_NEXT}" -m "${VERSION_NEXT}"
+        git push origin "${VERSION_NEXT}"


### PR DESCRIPTION
error: Terminal is dumb, but EDITOR unset
Please supply the message using either -m or -F option.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Fix semantic-release workflow configuration to use the correct GitHub App token input and ensure non-interactive tagging for automated releases.

CI:
- Correct GitHub App token input from app-id to client-id in the semantic-release workflow.
- Update release tagging to include an explicit tag message to avoid interactive editor prompts in CI.