### PR TITLE
RHINENG-26348: add ability to repair system_advisories_0 partition

### DIFF
--- a/database_admin/config.go
+++ b/database_admin/config.go
@@ -19,4 +19,6 @@ var (
 	updateDBConfig = utils.PodConfig.GetBool("update_db_config", false)
 	// Terminate lockUsers sessions after NOLOGIN (for major DDL migrations)
 	terminateDBSessions = utils.PodConfig.GetBool("terminate_db_sessions", false)
+	// One-off: truncate corrupt system_advisories_0 and clear bucket-0 advisory caches
+	repairSystemAdvisories0 = utils.PodConfig.GetBool("repair_system_advisories_0", false)
 )

--- a/database_admin/schema/repair_system_advisories_0.sql
+++ b/database_admin/schema/repair_system_advisories_0.sql
@@ -1,0 +1,20 @@
+-- One-off repair for corrupt system_advisories_0 (pg_xact / unreadable heap).
+-- Gated by database_admin flag repair_system_advisories_0=true (default false).
+-- Irreversible: truncates partition data for hash remainder 0 and clears related caches.
+-- Safe to re-run only when intentionally wiping bucket 0 again (e.g. failed cutover).
+-- TRUNCATE drops table segments without scanning the heap (validated on restore DB).
+
+BEGIN;
+
+TRUNCATE TABLE system_advisories_0;
+
+-- Clear denormalized counts for accounts that hash into remainder 0 (do not read old _0).
+DELETE FROM advisory_account_data aad
+ WHERE satisfies_hash_partition(
+         'system_advisories'::regclass, 32, 0, aad.rh_account_id);
+
+DELETE FROM account_advisory aa
+ WHERE satisfies_hash_partition(
+         'system_advisories'::regclass, 32, 0, aa.rh_account_id);
+
+COMMIT;

--- a/database_admin/update.go
+++ b/database_admin/update.go
@@ -184,6 +184,15 @@ func startMigration(conn database.Driver, db *sql.DB, migrationFilesURL string) 
 	unblockUsers(db)
 }
 
+func repairSystemAdvisories0Partition(db *sql.DB) {
+	log.Info("Repairing system_advisories_0 (truncate + clear bucket-0 caches)")
+	prepareForMigration(db)
+	execFromFile(db, "./database_admin/schema/repair_system_advisories_0.sql")
+	log.Info("system_advisories_0 repair finished")
+	log.Info("Reverting components privileges after system_advisories_0 repair")
+	unblockUsers(db)
+}
+
 func dbConn() (database.Driver, *sql.DB) {
 	sslModeCert := utils.CoreCfg.DBSslMode
 	if utils.CoreCfg.DBSslRootCert != "" {
@@ -234,6 +243,10 @@ func UpdateDB(migrationFilesURL string) {
 	case MIGRATE:
 		log.Info("Migrating the database")
 		startMigration(conn, db, migrationFilesURL)
+	}
+
+	if repairSystemAdvisories0 {
+		repairSystemAdvisories0Partition(db)
 	}
 
 	if updateUsers {

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -896,6 +896,7 @@ parameters:
 - {name: DATABASE_ADMIN_CONFIG, value: ''} # Set 'schema_version=XXX' if need specific database schema
                                            # 'terminate_db_sessions=true' to kill app DB sessions before DDL
                                            # 'force_schema_version=XXX' to reset the dirty flag to false and force the specific version, it will follow up with the schema upgrade defined by schema_version
+                                           # 'repair_system_advisories_0=true' one-off: truncate corrupt system_advisories_0 and clear bucket-0 AAD/AA (default false; remove after cutover)
 
 # Common parameters
 - {name: IMAGE, value: quay.io/redhat-services-prod/insights-management-tenant/insights-patch/patchman-engine}

--- a/docs/md/major-migration-runbook.md
+++ b/docs/md/major-migration-runbook.md
@@ -147,6 +147,18 @@ Config keys are defined in `database_admin/config.go`. ClowdApp comments in `dep
 
 `NOLOGIN` alone does not close existing connections — that is why this flag exists.
 
+### `repair_system_advisories_0`
+
+| | |
+|---|---|
+| **Config key** | `repair_system_advisories_0` (boolean, default `false`) |
+| **Where** | `DATABASE_ADMIN_CONFIG` on the **db-migration Job** only |
+| **Effect** | After migrate CONTINUE/MIGRATE, runs `prepareForMigration`, then `database_admin/schema/repair_system_advisories_0.sql`: `TRUNCATE system_advisories_0`, clear bucket-0 `advisory_account_data` and `account_advisory`. **Destructive** for hash remainder 0. |
+
+**Enable when:** one-off recovery from corrupt/unreadable `system_advisories_0`. Combine with `terminate_db_sessions=true` if truncate is blocked by app sessions.
+
+**Leave off for all normal deploys.** Remove after the cutover succeeds. Do not enable on manager/listener/evaluator pods.
+
 ---
 
 ## During deploy


### PR DESCRIPTION
This PR:
- adds one-off `repair_system_advisories_0` flag (default off) for db-migration Job
- replaces corrupt `system_advisories_0` and clears bucket-0 AAD/AA caches
- documents flag in `clowdapp.yaml` and major-migration runbook

Testing:
I've tested locally and all looks good. We will tests everything in stage before going to production even that stage doesn't have the corrupted partition.

## Summary by Sourcery

Add a one-off, configurable repair pathway for the system_advisories_0 partition in the db-migration job, including cache cleanup for bucket-0 accounts.

New Features:
- Introduce repairSystemAdvisories0 configuration flag for the db-migration job to trigger a targeted repair of the system_advisories_0 partition.

Enhancements:
- Add a dedicated repairSystemAdvisories0Partition flow that reuses migration preparation and user-unblocking steps around the repair operation.
- Document the repair_system_advisories_0 flag and its destructive, one-off usage in the major migration runbook and ClowdApp configuration comments.

Documentation:
- Extend the major migration runbook with guidance on using the repair_system_advisories_0 flag for one-off recovery of corrupt system_advisories_0 data.

Chores:
- Add a repair_system_advisories_0.sql admin script to recreate the system_advisories_0 partition and clear related bucket-0 advisory caches.