### PR TITLE
feat: delete unused advisories from account_advisory

### DIFF
--- a/tasks/cleaning/clean_unused_data.go
+++ b/tasks/cleaning/clean_unused_data.go
@@ -45,12 +45,14 @@ func deleteUnusedAdvisories() {
 	// remove unused advisories not synced from vmaas
 	// before changing the query below test its performance on big data otherwise it can lock database
 	// Time: 18988.223 ms (00:18.988) for 50k advisories, 75M system_advisories, 1.6M package and 50k rh_account
+	// both advisory_account_data and account_advisory are checked temporarily until the legacy table is dropped
 	subq := tx.Select("id").Table("advisory_metadata am").
 		Where("am.synced = ?", false).
 		Where("NOT EXISTS (SELECT 1 FROM system_advisories sa WHERE am.id = sa.advisory_id)").
 		Where("NOT EXISTS (SELECT 1 FROM template_advisory ta WHERE am.id = ta.advisory_id)").
 		Where("NOT EXISTS (SELECT 1 FROM package p WHERE am.id = p.advisory_id)").
 		Where("NOT EXISTS (SELECT 1 FROM advisory_account_data aad WHERE am.id = aad.advisory_id)").
+		Where("NOT EXISTS (SELECT 1 FROM account_advisory aa WHERE am.id = aa.advisory_id)").
 		Limit(tasks.DeleteUnusedDataLimit)
 
 	err := tx.Delete(&models.AdvisoryMetadata{}, "id IN (?)", subq).Error

--- a/tasks/cleaning/clean_unused_data_test.go
+++ b/tasks/cleaning/clean_unused_data_test.go
@@ -7,6 +7,7 @@ import (
 	"app/base/utils"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -94,4 +95,44 @@ func TestCleanUnusedAdvisories(t *testing.T) {
 	err = database.DB.Model(models.AdvisoryMetadata{}).Count(&afterAdvCount).Error
 	assert.Nil(t, err)
 	assert.Equal(t, beforeAdvCount-rh100count, afterAdvCount)
+}
+
+func TestDeleteUnusedAdvisoriesKeptByAccountAdvisory(t *testing.T) {
+	utils.SkipWithoutDB(t)
+	core.SetupTestEnvironment()
+
+	advisory := "CUSTOM-5678"
+	customAdv := models.AdvisoryMetadata{
+		Name:           advisory,
+		Description:    "Custom desc",
+		Synopsis:       "Custom syn",
+		Summary:        "Custom sum",
+		Solution:       utils.PtrString("Custom sol"),
+		AdvisoryTypeID: 1,
+		RebootRequired: false,
+		Synced:         false,
+	}
+	err := database.DB.Create(&customAdv).Error
+	assert.Nil(t, err)
+
+	aa := models.AccountAdvisory{
+		AdvisoryID:         customAdv.ID,
+		RhAccountID:        1,
+		WorkspaceID:        uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		SystemsApplicable:  1,
+		SystemsInstallable: 0,
+	}
+	err = database.DB.Create(&aa).Error
+	assert.Nil(t, err)
+
+	deleteUnusedAdvisories()
+
+	var count int64
+	err = database.DB.Model(models.AdvisoryMetadata{}).Where("name = ?", advisory).Count(&count).Error
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), count, "advisory with account_advisory row should not be deleted")
+
+	// cleanup
+	database.DB.Delete(&aa)
+	database.DB.Delete(&customAdv)
 }


### PR DESCRIPTION
## Summary

- Delete unused advisory data from the new table

## Follow-up
- [ ] `PUT /clean-advisory-account-data` admin API endpoint only cleans the legacy table. Update to also clean `account_advisory` (or rename/replace when legacy table is dropped)

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Protect account-referenced advisory data during unused advisory cleanup.

Bug Fixes:
- Prevent unused unsynced advisories from being deleted while they are still referenced by the new account_advisory table.

Tests:
- Add coverage confirming advisories referenced by account_advisory are retained during cleanup.