### PR TITLE
RHINENG-28970: change error to warning

### DIFF
--- a/base/mqueue/mqueue.go
+++ b/base/mqueue/mqueue.go
@@ -34,8 +34,13 @@ func createLoggerFunc(counter Counter) func(fmt string, args ...interface{}) {
 
 	fn := func(fmt string, args ...interface{}) {
 		counter.Inc()
-		utils.LogError("type", "kafka", format.Sprintf(fmt, args...))
-		if strings.Contains(fmt, "Group Load In Progress") {
+		msg := format.Sprintf(fmt, args...)
+		if strings.Contains(msg, "failed to dial") {
+			utils.LogWarn("type", "kafka", msg)
+		} else {
+			utils.LogError("type", "kafka", msg)
+		}
+		if strings.Contains(msg, "Group Load In Progress") {
 			utils.LogPanic("Kafka client stuck detected!!!")
 		}
 	}


### PR DESCRIPTION
Downgrade kafka errors that contain 'failed to dial' and show in glitchtip as 'error initializing the kafka reader for partition X' to only warnings. This kind of error should stop appearing in glitchtip.

## Testing

Glitchtip should stop surfacing errors starting with "error initializing the kafka reader for partition" such as [this one](https://glitchtip.devshift.net/insights/issues/4565608).

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Bug Fixes:
- Prevent benign Kafka dial failures from being reported as errors in monitoring systems by downgrading them to warnings.