### PR TITLE
RHINENG-29747: fix admin API

### DIFF
--- a/manager/routes/routes.go
+++ b/manager/routes/routes.go
@@ -106,7 +106,7 @@ func InitAdmin(app *gin.Engine, enableTurnpikeAuth bool) {
 	api.PUT("/refresh-packages", admin.RefreshPackagesHandler)
 	api.PUT("/refresh-packages/:account", admin.RefreshPackagesAccountHandler)
 	api.GET("/repack/:table_name", admin.RepackHandler)
-	api.DELETE("/system/:inventory_id", admin.SystemDeleteHandler)
+	api.DELETE("/systems/:inventory_id", admin.SystemDeleteHandler)
 
 	pprof := api.Group("/pprof")
 	pprof.GET("/evaluator_upload/:param", admin.GetEvaluatorUploadPprof)

--- a/turnpike/admin_api.go
+++ b/turnpike/admin_api.go
@@ -32,6 +32,7 @@ func RunAdminAPI() {
 	utils.LogInfo("port", utils.CoreCfg.PublicPort, "Manager-admin starting")
 	app := gin.New()
 	app.Use(middlewares.RequestResponseLogger())
+	app.Use(middlewares.DatabaseWithContext())
 	middlewares.SetAdminSwagger(app)
 
 	core.InitProbes(app)


### PR DESCRIPTION
InitAdmin route did not match OpenAPI 


## Secure Coding Practices Checklist GitHub Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [x] Input Validation
- [x] Output Encoding
- [x] Authentication and Password Management
- [x] Session Management
- [x] Access Control
- [x] Cryptographic Practices
- [x] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [x] System Configuration
- [x] Database Security
- [x] File Management
- [x] Memory Management
- [x] General Coding Practices

## Summary by Sourcery

Fix admin API routing and database context initialization.

Bug Fixes:
- Correct the admin system deletion endpoint to use the plural `/systems/:inventory_id` path.
- Enable database context middleware for the admin API.