### PR TITLE
fix: ignore 404s and dup inserts in template advisory sync

### DIFF
--- a/listener/listener.go
+++ b/listener/listener.go
@@ -9,6 +9,7 @@ import (
 	"app/base/models"
 	"app/base/mqueue"
 	"app/base/utils"
+	"github.com/pkg/errors"
 	"strings"
 	"sync"
 	"time"
@@ -40,8 +41,9 @@ var (
 	createdEventsBuffer eventBuffer
 
 	// Content sources client
-	contentSourcesClient  *api.Client
-	contentSourcesBaseURL string
+	contentSourcesClient              *api.Client
+	contentSourcesBaseURL             string
+	errContentSourcesTemplateNotFound = errors.New("content sources template not found")
 )
 
 const (

--- a/listener/template_advisories.go
+++ b/listener/template_advisories.go
@@ -6,16 +6,21 @@ import (
 	"app/base/models"
 	"app/base/utils"
 	"context"
-	"net/http"
-
 	"github.com/pkg/errors"
 	"github.com/redhatinsights/platform-go-middlewares/v2/identity"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"net/http"
 )
 
+// nolint: funlen
 func syncTemplateAdvisories(ctx context.Context, accountID int, templateID int64, templateUUID, orgID string) error {
 	current, err := callCSTemplateAdvisories(ctx, templateUUID)
 	if err != nil {
+		if errors.Is(err, errContentSourcesTemplateNotFound) {
+			utils.LogWarn("template_uuid", templateUUID, "template not found in content sources, skipping", err.Error())
+			return nil
+		}
 		return errors.Wrap(err, "fetching current template advisories from content-sources")
 	}
 
@@ -46,7 +51,10 @@ func syncTemplateAdvisories(ctx context.Context, accountID int, templateID int64
 	}
 
 	if len(toInsert) > 0 {
-		err = database.BulkInsert(tx, toInsert)
+		txOnConflict := tx.Clauses(clause.OnConflict{
+			DoNothing: true,
+		})
+		err = database.BulkInsert(txOnConflict, toInsert)
 		if err != nil {
 			return errors.Wrap(err, "bulk inserting added template advisories")
 		}
@@ -186,6 +194,9 @@ func httpCallCSTemplateAdvisories(ctx context.Context, templateUUID string) (
 	url := contentSourcesBaseURL + "/templates/" + templateUUID + "/advisories/ids"
 	var resp content_sources.TemplateAdvisoryIDsResponse
 	httpResp, err := client.Request(&ctx, http.MethodGet, url, nil, &resp)
+	if err != nil && httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
+		return &resp, httpResp, errors.Wrap(errContentSourcesTemplateNotFound, err.Error())
+	}
 
 	return &resp, httpResp, err
 }

--- a/listener/template_advisories_test.go
+++ b/listener/template_advisories_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const orgID = "org_1"
+
 func setupContentSourcesClient(t *testing.T) {
 	originalAddress := utils.CoreCfg.ContentSourcesAddress
 	address := utils.Getenv("CONTENT_SOURCES_ADDRESS", "http://platform:9001")
@@ -34,7 +36,6 @@ func TestCallCSTemplateAdvisories(t *testing.T) {
 	setupContentSourcesClient(t)
 
 	templateUUID := "99900000-0000-0000-0000-000000000001"
-	orgID := "org_1"
 	ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(orgID, utils.CoreCfg.ContentSourcesUser))
 	result, err := callCSTemplateAdvisories(ctx, templateUUID)
 
@@ -124,7 +125,6 @@ func TestSyncTemplateAdvisories(t *testing.T) {
 
 	templateID := int64(1)
 	templateUUID := "99900000-0000-0000-0000-000000000001"
-	orgID := "org_1"
 
 	// DB has RH-1 and RH-2 linked to the template
 	database.CreateTemplateAdvisories(t, accountID, templateID, []int64{1, 2})
@@ -145,4 +145,25 @@ func TestSyncTemplateAdvisories(t *testing.T) {
 		Count(&count).Error
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), count)
+}
+
+func TestSyncTemplateAdvisories_TemplateNotFound(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+	setupContentSourcesClient(t)
+
+	templateID := int64(1)
+	templateUUID := "40499999-9999-9999-9999-999999999404"
+
+	// DB has RH-1 and RH-2 linked to the template
+	database.CreateTemplateAdvisories(t, accountID, templateID, []int64{1, 2})
+	defer database.DeleteTemplateAdvisories(t, templateID, []int64{1, 2})
+
+	// content sources mock returns 404 for this template UUID
+	ctx := identity.WithIdentity(context.Background(), utils.XRHIDForOrg(orgID, utils.CoreCfg.ContentSourcesUser))
+	err := syncTemplateAdvisories(ctx, accountID, templateID, templateUUID, orgID)
+	assert.Nil(t, err)
+
+	// sync was skipped and no advisories were changed
+	database.CheckTemplateAdvisories(t, templateID, []int64{1, 2})
 }

--- a/platform/content_sources.go
+++ b/platform/content_sources.go
@@ -8,6 +8,11 @@ import (
 )
 
 func templateAdvisoryIDsGetHandler(c *gin.Context) {
+	uuid := c.Param("uuid")
+	if uuid == "40499999-9999-9999-9999-999999999404" {
+		c.Data(http.StatusNotFound, gin.MIMEJSON, []byte{})
+		return
+	}
 	response := content_sources.TemplateAdvisoryIDsResponse{
 		AdvisoryIDs: []string{"RH-1", "RH-3"},
 	}


### PR DESCRIPTION
- Skip sync if a template isn't found in content sources (it may have already been deleted)
- Use `ON CONFLICT DO NOTHING` on template advisory inserts

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Handle missing templates and duplicate inserts gracefully in template advisory synchronization with content sources.

Bug Fixes:
- Skip template advisory sync when the template is missing in content sources to avoid failing on deleted templates.
- Prevent duplicate template advisory insert errors by using a no-op on-conflict insert strategy.

Enhancements:
- Introduce a dedicated not-found error for content sources templates to standardize 404 handling in the listener.

Tests:
- Add a test to verify that template advisory sync is skipped when content sources returns 404 for a template.