### PR TITLE
HMS-10223: mark bootc system advisories as applicable

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -39,7 +39,7 @@ func runServer() {
 }
 
 func subscribeToAdvisoryUpdates(wg *sync.WaitGroup, readerBuilder mqueue.CreateReader) {
-	handler := mqueue.MakeRetryingHandler(mqueue.MakeAdvisoryUpdateHandler(advisoryUpdateHandler))
+	handler := mqueue.MakeRetryingHandler(advisoryUpdateHandler)
 	for i := 0; i < consumerCount; i++ {
 		mqueue.SpawnReader(base.Context, wg, advisoryUpdateTopic, readerBuilder, handler)
 		utils.LogDebug("spawned advisory update reader", i)

--- a/aggregator/events.go
+++ b/aggregator/events.go
@@ -2,9 +2,19 @@ package aggregator
 
 import (
 	"app/base/mqueue"
+	"app/base/utils"
+
+	"github.com/bytedance/sonic"
 )
 
 // TODO: stub - will process advisory update events in batches and update account_advisory table
-func advisoryUpdateHandler(event mqueue.AdvisoryUpdateEvent) error {
+func advisoryUpdateHandler(m mqueue.KafkaMessage) error {
+	var event mqueue.AdvisoryUpdateEvent
+	if err := sonic.Unmarshal(m.Value, &event); err != nil {
+		utils.LogError("err", err, "Could not deserialize advisory update event")
+		return nil
+	}
+	// TODO: advisory update code goes here
+	_ = event
 	return nil
 }

--- a/base/mqueue/advisory_update_event.go
+++ b/base/mqueue/advisory_update_event.go
@@ -2,27 +2,12 @@ package mqueue
 
 import (
 	"app/base/types"
-	"app/base/utils"
 	"context"
 
 	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
-
-type AdvisoryUpdateEventHandler func(event AdvisoryUpdateEvent) error
-
-func MakeAdvisoryUpdateHandler(handler AdvisoryUpdateEventHandler) MessageHandler {
-	return func(m KafkaMessage) error {
-		var event AdvisoryUpdateEvent
-		err := sonic.Unmarshal(m.Value, &event)
-		if err != nil {
-			utils.LogError("err", err, "Could not deserialize advisory update event")
-			return nil
-		}
-		return handler(event)
-	}
-}
 
 type AdvisoryUpdateEvent struct {
 	RhAccountID int                    `json:"rh_account_id"`

--- a/base/mqueue/event.go
+++ b/base/mqueue/event.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/bytedance/sonic"
 	"github.com/lestrrat-go/backoff/v2"
 )
 
@@ -16,24 +15,8 @@ var policy = backoff.Exponential(
 	backoff.WithMaxRetries(5),
 )
 
-type EventHandler func(message PlatformEvent) error
-
 type MessageData interface {
 	WriteEvents(ctx context.Context, w Writer) error
-}
-
-// Performs parsing of kafka message, and then dispatches this message into provided functions
-func MakeMessageHandler(eventHandler EventHandler) MessageHandler {
-	return func(m KafkaMessage) error {
-		var event PlatformEvent
-		err := sonic.Unmarshal(m.Value, &event)
-		// Not a fatal error, invalid data format, log and skip
-		if err != nil {
-			utils.LogError("err", err, "Could not deserialize platform event")
-			return nil
-		}
-		return eventHandler(event)
-	}
 }
 
 func SendMessages(ctx context.Context, w Writer, data MessageData) error {

--- a/base/mqueue/mqueue_test.go
+++ b/base/mqueue/mqueue_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,30 +17,15 @@ var someid = uuid.MustParse("99c0ffee-0000-0000-0000-0000000050de")
 
 var msg = KafkaMessage{Value: []byte(`{"id": "` + id.String() + `", "type": "delete"}`)}
 
-func TestParseEvents(t *testing.T) {
-	reached := false
-
-	err := MakeMessageHandler(func(event PlatformEvent) error {
-		assert.Equal(t, event.ID, id)
-		assert.Equal(t, *event.Type, "delete")
-		reached = true
-		return nil
-	})(msg)
-
-	assert.True(t, reached, "Event handler should have been called")
-	assert.NoError(t, err)
-}
-
 func TestRoundTripKafkaGo(t *testing.T) {
 	utils.SkipWithoutPlatform(t)
 	reader := NewKafkaReaderFromEnv("test")
 	defer reader.Close()
 
 	var eventOut PlatformEvent
-	go reader.HandleMessages(t.Context(), MakeMessageHandler(func(event PlatformEvent) error {
-		eventOut = event
-		return nil
-	}))
+	go reader.HandleMessages(t.Context(), func(m KafkaMessage) error {
+		return sonic.Unmarshal(m.Value, &eventOut)
+	})
 
 	writer := NewKafkaWriterFromEnv("test")
 	eventIn := PlatformEvent{ID: someid}
@@ -53,14 +39,14 @@ func TestSpawnReader(t *testing.T) {
 	var nReaders int32
 	wg := sync.WaitGroup{}
 	SpawnReader(context.Background(), &wg, "", CreateCountedMockReader(&nReaders),
-		MakeMessageHandler(func(_ PlatformEvent) error { return nil }))
+		func(_ KafkaMessage) error { return nil })
 	wg.Wait()
 	assert.Equal(t, 1, int(nReaders))
 }
 
 func TestRetry(t *testing.T) {
 	i := 0
-	handler := func(_ PlatformEvent) error {
+	handler := func(_ KafkaMessage) error {
 		i++
 		if i < 2 {
 			return errors.New("Failed")
@@ -69,8 +55,8 @@ func TestRetry(t *testing.T) {
 	}
 
 	// Without retry handler should fail
-	assert.Error(t, MakeMessageHandler(handler)(msg))
+	assert.Error(t, handler(msg))
 
 	// With retry we handler should eventually succeed
-	assert.NoError(t, MakeRetryingHandler(MakeMessageHandler(handler))(msg))
+	assert.NoError(t, MakeRetryingHandler(handler)(msg))
 }

--- a/evaluator/advisory_update_test.go
+++ b/evaluator/advisory_update_test.go
@@ -155,11 +155,13 @@ func TestAdvisoryUpdateKafkaRoundTrip(t *testing.T) {
 	database.CheckCachesValid(t)
 
 	// Run evaluation
-	err := evaluateHandler(mqueue.PlatformEvent{
+	data, err := sonic.Marshal(mqueue.PlatformEvent{
 		SystemIDs:  []uuid.UUID{testInventoryID},
 		RequestIDs: []string{"request-1"},
 		OrgID:      &orgID,
 		AccountID:  rhAccountID})
+	assert.NoError(t, err)
+	err = evaluateHandler(mqueue.KafkaMessage{Value: data})
 	assert.NoError(t, err)
 
 	utils.AssertEqualWait(t, 10, func() (exp, act interface{}) {

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -733,7 +733,13 @@ func invalidateCaches(orgID string) error {
 	return err
 }
 
-func evaluateHandler(event mqueue.PlatformEvent) error {
+func evaluateHandler(m mqueue.KafkaMessage) error {
+	var event mqueue.PlatformEvent
+	if err := sonic.Unmarshal(m.Value, &event); err != nil {
+		utils.LogError("err", err, "Could not deserialize platform event")
+		return nil
+	}
+
 	var err error
 	var wg sync.WaitGroup
 	guard := make(chan struct{}, nEvalGoroutines)
@@ -800,7 +806,7 @@ func run(wg *sync.WaitGroup, readerBuilder mqueue.CreateReader) {
 
 	loadCache()
 
-	var handler = mqueue.MakeRetryingHandler(mqueue.MakeMessageHandler(evaluateHandler))
+	var handler = mqueue.MakeRetryingHandler(evaluateHandler)
 	// We create multiple consumers, and hope that the partition rebalancing
 	// algorithm assigns each consumer a single partition
 	for i := 0; i < consumerCount; i++ {

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -341,6 +341,13 @@ func getUpdatesData(ctx context.Context, system *models.SystemPlatformV2) (*vmaa
 	}
 
 	merged := utils.MergeVMaaSResponses(yumUpdates, vmaasData)
+	if system.Inventory.Bootc && merged != nil {
+		// image-mode systems are not patchable via Insights; force all updates applicable
+		mergedUpdateList := merged.GetUpdateList()
+		for nevra := range mergedUpdateList {
+			(*mergedUpdateList[nevra]).SetUpdatesInstallability(APPLICABLE)
+		}
+	}
 	return merged, nil
 }
 

--- a/evaluator/evaluate_test.go
+++ b/evaluator/evaluate_test.go
@@ -359,6 +359,147 @@ func TestSatelliteSystemAdvisories(t *testing.T) {
 	assert.Equal(t, 2, applicableCnt)
 }
 
+// nolint:funlen
+func TestBootcSystemAdvisories(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	utils.SkipWithoutPlatform(t)
+	core.SetupTestEnvironment()
+
+	ogYumUpdatesEval := enableYumUpdatesEval
+	enableYumUpdatesEval = true
+	defer func() { enableYumUpdatesEval = ogYumUpdatesEval }()
+
+	configure()
+	loadCache()
+	mockWriter := mqueue.MockKafkaWriter{}
+	remediationsPublisher = &mockWriter
+
+	vmaasJSON := `
+	{
+		"package_list": [
+			"git-2.30.1-1.el8_8.x86_64",
+			"sqlite-3.21.0-1.el8_6.x86_64"
+		],
+		"repository_list": [
+			"rhel-8-for-x86_64-appstream-rpms"
+		],
+		"releasever": "8",
+		"basearch": "x86_64",
+		"latest_only": true
+	}
+	`
+	vmaasDataResp := `
+	{
+		"update_list": {
+			"git-2.30.1-1.el8_8.x86_64": {
+				"available_updates": [
+					{
+						"erratum": "RHSA-2023:3246",
+						"basearch": "x86_64",
+						"releasever": "8",
+						"repository": "rhel-8-for-x86_64-appstream-rpms",
+						"package": "git-2.39.3-1.el8_8.x86_64",
+						"package_name": "git",
+						"evra": "0:2.39.3-1.el8_8.x86_64"
+					},
+					{
+						"erratum": "RHSA-2023:3240",
+						"basearch": "x86_64",
+						"releasever": "8",
+						"repository": "rhel-8-for-x86_64-appstream-rpms",
+						"package": "git-2.39.4-1.el8_8.x86_64",
+						"package_name": "git",
+						"evra": "0:2.39.4-1.el8_8.x86_64"
+					}
+				]
+			},
+			"sqlite-3.21.0-1.el8_6.x86_64": {
+				"available_updates": [
+					{
+						"erratum": "RHSA-2022:7100",
+						"basearch": "x86_64",
+						"releasever": "8",
+						"repository": "rhel-8-for-x86_64-appstream-rpms",
+						"package": "sqlite-3.26.0-16.el8_6.x86_64",
+						"package_name": "sqlite",
+						"evra": "0:3.26.0-16.el8_6.x86_64"
+					}
+				]
+			}
+		}
+	}
+	`
+
+	var vmaasData vmaas.UpdatesV3Response
+	err := sonic.Unmarshal([]byte(vmaasDataResp), &vmaasData)
+	assert.Nil(t, err)
+
+	vmaasJSONChecksum := "bootc-1337"
+	memoryVmaasCache.Add(&vmaasJSONChecksum, &vmaasData)
+
+	yumUpdatesRaw := []byte(`
+		{
+			"update_list": {
+				"git-2.30.1-1.el8_8.x86_64": {
+					"available_updates": [
+						{
+							"erratum": "RHSA-2023:3246",
+							"basearch": "x86_64",
+							"releasever": "8",
+							"repository": "rhel-8-for-x86_64-appstream-rpms",
+							"package": "git-0:2.39.3-1.el8_8.x86_64"
+						}
+					]
+				},
+				"sqlite-3.21.0-1.el8_6.x86_64": {
+					"available_updates": [
+						{
+							"erratum": "RHSA-2022:7108",
+							"basearch": "x86_64",
+							"releasever": "8",
+							"repository": "rhel-8-for-x86_64-appstream-rpms",
+							"package": "sqlite-3.26.0-16.el8_6.x86_64"
+						}
+					]
+				}
+			}
+		}
+		`)
+
+	system := &models.SystemPlatformV2{
+		Inventory: models.SystemInventory{
+			InventoryID:   uuid.MustParse("99999999-0000-0000-0000-000000000016"),
+			JSONChecksum:  &vmaasJSONChecksum,
+			VmaasJSON:     &vmaasJSON,
+			YumUpdates:    yumUpdatesRaw,
+			DisplayName:   "bootc_system_test1",
+			RhAccountID:   1,
+			BuiltPkgcache: true,
+			Bootc:         true,
+		},
+		Patch: models.SystemPatch{},
+	}
+
+	result, err := getUpdatesData(context.Background(), system)
+	assert.Nil(t, err)
+	assert.NotNil(t, result)
+
+	// bootc systems cannot be patched via Insights: every update must be applicable
+	var installableCnt, applicableCnt int
+	for _, updates := range result.GetUpdateList() {
+		for _, update := range updates.GetAvailableUpdates() {
+			switch update.StatusID {
+			case INSTALLABLE:
+				installableCnt++
+			case APPLICABLE:
+				applicableCnt++
+			}
+		}
+	}
+	assert.Equal(t, 0, installableCnt)
+	assert.Equal(t, 4, applicableCnt)
+}
+
 func TestCallVmaas400(t *testing.T) {
 	utils.SkipWithoutDB(t)
 	utils.SkipWithoutPlatform(t)

--- a/evaluator/evaluate_test.go
+++ b/evaluator/evaluate_test.go
@@ -62,11 +62,13 @@ func TestEvaluate(t *testing.T) {
 	database.CheckCachesValid(t)
 
 	// do evaluate the system
-	err := evaluateHandler(mqueue.PlatformEvent{
+	data, err := sonic.Marshal(mqueue.PlatformEvent{
 		SystemIDs:  []uuid.UUID{testInventoryID, testInventoryID2},
 		RequestIDs: []string{"request-1", "request-2"},
 		OrgID:      &orgID,
 		AccountID:  rhAccountID})
+	assert.NoError(t, err)
+	err = evaluateHandler(mqueue.KafkaMessage{Value: data})
 	assert.NoError(t, err)
 
 	advisoryIDs := database.CheckAdvisoriesInDB(t, expectedAddedAdvisories)
@@ -80,11 +82,13 @@ func TestEvaluate(t *testing.T) {
 	thirdPartySystemRepoIDs := []int64{1, 2, 4}
 	database.DeleteSystemRepos(t, rhAccountID, testDBID, systemRepoIDs)
 	database.CreateSystemRepos(t, rhAccountID, testDBID, thirdPartySystemRepoIDs)
-	err = evaluateHandler(mqueue.PlatformEvent{
+	data, err = sonic.Marshal(mqueue.PlatformEvent{
 		SystemIDs:  []uuid.UUID{testInventoryID},
 		RequestIDs: []string{"request-1"},
 		OrgID:      &orgID,
 		AccountID:  rhAccountID})
+	assert.NoError(t, err)
+	err = evaluateHandler(mqueue.KafkaMessage{Value: data})
 	assert.NoError(t, err)
 	database.CheckSystemJustEvaluated(t, testInventoryID, 3, 1, 1, 0,
 		3, 1, 1, 0, 2, 2, 2, true)
@@ -124,10 +128,12 @@ func TestEvaluateYum(t *testing.T) {
 	database.CreateAdvisoryAccountData(t, rhAccountID, oldSystemAdvisoryIDs, 1)
 	database.CheckCachesValid(t)
 
-	err := evaluateHandler(mqueue.PlatformEvent{
+	data, err := sonic.Marshal(mqueue.PlatformEvent{
 		SystemIDs: []uuid.UUID{testInventoryID},
 		OrgID:     &orgID,
 		AccountID: rhAccountID})
+	assert.NoError(t, err)
+	err = evaluateHandler(mqueue.KafkaMessage{Value: data})
 	assert.NoError(t, err)
 
 	expectedPackageIDs := database.GetPackageIDs(expectedPackages...)

--- a/evaluator/notifications_test.go
+++ b/evaluator/notifications_test.go
@@ -58,11 +58,13 @@ func TestAdvisoriesNotificationPublish(t *testing.T) {
 
 	orgID := "1234567"
 	// do evaluate the system
-	err := evaluateHandler(mqueue.PlatformEvent{
+	data, err := sonic.Marshal(mqueue.PlatformEvent{
 		SystemIDs:  []uuid.UUID{testInventoryID},
 		RequestIDs: []string{"request-2"},
 		AccountID:  rhAccountID,
 		OrgID:      &orgID})
+	assert.NoError(t, err)
+	err = evaluateHandler(mqueue.KafkaMessage{Value: data})
 	assert.NoError(t, err)
 	advisoryIDs := database.CheckAdvisoriesInDB(t, expectedAddedAdvisories)
 	database.CheckAdvisoriesAccountDataNotified(t, rhAccountID, expectedAdvisoryIDs, true)

--- a/evaluator/template_advisory_e2e_test.go
+++ b/evaluator/template_advisory_e2e_test.go
@@ -26,7 +26,11 @@ func prepareTemplateAdvisoryIntegrationTest() {
 }
 
 func evaluateHandlerForTest(event mqueue.PlatformEvent) error {
-	return evaluateHandler(event)
+	data, err := sonic.Marshal(event)
+	if err != nil {
+		return err
+	}
+	return evaluateHandler(mqueue.KafkaMessage{Value: data})
 }
 
 // nolint: funlen


### PR DESCRIPTION
## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Handle evaluation and advisory update processing directly from Kafka messages while ensuring bootc systems have all updates marked applicable.

New Features:
- Add support for marking all updates as applicable for bootc (image-mode) systems based on merged VMaaS and yum update data.

Enhancements:
- Refactor message handling so evaluators and advisory update handlers accept raw Kafka messages and perform their own event deserialization.
- Simplify Kafka reader and retry logic by removing generic PlatformEvent and advisory event handler wrappers.
- Update evaluator and aggregator tests to reflect KafkaMessage-based handlers and verify bootc advisory applicability behavior.

Tests:
- Add a dedicated test to verify bootc systems produce only applicable advisories and no installable updates.
- Adjust existing evaluator, notifications, and Kafka round-trip tests to use KafkaMessage-based evaluate and advisory handlers.