### PR TITLE
RHINENG-28970: change error to warning

### DIFF
--- a/base/mqueue/mqueue.go
+++ b/base/mqueue/mqueue.go
@@ -35,7 +35,8 @@ func createLoggerFunc(counter Counter) func(fmt string, args ...interface{}) {
 	fn := func(fmt string, args ...interface{}) {
 		counter.Inc()
 		msg := format.Sprintf(fmt, args...)
-		if strings.Contains(msg, "failed to dial") {
+		if strings.Contains(msg, "failed to dial") ||
+			strings.Contains(msg, "unknown error reading partition") {
 			utils.LogWarn("type", "kafka", msg)
 		} else {
 			utils.LogError("type", "kafka", msg)


### PR DESCRIPTION
'unknown error reading partition' is a common situation when kafka is rebalancing topic partitions

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Enhancements:
- Treat Kafka partition-read errors that commonly occur during partition rebalancing as warnings instead of errors.