### PR TITLE
fix: add primary keys to tables

### DIFF
--- a/database_admin/migrations/165_system_repo_pk.down.sql
+++ b/database_admin/migrations/165_system_repo_pk.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE deleted_system ADD CONSTRAINT deleted_system_inventory_id_key UNIQUE (inventory_id);
+ALTER TABLE deleted_system DROP CONSTRAINT deleted_system_pkey;
+
+ALTER TABLE system_repo ADD CONSTRAINT system_repo_rh_account_id_system_id_repo_id_key UNIQUE (rh_account_id, system_id, repo_id);
+ALTER TABLE system_repo DROP CONSTRAINT system_repo_pkey;
+
+ALTER TABLE timestamp_kv ADD CONSTRAINT timestamp_kv_name_key UNIQUE (name);
+ALTER TABLE timestamp_kv DROP CONSTRAINT timestamp_kv_pkey;

--- a/database_admin/migrations/165_system_repo_pk.up.sql
+++ b/database_admin/migrations/165_system_repo_pk.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE deleted_system ADD CONSTRAINT deleted_system_pkey PRIMARY KEY (inventory_id);
+ALTER TABLE deleted_system DROP CONSTRAINT deleted_system_inventory_id_key;
+
+ALTER TABLE system_repo ADD CONSTRAINT system_repo_pkey PRIMARY KEY (rh_account_id, system_id, repo_id);
+ALTER TABLE system_repo DROP CONSTRAINT system_repo_rh_account_id_system_id_repo_id_key;
+
+ALTER TABLE timestamp_kv ADD CONSTRAINT timestamp_kv_pkey PRIMARY KEY (name);
+ALTER TABLE timestamp_kv DROP CONSTRAINT timestamp_kv_name_key;

--- a/database_admin/schema/create_schema.sql
+++ b/database_admin/schema/create_schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations
 
 
 INSERT INTO schema_migrations
-VALUES (164, false);
+VALUES (165, false);
 
 -- ---------------------------------------------------------------------------
 -- Functions
@@ -700,7 +700,7 @@ CREATE TABLE IF NOT EXISTS deleted_system
     inventory_id TEXT                     NOT NULL,
     CHECK (NOT empty(inventory_id)),
     when_deleted TIMESTAMP WITH TIME ZONE NOT NULL,
-    UNIQUE (inventory_id)
+    PRIMARY KEY (inventory_id)
 ) TABLESPACE pg_default;
 
 CREATE INDEX ON deleted_system (when_deleted);
@@ -925,7 +925,7 @@ CREATE TABLE IF NOT EXISTS system_repo
     system_id     BIGINT NOT NULL,
     repo_id       BIGINT NOT NULL,
     rh_account_id INT NOT NULL,
-    UNIQUE (rh_account_id, system_id, repo_id),
+    PRIMARY KEY (rh_account_id, system_id, repo_id),
     CONSTRAINT system_inventory_id
         FOREIGN KEY (rh_account_id, system_id)
             REFERENCES system_inventory (rh_account_id, id),
@@ -1043,7 +1043,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON package_account_data TO vmaas_sync;
 -- timestamp_kv
 CREATE TABLE IF NOT EXISTS timestamp_kv
 (
-    name  TEXT                     NOT NULL UNIQUE,
+    name  TEXT                     NOT NULL PRIMARY KEY,
     CHECK (NOT empty(name)),
     value TIMESTAMP WITH TIME ZONE NOT NULL
 ) TABLESPACE pg_default;


### PR DESCRIPTION
fixes errors during blue/green db upgrade

## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Add primary keys to key database tables to support reliable blue/green database upgrades.

Bug Fixes:
- Add primary key constraints to the deleted_system, system_repo, and timestamp_kv tables to prevent errors during blue/green database upgrades.

Chores:
- Update the database schema and migration version to reflect the new primary key constraints, with reversible downgrade support.