### PR TITLE
fix: missing Kafka message deserialization in aggregator

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -39,7 +39,7 @@ func runServer() {
 }
 
 func subscribeToAdvisoryUpdates(wg *sync.WaitGroup, readerBuilder mqueue.CreateReader) {
-	handler := mqueue.MakeRetryingHandler(advisoryUpdateHandler)
+	handler := mqueue.MakeRetryingHandler(mqueue.MakeAdvisoryUpdateHandler(advisoryUpdateHandler))
 	for i := 0; i < consumerCount; i++ {
 		mqueue.SpawnReader(base.Context, wg, advisoryUpdateTopic, readerBuilder, handler)
 		utils.LogDebug("spawned advisory update reader", i)

--- a/aggregator/events.go
+++ b/aggregator/events.go
@@ -5,6 +5,6 @@ import (
 )
 
 // TODO: stub - will process advisory update events in batches and update account_advisory table
-func advisoryUpdateHandler(m mqueue.KafkaMessage) error {
+func advisoryUpdateHandler(event mqueue.AdvisoryUpdateEvent) error {
 	return nil
 }

--- a/base/mqueue/advisory_update_event.go
+++ b/base/mqueue/advisory_update_event.go
@@ -2,12 +2,27 @@ package mqueue
 
 import (
 	"app/base/types"
+	"app/base/utils"
 	"context"
 
 	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
+
+type AdvisoryUpdateEventHandler func(event AdvisoryUpdateEvent) error
+
+func MakeAdvisoryUpdateHandler(handler AdvisoryUpdateEventHandler) MessageHandler {
+	return func(m KafkaMessage) error {
+		var event AdvisoryUpdateEvent
+		err := sonic.Unmarshal(m.Value, &event)
+		if err != nil {
+			utils.LogError("err", err, "Could not deserialize advisory update event")
+			return nil
+		}
+		return handler(event)
+	}
+}
 
 type AdvisoryUpdateEvent struct {
 	RhAccountID int                    `json:"rh_account_id"`


### PR DESCRIPTION
Add `MakeAdvisoryUpdateHandler` to deserialize raw Kafka messages into `AdvisoryUpdateEvent` objects, mirroring the existing `MakeMessageHandler` pattern.

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Add a dedicated advisory update event handler that deserializes Kafka messages before processing and wire it into the aggregator subscription flow.

New Features:
- Introduce MakeAdvisoryUpdateHandler to convert raw Kafka messages into AdvisoryUpdateEvent objects for downstream handlers.

Bug Fixes:
- Ensure advisory update Kafka messages are properly deserialized before being handled in the aggregator.

Enhancements:
- Refine advisory update handling API so aggregator logic operates on typed AdvisoryUpdateEvent instances instead of raw Kafka messages.